### PR TITLE
fix: restore lazy load litellm overrides changes

### DIFF
--- a/tests/engine/models/test_litellm_overrides.py
+++ b/tests/engine/models/test_litellm_overrides.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import litellm
 import pytest
 
 from data_designer.engine.models.litellm_overrides import (
@@ -14,10 +14,6 @@ from data_designer.engine.models.litellm_overrides import (
     ThreadSafeCache,
     apply_litellm_patches,
 )
-from data_designer.lazy_heavy_imports import litellm
-
-if TYPE_CHECKING:
-    import litellm
 
 
 @pytest.fixture


### PR DESCRIPTION
Despite [PR-228](https://github.com/NVIDIA-NeMo/DataDesigner/pull/228), we're still intermittently seeing the following:
```
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.11/site-packages/data_designer/interface/data_designer.py", line 379, in _create_resource_provider
    return create_resource_provider(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.11/site-packages/data_designer/engine/resources/resource_provider.py", line 69, in create_resource_provider
    model_registry=create_model_registry(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.11/site-packages/data_designer/engine/models/factory.py", line 28, in create_model_registry
    from data_designer.engine.models.facade import ModelFacade
  File "/workspace/.venv/lib/python3.11/site-packages/data_designer/engine/models/facade.py", line 18, in <module>
    from data_designer.engine.models.litellm_overrides import CustomRouter, LiteLLMRouterDefaultKwargs
  File "/workspace/.venv/lib/python3.11/site-packages/data_designer/engine/models/litellm_overrides.py", line 13, in <module>
    import litellm.caching.in_memory_cache as _litellm_cache
ImportError: cannot import name 'in_memory_cache' from '<unknown module name>' (unknown location)
srun: error: pool0-00967: task 0: Exited with exit code 1
srun: Terminating StepId=8992952.3
```

In this PR, we roll back lazy load import changes in `litellm_overrides.py`.