### PR TITLE
fix: update Python version to 3.11 on build notebooks CI

### DIFF
--- a/.github/workflows/build-notebooks.yml
+++ b/.github/workflows/build-notebooks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: "0.9.5"
       - name: Set up Python
-        run: uv python install
+        run: uv python install 3.11
       - name: Convert and execute notebooks
         run: make convert-execute-notebooks
       - name: Upload notebooks as artifacts


### PR DESCRIPTION
We are using 3.14 which is currently not supported and is leading to spurious warnings.

Tried [here](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/19909814637) and it now produces notebooks without warnings.