### PR TITLE
fix: dataset metadata should be optional in `PreviewResults`

### DIFF
--- a/src/data_designer/config/preview_results.py
+++ b/src/data_designer/config/preview_results.py
@@ -16,7 +16,7 @@ class PreviewResults(WithRecordSamplerMixin):
         self,
         *,
         config_builder: DataDesignerConfigBuilder,
-        dataset_metadata: DatasetMetadata,
+        dataset_metadata: DatasetMetadata | None = None,
         dataset: pd.DataFrame | None = None,
         analysis: DatasetProfilerResults | None = None,
         processor_artifacts: dict[str, list[str] | str] | None = None,
@@ -33,5 +33,5 @@ class PreviewResults(WithRecordSamplerMixin):
         self.dataset: pd.DataFrame | None = dataset
         self.analysis: DatasetProfilerResults | None = analysis
         self.processor_artifacts: dict[str, list[str] | str] | None = processor_artifacts
-        self.dataset_metadata = dataset_metadata
+        self.dataset_metadata: DatasetMetadata | None = dataset_metadata
         self._config_builder = config_builder

--- a/src/data_designer/config/utils/visualization.py
+++ b/src/data_designer/config/utils/visualization.py
@@ -58,7 +58,7 @@ class ColorPalette(str, Enum):
 
 class WithRecordSamplerMixin:
     _display_cycle_index: int = 0
-    dataset_metadata: DatasetMetadata
+    dataset_metadata: DatasetMetadata | None
 
     @cached_property
     def _record_sampler_dataset(self) -> pd.DataFrame:
@@ -122,7 +122,9 @@ class WithRecordSamplerMixin:
                     else:
                         processor_data_to_display[processor] = self.processor_artifacts[processor]
 
-        seed_column_names = None if hide_seed_columns else self.dataset_metadata.seed_column_names
+        seed_column_names = (
+            None if hide_seed_columns or self.dataset_metadata is None else self.dataset_metadata.seed_column_names
+        )
 
         display_sample_record(
             record=record,


### PR DESCRIPTION
Making `dataset_metadata` optional in `PreviewResults` just to be consistent