### PR TITLE
fix: `Decimal` in structured generation leads to errors

### DIFF
--- a/tests/engine/processing/gsonschema/test_validators.py
+++ b/tests/engine/processing/gsonschema/test_validators.py
@@ -199,21 +199,31 @@ def test_invalid_data_type():
 
 
 def test_normalize_decimal_anyof_fields() -> None:
-    """Test that Decimal-like anyOf fields (number|string) are normalized to strings."""
+    """Test that Decimal-like anyOf fields are normalized to floats with proper precision."""
     schema = {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
-            "price": {"anyOf": [{"type": "number"}, {"type": "string"}]},
+            "price": {
+                "anyOf": [
+                    {"type": "number"},
+                    {"type": "string", "pattern": r"^(?!^[-+.]*$)[+-]?0*\d*\.?\d{0,2}0*$"},
+                ]
+            },
         },
     }
 
-    # Numeric value should be converted to string
-    result1 = validate({"name": "Widget", "price": 189.99}, schema)
-    assert result1["price"] == "189.99"
-    assert isinstance(result1["price"], str)
+    # Numeric value with extra precision should be rounded to 2 decimal places
+    result1 = validate({"name": "Widget", "price": 189.999}, schema)
+    assert result1["price"] == 190.0
+    assert isinstance(result1["price"], float)
 
-    # String value should remain a string
-    result2 = validate({"name": "Gadget", "price": "249.99"}, schema)
-    assert result2["price"] == "249.99"
-    assert isinstance(result2["price"], str)
+    # Numeric value should be converted to float
+    result2 = validate({"name": "Gadget", "price": 50.5}, schema)
+    assert result2["price"] == 50.5
+    assert isinstance(result2["price"], float)
+
+    # String value should be converted to float
+    result3 = validate({"name": "Gizmo", "price": "249.99"}, schema)
+    assert result3["price"] == 249.99
+    assert isinstance(result3["price"], float)


### PR DESCRIPTION
During structured generation, quantities like prices and such are typically modeled using `Decimal`, see e.g. [our tutorial number 2](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/2-structured-outputs-and-jinja-expressions/).
Some models will output such quantities both with and without quotes. We currently use `gsonschema` within the  `StructuredResponseRecipe` to validate these outputs, and for `Decimals`, Pydantic gives for the schema:

```
"anyOf": [
  {"type": "number", "minimum": 10.0, "maximum": 1000.0},
  {"type": "string", "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d{0,2}0*$"}
]
```

Thus, both strings and floats are accepted, which will cause an issue when calling `dataframe.to_parquet`. This has been happening often in our tutorial number 2.

The proposed solution is to convert fields detected as `Decimal`s to string, always. This is done inside `gsonschema.validators.validate`. A small test is added to ensure the behavior.