### PR TITLE
fix: incorrect litellm lazy load for class extension

### DIFF
--- a/src/data_designer/engine/models/litellm_overrides.py
+++ b/src/data_designer/engine/models/litellm_overrides.py
@@ -7,9 +7,15 @@ import random
 import threading
 from typing import TYPE_CHECKING
 
+# Import specific litellm submodules needed for class inheritance
+# Note: Class inheritance requires base classes at definition time, so we import these directly.
+# Runtime litellm usage below still benefits from lazy loading via the litellm alias.
+import litellm.caching.in_memory_cache as _litellm_cache
+import litellm.router as _litellm_router
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
+# Use lazy loading for runtime litellm usage (RetryPolicy, utils, etc.)
 from data_designer.lazy_heavy_imports import httpx, litellm
 from data_designer.logging import quiet_noisy_logger
 
@@ -48,7 +54,7 @@ class LiteLLMRouterDefaultKwargs(BaseModel):
     )
 
 
-class ThreadSafeCache(litellm.caching.in_memory_cache.InMemoryCache):
+class ThreadSafeCache(_litellm_cache.InMemoryCache):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -83,7 +89,7 @@ class ThreadSafeCache(litellm.caching.in_memory_cache.InMemoryCache):
             super().flush_cache()
 
 
-class CustomRouter(litellm.router.Router):
+class CustomRouter(_litellm_router.Router):
     def __init__(
         self,
         *args,

--- a/tests/config/analysis/test_column_statistics.py
+++ b/tests/config/analysis/test_column_statistics.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.analysis.column_statistics import (
@@ -21,6 +23,11 @@ from data_designer.config.analysis.column_statistics import (
     SamplerType,
     ValidationColumnStatistics,
 )
+from data_designer.lazy_heavy_imports import np, pd
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/config/test_config_builder.py
+++ b/tests/config/test_config_builder.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pandas as pd
 import pytest
 import yaml
 from pydantic import BaseModel, ValidationError
@@ -39,6 +41,10 @@ from data_designer.config.seed_source import DataFrameSeedSource, HuggingFaceSee
 from data_designer.config.utils.code_lang import CodeLang
 from data_designer.config.utils.info import ConfigBuilderInfo
 from data_designer.config.validator_params import CodeValidatorParams
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class DummyStructuredModel(BaseModel):

--- a/tests/config/test_seed_source.py
+++ b/tests/config/test_seed_source.py
@@ -1,13 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
+from __future__ import annotations
 
-import pandas as pd
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.errors import InvalidFilePathError
 from data_designer.config.seed_source import DataFrameSeedSource, LocalFileSeedSource
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def create_partitions_in_path(temp_dir: Path, extension: str, num_files: int = 2) -> Path:

--- a/tests/config/test_validator_params.py
+++ b/tests/config/test_validator_params.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from pydantic import ValidationError
 
@@ -11,6 +14,10 @@ from data_designer.config.validator_params import (
     LocalCallableValidatorParams,
     RemoteValidatorParams,
 )
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_code_validator_params():

--- a/tests/config/utils/test_io_helpers.py
+++ b/tests/config/utils/test_io_helpers.py
@@ -1,18 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import tempfile
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import numpy as np
-import pandas as pd
 import pytest
 import yaml
 
 from data_designer.config.utils.io_helpers import serialize_data, smart_load_dataframe, smart_load_yaml
+from data_designer.lazy_heavy_imports import np, pd
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 
 @patch("data_designer.config.utils.io_helpers.Path", autospec=True)

--- a/tests/config/utils/test_visualization.py
+++ b/tests/config/utils/test_visualization.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.config_builder import DataDesignerConfigBuilder
@@ -12,6 +15,10 @@ from data_designer.config.utils.visualization import (
     mask_api_key,
 )
 from data_designer.config.validator_params import CodeValidatorParams
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
 import tarfile
 import tempfile
 import textwrap
+from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
 import yaml
 
@@ -18,6 +20,10 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig, ModelProvider
 from data_designer.config.seed_source import HuggingFaceSeedSource
 from data_designer.engine.resources.seed_reader import SeedReader
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/analysis/column_profilers/test_base.py
+++ b/tests/engine/analysis/column_profilers/test_base.py
@@ -1,13 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from pydantic import ValidationError
 
 from data_designer.config.column_configs import SamplerColumnConfig
 from data_designer.config.sampler_params import SamplerType
 from data_designer.engine.analysis.column_profilers.base import ColumnConfigWithDataFrame
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_column_config_with_dataframe_valid_column_config_with_dataframe():

--- a/tests/engine/analysis/column_profilers/test_judge_score_profiler.py
+++ b/tests/engine/analysis/column_profilers/test_judge_score_profiler.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
-import pyarrow as pa
 import pytest
 
 from data_designer.config.analysis.column_statistics import (
@@ -23,6 +24,11 @@ from data_designer.engine.analysis.column_profilers.judge_score_profiler import 
     JudgeScoreSummary,
 )
 from data_designer.engine.analysis.utils.judge_score_processing import JudgeScoreDistributions, JudgeScoreSample
+from data_designer.lazy_heavy_imports import pa, pd
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow as pa
 
 
 @pytest.fixture

--- a/tests/engine/analysis/conftest.py
+++ b/tests/engine/analysis/conftest.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
-import pyarrow as pa
 from pytest import fixture
 
 from data_designer.config.analysis.column_statistics import (
@@ -26,6 +27,11 @@ from data_designer.engine.dataset_builders.artifact_storage import ArtifactStora
 from data_designer.engine.models.registry import ModelRegistry
 from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pa, pd
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow as pa
 
 
 @fixture

--- a/tests/engine/analysis/test_column_statistics_calculator.py
+++ b/tests/engine/analysis/test_column_statistics_calculator.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from data_designer.config.analysis.column_statistics import ColumnDistributionType
 from data_designer.config.column_types import DataDesignerColumnType
@@ -9,6 +11,10 @@ from data_designer.config.sampler_params import SamplerType
 from data_designer.engine.analysis.column_profilers.base import ColumnConfigWithDataFrame
 from data_designer.engine.analysis.column_statistics import get_column_statistics_calculator
 from data_designer.engine.analysis.utils.column_statistics_calculations import ensure_hashable
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_general_column_statistics(stub_df, column_configs):

--- a/tests/engine/analysis/utils/test_column_statistics_calculations.py
+++ b/tests/engine/analysis/utils/test_column_statistics_calculations.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from itertools import cycle
+from __future__ import annotations
 
-import numpy as np
-import pandas as pd
-import pyarrow as pa
+from itertools import cycle
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.analysis.column_statistics import (
@@ -27,6 +27,12 @@ from data_designer.engine.analysis.utils.column_statistics_calculations import (
     ensure_boolean,
     ensure_hashable,
 )
+from data_designer.lazy_heavy_imports import np, pa, pd
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
 
 
 @pytest.fixture

--- a/tests/engine/analysis/utils/test_judge_score_processing.py
+++ b/tests/engine/analysis/utils/test_judge_score_processing.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.analysis.column_statistics import (
@@ -18,6 +21,10 @@ from data_designer.engine.analysis.utils.judge_score_processing import (
     extract_judge_score_distributions,
     sample_scores_and_reasoning,
 )
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_extract_judge_score_distributions_numerical_scores(stub_judge_column_config):

--- a/tests/engine/column_generators/generators/test_column_generator_base.py
+++ b/tests/engine/column_generators/generators/test_column_generator_base.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock
+from __future__ import annotations
 
-import pandas as pd
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.engine.column_generators.generators.base import (
@@ -12,6 +13,10 @@ from data_designer.engine.column_generators.generators.base import (
     GenerationStrategy,
 )
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _create_test_generator_class(strategy=GenerationStrategy.CELL_BY_CELL):

--- a/tests/engine/column_generators/generators/test_expression.py
+++ b/tests/engine/column_generators/generators/test_expression.py
@@ -1,15 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.engine.column_generators.generators.expression import ExpressionColumnGenerator
 from data_designer.engine.column_generators.utils.errors import ExpressionTemplateRenderError
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _create_test_config(name="test_column", expr="{{ col1 }}", dtype="str"):

--- a/tests/engine/column_generators/generators/test_seed_dataset.py
+++ b/tests/engine/column_generators/generators/test_seed_dataset.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
 import tempfile
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import duckdb
-import pandas as pd
 import pytest
 
 from data_designer.config.column_configs import SeedDatasetColumnConfig
@@ -20,6 +21,11 @@ from data_designer.engine.column_generators.generators.seed_dataset import (
 from data_designer.engine.column_generators.utils.errors import SeedDatasetError
 from data_designer.engine.dataset_builders.multi_column_configs import SeedDatasetMultiColumnConfig
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import duckdb, pd
+
+if TYPE_CHECKING:
+    import duckdb
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/column_generators/generators/test_validation.py
+++ b/tests/engine/column_generators/generators/test_validation.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.config.column_configs import ValidationColumnConfig
@@ -27,6 +29,10 @@ from data_designer.engine.validators import (
     ValidationResult,
 )
 from data_designer.engine.validators.base import ValidationOutput
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from data_designer.config.run_config import RunConfig
@@ -12,6 +14,10 @@ from data_designer.engine.models.facade import ModelFacade
 from data_designer.engine.models.registry import ModelRegistry
 from data_designer.engine.resources.managed_storage import ManagedBlobStorage
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/dataset_builders/test_artifact_storage.py
+++ b/tests/engine/dataset_builders/test_artifact_storage.py
@@ -1,16 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 from datetime import datetime
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pandas as pd
 import pytest
 from pyarrow import ArrowNotImplementedError
 
 from data_designer.engine.dataset_builders.artifact_storage import ArtifactStorage, BatchStage
 from data_designer.engine.dataset_builders.errors import ArtifactStorageError
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/dataset_builders/test_column_wise_builder.py
+++ b/tests/engine/dataset_builders/test_column_wise_builder.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.config.column_configs import LLMTextColumnConfig, SamplerColumnConfig
@@ -20,6 +22,10 @@ from data_designer.engine.dataset_builders.errors import DatasetGenerationError
 from data_designer.engine.models.telemetry import InferenceEvent, NemoSourceEnum, TaskStatusEnum
 from data_designer.engine.models.usage import ModelUsageStats, TokenUsageStats
 from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/dataset_builders/utils/test_dataset_batch_manager.py
+++ b/tests/engine/dataset_builders/utils/test_dataset_batch_manager.py
@@ -1,15 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.dataset_builders.artifact_storage import BatchStage
 from data_designer.engine.dataset_builders.utils.dataset_batch_manager import DatasetBatchManager
 from data_designer.engine.dataset_builders.utils.errors import DatasetBatchManagementError
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/models/parsers/test_parser.py
+++ b/tests/engine/models/parsers/test_parser.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pydantic import BaseModel
 
 from data_designer.engine.models.parsers.parser import LLMResponseParser

--- a/tests/engine/models/test_litellm_overrides.py
+++ b/tests/engine/models/test_litellm_overrides.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import litellm
 import pytest
 
 from data_designer.engine.models.litellm_overrides import (
@@ -12,6 +14,10 @@ from data_designer.engine.models.litellm_overrides import (
     ThreadSafeCache,
     apply_litellm_patches,
 )
+from data_designer.lazy_heavy_imports import litellm
+
+if TYPE_CHECKING:
+    import litellm
 
 
 @pytest.fixture

--- a/tests/engine/processing/processors/test_drop_columns.py
+++ b/tests/engine/processing/processors/test_drop_columns.py
@@ -1,15 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.config.dataset_builders import BuildStage
 from data_designer.config.processors import DropColumnsProcessorConfig
 from data_designer.engine.dataset_builders.artifact_storage import BatchStage
 from data_designer.engine.processing.processors.drop_columns import DropColumnsProcessor
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/processing/processors/test_schema_transform.py
+++ b/tests/engine/processing/processors/test_schema_transform.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from data_designer.config.dataset_builders import BuildStage
@@ -12,6 +14,10 @@ from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.engine.dataset_builders.artifact_storage import BatchStage
 from data_designer.engine.processing.processors.schema_transform import SchemaTransformProcessor
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/processing/test_utils.py
+++ b/tests/engine/processing/test_utils.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.processing.utils import (
@@ -11,6 +13,10 @@ from data_designer.engine.processing.utils import (
     deserialize_json_values,
     parse_list_string,
 )
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/resources/conftest.py
+++ b/tests/engine/resources/conftest.py
@@ -1,14 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.resources.managed_storage import LocalBlobStorageProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/resources/test_managed_dataset_generator.py
+++ b/tests/engine/resources/test_managed_dataset_generator.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.resources.managed_dataset_generator import ManagedDatasetGenerator
@@ -11,6 +13,10 @@ from data_designer.engine.resources.managed_dataset_repository import ManagedDat
 from data_designer.engine.resources.managed_storage import ManagedBlobStorage
 from data_designer.engine.sampling_gen.entities.person import load_person_data_sampler
 from data_designer.engine.sampling_gen.errors import DatasetNotAvailableForLocaleError
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/resources/test_managed_dataset_repository.py
+++ b/tests/engine/resources/test_managed_dataset_repository.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.resources.managed_dataset_repository import (
@@ -14,6 +16,10 @@ from data_designer.engine.resources.managed_dataset_repository import (
     load_managed_dataset_repository,
 )
 from data_designer.engine.resources.managed_storage import ManagedBlobStorage
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_table_creation_default_schema():

--- a/tests/engine/resources/test_seed_reader.py
+++ b/tests/engine/resources/test_seed_reader.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.seed_source import DataFrameSeedSource
@@ -12,6 +15,10 @@ from data_designer.engine.resources.seed_reader import (
     SeedReaderRegistry,
 )
 from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_one_reader_per_seed_type():

--- a/tests/engine/sampling_gen/conftest.py
+++ b/tests/engine/sampling_gen/conftest.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import random
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
 from faker import Faker
 
@@ -13,6 +15,10 @@ from data_designer.engine.sampling_gen.data_sources.base import DataSource
 from data_designer.engine.sampling_gen.data_sources.sources import SamplerRegistry
 from data_designer.engine.sampling_gen.people_gen import PeopleGenFaker, PeopleGenFromDataset
 from data_designer.engine.sampling_gen.schema_builder import SchemaBuilder
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def create_person_args():

--- a/tests/engine/sampling_gen/data_sources/test_sources.py
+++ b/tests/engine/sampling_gen/data_sources/test_sources.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import numpy as np
-import pandas as pd
 import pytest
 
 from data_designer.config.sampler_params import (
@@ -43,6 +44,11 @@ from data_designer.engine.sampling_gen.data_sources.sources import (
     UUIDSampler,
     load_sampler,
 )
+from data_designer.lazy_heavy_imports import np, pd
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/engine/sampling_gen/test_constraints.py
+++ b/tests/engine/sampling_gen/test_constraints.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.sampler_constraints import (
@@ -10,6 +13,10 @@ from data_designer.config.sampler_constraints import (
     ScalarInequalityConstraint,
 )
 from data_designer.engine.sampling_gen.constraints import get_constraint_checker
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/sampling_gen/test_generator.py
+++ b/tests/engine/sampling_gen/test_generator.py
@@ -1,16 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from decimal import Decimal
 from functools import partial
+from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
 
 from data_designer.config.sampler_constraints import ColumnInequalityConstraint, ScalarInequalityConstraint
 from data_designer.config.sampler_params import SamplerType
 from data_designer.engine.sampling_gen.errors import RejectionSamplingError
 from data_designer.engine.sampling_gen.generator import DatasetGenerator
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 TEST_LOCALE_1 = "en_GB"
 TEST_LOCALE_2 = "fr_FR"

--- a/tests/engine/sampling_gen/test_jinja_utils.py
+++ b/tests/engine/sampling_gen/test_jinja_utils.py
@@ -1,12 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from data_designer.engine.sampling_gen.jinja_utils import JinjaDataFrame, extract_column_names_from_expression
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/sampling_gen/test_utils.py
+++ b/tests/engine/sampling_gen/test_utils.py
@@ -1,10 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.engine.sampling_gen.utils import check_random_state
+from data_designer.lazy_heavy_imports import np
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/test_configurable_task.py
+++ b/tests/engine/test_configurable_task.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from data_designer.config.base import ConfigBase
@@ -11,6 +13,10 @@ from data_designer.engine.configurable_task import ConfigurableTask, DataT, Task
 from data_designer.engine.dataset_builders.artifact_storage import ArtifactStorage
 from data_designer.engine.models.registry import ModelRegistry
 from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_configurable_task_generic_type_variables() -> None:

--- a/tests/engine/validators/test_local_callable.py
+++ b/tests/engine/validators/test_local_callable.py
@@ -1,11 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from data_designer.config.validator_params import LocalCallableValidatorParams
 from data_designer.engine.validators.local_callable import LocalCallableValidator
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture()

--- a/tests/engine/validators/test_python.py
+++ b/tests/engine/validators/test_python.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import tempfile
 

--- a/tests/engine/validators/test_remote.py
+++ b/tests/engine/validators/test_remote.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import json
+from __future__ import annotations
 
-import httpx
+import json
+from typing import TYPE_CHECKING
+
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -12,6 +14,10 @@ from data_designer.engine.validators.remote import (
     RemoteEndpointClient,
     RemoteValidator,
 )
+from data_designer.lazy_heavy_imports import httpx
+
+if TYPE_CHECKING:
+    import httpx
 
 
 @pytest.fixture()

--- a/tests/interface/test_data_designer.py
+++ b/tests/interface/test_data_designer.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pytest
 from pydantic import ValidationError
 
@@ -23,6 +25,10 @@ from data_designer.interface.errors import (
     DataDesignerGenerationError,
     DataDesignerProfilingError,
 )
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests/interface/test_results.py
+++ b/tests/interface/test_results.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pytest
 
 from data_designer.config.analysis.dataset_profiler import DatasetProfilerResults
@@ -14,6 +16,10 @@ from data_designer.config.utils.errors import DatasetSampleDisplayError
 from data_designer.config.utils.visualization import display_sample_record as display_fn
 from data_designer.engine.dataset_builders.artifact_storage import ArtifactStorage
 from data_designer.interface.results import DatasetCreationResults
+from data_designer.lazy_heavy_imports import pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @pytest.fixture

--- a/tests_e2e/src/data_designer_e2e_tests/plugins/column_generator/impl.py
+++ b/tests_e2e/src/data_designer_e2e_tests/plugins/column_generator/impl.py
@@ -1,10 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from data_designer.engine.column_generators.generators.base import ColumnGeneratorFullColumn
+from data_designer.lazy_heavy_imports import pd
 from data_designer_e2e_tests.plugins.column_generator.config import DemoColumnGeneratorConfig
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class DemoColumnGeneratorImpl(ColumnGeneratorFullColumn[DemoColumnGeneratorConfig]):

--- a/tests_e2e/src/data_designer_e2e_tests/plugins/seed_reader/impl.py
+++ b/tests_e2e/src/data_designer_e2e_tests/plugins/seed_reader/impl.py
@@ -1,10 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import duckdb
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from data_designer.engine.resources.seed_reader import SeedReader
+from data_designer.lazy_heavy_imports import duckdb
 from data_designer_e2e_tests.plugins.seed_reader.config import DemoSeedSource
+
+if TYPE_CHECKING:
+    import duckdb
 
 
 class DemoSeedReader(SeedReader[DemoSeedSource]):


### PR DESCRIPTION
Getting this:
```
     41     ## Sets the default retry policy, including the number
     42     ## of retries to use in particular scenarios.
     43     retry_policy: litellm.RetryPolicy = Field(
     44         default_factory=lambda: litellm.RetryPolicy(
     45             RateLimitErrorRetries=3,
     46             TimeoutErrorRetries=3,
     47         )
     48     )
---> 51 class ThreadSafeCache(litellm.caching.in_memory_cache.InMemoryCache):
     52     def __init__(self, *args, **kwargs):
     53         super().__init__(*args, **kwargs)

AttributeError: 'bool' object has no attribute 'in_memory_cache'
```

Hypothesis on why our unit/e2e tests didn't catch this is because our tests import `litellm` directly and when that is resolved first, by the time we get to `class ThreadSafeCache(litellm.caching.in_memory_cache.InMemoryCache):`, this is valid. But without it, `litellm.caching` resolves to the boolean var in `litellm.__init__.py`

Updated the rest of the test files to follow the same lazy load patterns.