### PR TITLE
chore: Set json_schema_mode_override validation on ConfigBase

### DIFF
--- a/src/data_designer/config/base.py
+++ b/src/data_designer/config/base.py
@@ -18,6 +18,7 @@ class ConfigBase(BaseModel):
         use_enum_values=True,
         arbitrary_types_allowed=True,
         extra="forbid",
+        json_schema_mode_override="validation",
     )
 
 


### PR DESCRIPTION
Set json schema mode on `ConfigBase` so that all our types inherit it. This prevents openapi and Stainless from generating separate `-Input/-Output` objects.