### PR TITLE
fix: add git user/email and allow manual trigger for docs pipeline

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,5 @@
 name: Build docs
 on:
-  push:
   workflow_dispatch:
   release:
     types:


### PR DESCRIPTION
Tested here: https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/20034876460

New docs now deployed at https://nvidia-nemo.github.io/DataDesigner/latest/