### PR TITLE
fix: Fix starting index for batch processing

### DIFF
--- a/src/data_designer/engine/dataset_builders/column_wise_builder.py
+++ b/src/data_designer/engine/dataset_builders/column_wise_builder.py
@@ -88,8 +88,8 @@ class ColumnWiseDatasetBuilder:
         start_time = time.perf_counter()
 
         self.batch_manager.start(num_records=num_records, buffer_size=buffer_size)
-        for batch_idx in range(1, self.batch_manager.num_batches + 1):
-            logger.info(f"⏳ Processing batch {batch_idx} of {self.batch_manager.num_batches}")
+        for batch_idx in range(self.batch_manager.num_batches):
+            logger.info(f"⏳ Processing batch {batch_idx + 1} of {self.batch_manager.num_batches}")
             self._run_batch(generators)
             df_batch = self._run_processors(
                 stage=BuildStage.POST_BATCH,


### PR DESCRIPTION
Closes: https://github.com/NVIDIA-NeMo/DataDesigner/issues/79

After fix:
```
(data-designer) nmulepati@nmulepati-mlt DataDesigner % tree .scratch/artifacts/dataset
.scratch/artifacts/dataset
├── column_configs.json
├── dropped-columns-parquet-files
│   ├── batch_00000.parquet
│   ├── batch_00001.parquet
│   ├── batch_00002.parquet
│   ├── batch_00003.parquet
│   ├── batch_00004.parquet
│   ├── batch_00005.parquet
│   ├── batch_00006.parquet
│   ├── batch_00007.parquet
│   ├── batch_00008.parquet
│   └── batch_00009.parquet
├── metadata.json
├── model_configs.json
└── parquet-files
    ├── batch_00000.parquet
    ├── batch_00001.parquet
    ├── batch_00002.parquet
    ├── batch_00003.parquet
    ├── batch_00004.parquet
    ├── batch_00005.parquet
    ├── batch_00006.parquet
    ├── batch_00007.parquet
    ├── batch_00008.parquet
    └── batch_00009.parquet

3 directories, 23 files
```