### PR TITLE
fix: pulling default provider name from default config file and use it

### DIFF
--- a/src/data_designer/engine/model_provider.py
+++ b/src/data_designer/engine/model_provider.py
@@ -64,10 +64,12 @@ class ModelProviderRegistry(BaseModel):
             raise UnknownProviderError(f"No provider named {name!r} registered")
 
 
-def resolve_model_provider_registry(model_providers: list[ModelProvider]) -> ModelProviderRegistry:
+def resolve_model_provider_registry(
+    model_providers: list[ModelProvider], default_provider_name: str | None = None
+) -> ModelProviderRegistry:
     if len(model_providers) == 0:
         raise NoModelProvidersError("At least one model provider must be defined")
     return ModelProviderRegistry(
         providers=model_providers,
-        default=model_providers[0].name,
+        default=default_provider_name or model_providers[0].name,
     )

--- a/src/data_designer/interface/data_designer.py
+++ b/src/data_designer/interface/data_designer.py
@@ -10,6 +10,7 @@ from data_designer.config.analysis.dataset_profiler import DatasetProfilerResult
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.default_model_settings import (
     get_default_model_configs,
+    get_default_provider_name,
     get_default_providers,
     resolve_seed_default_model_settings,
 )
@@ -22,6 +23,8 @@ from data_designer.config.preview_results import PreviewResults
 from data_designer.config.seed import LocalSeedDatasetReference
 from data_designer.config.utils.constants import (
     DEFAULT_NUM_RECORDS,
+    MODEL_CONFIGS_FILE_PATH,
+    MODEL_PROVIDERS_FILE_PATH,
 )
 from data_designer.config.utils.info import InterfaceInfo
 from data_designer.config.utils.io_helpers import write_seed_dataset
@@ -96,7 +99,9 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
             else init_managed_blob_storage(str(blob_storage_path))
         )
         self._model_providers = model_providers or self.get_default_model_providers()
-        self._model_provider_registry = resolve_model_provider_registry(self._model_providers)
+        self._model_provider_registry = resolve_model_provider_registry(
+            self._model_providers, get_default_provider_name()
+        )
 
     @staticmethod
     def make_seed_reference_from_file(file_path: str | Path) -> LocalSeedDatasetReference:
@@ -248,6 +253,7 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         Returns:
             List of default model configurations.
         """
+        logger.info(f"♻️ Using default model configs from {str(MODEL_CONFIGS_FILE_PATH)!r}")
         return get_default_model_configs()
 
     def get_default_model_providers(self) -> list[ModelProvider]:
@@ -256,6 +262,7 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         Returns:
             List of default model providers.
         """
+        logger.info(f"♻️ Using default model providers from {str(MODEL_PROVIDERS_FILE_PATH)!r}")
         return get_default_providers()
 
     def set_buffer_size(self, buffer_size: int) -> None:

--- a/tests/config/test_default_model_settings.py
+++ b/tests/config/test_default_model_settings.py
@@ -13,6 +13,7 @@ from data_designer.config.default_model_settings import (
     get_builtin_model_providers,
     get_default_inference_parameters,
     get_default_model_configs,
+    get_default_provider_name,
     get_default_providers,
     resolve_seed_default_model_settings,
 )
@@ -93,6 +94,28 @@ def test_get_default_providers_path_does_not_exist():
     with patch("data_designer.config.default_model_settings.MODEL_PROVIDERS_FILE_PATH", new=Path("non_existent_path")):
         with pytest.raises(FileNotFoundError, match=r"Default model providers file not found at 'non_existent_path'"):
             get_default_providers()
+
+
+def test_get_default_provider_name_with_default_key(tmp_path: Path):
+    providers_file_path = tmp_path / "providers.yaml"
+    providers_file_path.write_text(
+        json.dumps(dict(providers=[p.model_dump() for p in get_builtin_model_providers()], default="nvidia"))
+    )
+    with patch("data_designer.config.default_model_settings.MODEL_PROVIDERS_FILE_PATH", new=providers_file_path):
+        assert get_default_provider_name() == "nvidia"
+
+
+def test_get_default_provider_name_without_default_key(tmp_path: Path):
+    providers_file_path = tmp_path / "providers.yaml"
+    providers_file_path.write_text(json.dumps({"providers": [p.model_dump() for p in get_builtin_model_providers()]}))
+    with patch("data_designer.config.default_model_settings.MODEL_PROVIDERS_FILE_PATH", new=providers_file_path):
+        assert get_default_provider_name() is None
+
+
+def test_get_default_provider_name_path_does_not_exist():
+    with patch("data_designer.config.default_model_settings.MODEL_PROVIDERS_FILE_PATH", new=Path("non_existent_path")):
+        with pytest.raises(FileNotFoundError, match=r"Default model providers file not found at 'non_existent_path'"):
+            get_default_provider_name()
 
 
 def test_get_nvidia_api_key():


### PR DESCRIPTION
- I noticed it while I was writing docs. If you have default model providers and configs, but then add a new model config manually editing the yml (without specifying a provider), we don't use the default provider set in `model_providers.yaml`

This fixes this small edge case.