### PR TITLE
chore: add CODEOWNERS for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files in the repository
+* @NVIDIA-NeMo/data_designer_reviewers


### PR DESCRIPTION
## 📋 Summary

Adds a CODEOWNERS file to automatically assign the `@NVIDIA-NeMo/data_designer_reviewers` team as reviewers for all pull requests.

## 🔄 Changes

### ✨ Added
- [`.github/CODEOWNERS`](.github/CODEOWNERS) - Assigns default reviewers for all files

---
🤖 *Generated with AI*