### PR TITLE
fix: plugins cause circular imports

### DIFF
--- a/src/data_designer/engine/column_generators/generators/base.py
+++ b/src/data_designer/engine/column_generators/generators/base.py
@@ -8,7 +8,6 @@ from typing import overload
 
 import pandas as pd
 
-from data_designer.config.column_types import COLUMN_TYPE_EMOJI_MAP
 from data_designer.config.models import BaseInferenceParams, ModelConfig
 from data_designer.config.utils.type_helpers import StrEnum
 from data_designer.engine.configurable_task import ConfigurableTask, ConfigurableTaskMetadata, DataT, TaskConfigT
@@ -82,6 +81,8 @@ class WithModelGeneration:
         return self.model_config.inference_parameters
 
     def log_pre_generation(self) -> None:
+        from data_designer.config.column_types import COLUMN_TYPE_EMOJI_MAP
+
         emoji = COLUMN_TYPE_EMOJI_MAP[self.config.column_type]
         logger.info(f"{emoji} Preparing {self.config.column_type} column generation")
         logger.info(f"  |-- column name: {self.config.name!r}")


### PR DESCRIPTION
As reported by @nabinchha - plugins that import from `data_designer.engine.column_generators.generators.base` (to subclass `ColumnGenerator`) caused circular import errors during plugin discovery.

That is because base.py imported `COLUMN_TYPE_EMOJI_MAP` from column_types.py at module level. Since column_types.py instantiates PluginManager() at import time (which triggers plugin discovery), this created a circular import chain:

plugin.module → base.py → column_types.py → PluginManager → plugin.module

The fix was to change the `COLUMN_TYPE_EMOJI_MAP` import in base.py from module-level to a lazy import inside the log_pre_generation() method where it's actually used.

Also added a test which fails before this fix, and passes after.