### PR TITLE
feat: move buffer size control to RunConfig

### DIFF
--- a/src/data_designer/config/run_config.py
+++ b/src/data_designer/config/run_config.py
@@ -21,6 +21,9 @@ class RunConfig(ConfigBase):
             early shutdown is enabled. Default is 0.5.
         shutdown_error_window: Minimum number of completed tasks before error rate
             monitoring begins. Must be >= 0. Default is 10.
+        buffer_size: Number of records to process in each batch during dataset generation.
+            A batch is processed end-to-end (column generation, post-batch processors, and writing the batch
+            to artifact storage) before moving on to the next batch. Must be > 0. Default is 1000.
         max_conversation_restarts: Maximum number of full conversation restarts permitted when
             generation tasks call `ModelFacade.generate(...)`. Must be >= 0. Default is 5.
         max_conversation_correction_steps: Maximum number of correction rounds permitted within a
@@ -31,6 +34,7 @@ class RunConfig(ConfigBase):
     disable_early_shutdown: bool = False
     shutdown_error_rate: float = Field(default=0.5, ge=0.0, le=1.0)
     shutdown_error_window: int = Field(default=10, ge=0)
+    buffer_size: int = Field(default=1000, gt=0)
     max_conversation_restarts: int = Field(default=5, ge=0)
     max_conversation_correction_steps: int = Field(default=0, ge=0)
 

--- a/src/data_designer/engine/dataset_builders/column_wise_builder.py
+++ b/src/data_designer/engine/dataset_builders/column_wise_builder.py
@@ -94,7 +94,6 @@ class ColumnWiseDatasetBuilder:
         self,
         *,
         num_records: int,
-        buffer_size: int,
         on_batch_complete: Callable[[Path], None] | None = None,
     ) -> Path:
         self._write_configs()
@@ -104,6 +103,7 @@ class ColumnWiseDatasetBuilder:
         start_time = time.perf_counter()
         group_id = uuid.uuid4().hex
 
+        buffer_size = self._resource_provider.run_config.buffer_size
         self.batch_manager.start(num_records=num_records, buffer_size=buffer_size)
         for batch_idx in range(self.batch_manager.num_batches):
             logger.info(f"⏳ Processing batch {batch_idx + 1} of {self.batch_manager.num_batches}")

--- a/src/data_designer/interface/data_designer.py
+++ b/src/data_designer/interface/data_designer.py
@@ -56,14 +56,11 @@ from data_designer.engine.secret_resolver import (
 from data_designer.interface.errors import (
     DataDesignerGenerationError,
     DataDesignerProfilingError,
-    InvalidBufferValueError,
 )
 from data_designer.interface.results import DatasetCreationResults
 from data_designer.logging import RandomEmoji
 from data_designer.plugins.plugin import PluginType
 from data_designer.plugins.registry import PluginRegistry
-
-DEFAULT_BUFFER_SIZE = 1000
 
 DEFAULT_SECRET_RESOLVER = CompositeResolver([EnvironmentResolver(), PlaintextResolver()])
 
@@ -112,7 +109,6 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
     ):
         self._secret_resolver = secret_resolver or DEFAULT_SECRET_RESOLVER
         self._artifact_path = Path(artifact_path) if artifact_path is not None else Path.cwd() / "artifacts"
-        self._buffer_size = DEFAULT_BUFFER_SIZE
         self._run_config = RunConfig()
         self._managed_assets_path = Path(managed_assets_path or MANAGED_ASSETS_PATH)
         self._model_providers = self._resolve_model_providers(model_providers)
@@ -169,7 +165,7 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         builder = self._create_dataset_builder(config_builder, resource_provider)
 
         try:
-            builder.build(num_records=num_records, buffer_size=self._buffer_size)
+            builder.build(num_records=num_records)
         except Exception as e:
             raise DataDesignerGenerationError(f"🛑 Error generating dataset: {e}")
 
@@ -300,29 +296,13 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         """
         return self._secret_resolver
 
-    def set_buffer_size(self, buffer_size: int) -> None:
-        """Set the buffer size for dataset generation.
-
-        The buffer size controls how many records are processed in memory at once
-        during dataset generation using the `create` method. The default value is
-        set to the constant `DEFAULT_BUFFER_SIZE` defined in the data_designer module.
-
-        Args:
-            buffer_size: Number of records to process in each buffer.
-
-        Raises:
-            InvalidBufferValueError: If buffer size is less than or equal to 0.
-        """
-        if buffer_size <= 0:
-            raise InvalidBufferValueError("Buffer size must be greater than 0.")
-        self._buffer_size = buffer_size
-
     def set_run_config(self, run_config: RunConfig) -> None:
         """Set the runtime configuration for dataset generation.
 
         Args:
             run_config: A RunConfig instance containing runtime settings such as
-                early shutdown behavior. Import RunConfig from data_designer.essentials.
+                early shutdown behavior and batch sizing via `buffer_size`. Import RunConfig from
+                data_designer.essentials.
 
         Example:
             >>> from data_designer.essentials import DataDesigner, RunConfig


### PR DESCRIPTION
## Summary
This change moves dataset generation **buffer sizing** into `RunConfig`, making runtime execution settings explicit and centralized.

- Add `RunConfig.buffer_size` (default: **1000**, validated via `Field(gt=0)`).
- Make `ColumnWiseDatasetBuilder.build(...)` read `buffer_size` from `ResourceProvider.run_config` (removes the explicit `buffer_size` argument).
- Remove `DataDesigner`’s buffer configuration helper (`set_buffer_size`) and its internal `_buffer_size` state.
- Update unit tests to configure buffer sizing via `RunConfig`.

## Motivation
Previously, buffer sizing lived on `DataDesigner` via a separate helper method, while other runtime/execution controls (early shutdown, retry limits) lived on `RunConfig`. That split made it harder for users to discover, reason about, and persist “how generation runs” settings.

By consolidating `buffer_size` into `RunConfig`, **all runtime knobs that affect execution behavior now live in one place**, and the engine consistently reads them from a single source (`ResourceProvider.run_config`). This clarifies dataset generation settings, makes configs easier to share/reuse, and reduces the chance of configuration drift between interface and engine.

## Behavior / impact
- **Default behavior is unchanged**: if users do nothing, `RunConfig().buffer_size == 1000`.
- `buffer_size` controls **end-to-end batch size** during persisted generation: one batch is generated, post-batch processors run, and the batch is written to artifact storage before the next batch begins.
- **Breaking change**: `DataDesigner.set_buffer_size(...)` was removed. Buffer sizing is now configured only via `RunConfig`.

## Usage example

```python
from data_designer.essentials import DataDesigner, RunConfig

dd = DataDesigner(artifact_path="./artifacts")

# Configure runtime execution settings in one place
run_config = RunConfig(
    buffer_size=250,  # records per end-to-end batch (generate -> process -> write)
    shutdown_error_rate=0.3,
    shutdown_error_window=25,
)

dd.set_run_config(run_config)

results = dd.create(config_builder, num_records=10_000)
```

## Tests
- Updated interface and engine builder tests to validate default + configured `buffer_size` behavior and to reflect the removed helper API.
