### PR TITLE
fix: remove broken download links in notebooks and add download button instead

### DIFF
--- a/docs/notebook_source/1-the-basics.py
+++ b/docs/notebook_source/1-the-basics.py
@@ -15,8 +15,6 @@
 # %% [markdown]
 # # 🎨 Data Designer 101: The Basics
 #
-# [Click here](https://raw.githubusercontent.com/NVIDIA-NeMo/DataDesigner/refs/heads/main/docs/notebooks/1-the-basics.ipynb) to download this notebook to your computer.
-#
 # #### 📚 What you'll learn
 #
 # This notebook demonstrates the basics of Data Designer by generating a simple product review dataset.

--- a/docs/notebook_source/2-structured-outputs-and-jinja-expressions.py
+++ b/docs/notebook_source/2-structured-outputs-and-jinja-expressions.py
@@ -15,8 +15,6 @@
 # %% [markdown]
 # # 🎨 Data Designer 101: Structured Outputs and Jinja Expressions
 #
-# [Click here](https://raw.githubusercontent.com/NVIDIA-NeMo/DataDesigner/refs/heads/main/docs/notebooks/2-structured-outputs-and-jinja-expressions.ipynb) to download this notebook to your computer.
-#
 # #### 📚 What you'll learn
 #
 # In this notebook, we will continue our exploration of Data Designer, demonstrating more advanced data generation using structured outputs and Jinja expressions.

--- a/docs/notebook_source/3-seeding-with-a-dataset.py
+++ b/docs/notebook_source/3-seeding-with-a-dataset.py
@@ -15,8 +15,6 @@
 # %% [markdown]
 # # 🎨 Data Designer 101: Seeding Synthetic Data Generation with an External Dataset
 #
-# [Click here](https://raw.githubusercontent.com/NVIDIA-NeMo/DataDesigner/refs/heads/main/docs/notebooks/3-seeding-with-a-dataset.ipynb) to download this notebook to your computer.
-#
 # #### 📚 What you'll learn
 #
 # In this notebook, we will demonstrate how to seed synthetic data generation in Data Designer with an external dataset.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if page.nb_url %}
+    <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
+        {% include ".icons/material/download.svg" %}
+    </a>
+{% endif %}
+
+{{ super() }}
+{% endblock content %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
 
 theme:
   name: material
+  custom_dir: docs/overrides
   font:
     text: Roboto
     code: Fira Code
@@ -76,6 +77,7 @@ plugins:
         execute: false
         include_requirejs: true
         ignore_h1_titles: True
+        include_source: True
   - mkdocstrings:
       handlers:
           python:


### PR DESCRIPTION
Originally, we had links to the notebooks on the main branch, but now they are not available anymore.
I've thus added a download button on the top following the instructions in the [mkdocs-jupyter readme](https://github.com/danielfrg/mkdocs-jupyter?tab=readme-ov-file#download-notebook-link).

Tested locally by running `make serve-docs-locally` (need to run `make convert-execute-notebooks` first).