### PR TITLE
fix: automate README sync for data-designer package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INTERFACE_PKG := packages/data-designer
 # Package source and test paths
 CONFIG_PATHS := $(CONFIG_PKG)/src $(CONFIG_PKG)/tests
 ENGINE_PATHS := $(ENGINE_PKG)/src $(ENGINE_PKG)/tests
-INTERFACE_PATHS := $(INTERFACE_PKG)/src $(INTERFACE_PKG)/tests
+INTERFACE_PATHS := $(INTERFACE_PKG)/src $(INTERFACE_PKG)/tests $(INTERFACE_PKG)/dev-tools
 ALL_PKG_PATHS := packages/ scripts/ tests_e2e/
 
 # Test directories

--- a/packages/data-designer/dev-tools/hatch_build.py
+++ b/packages/data-designer/dev-tools/hatch_build.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 """Custom hatch metadata hook to sync README from root.
 
 This hook runs during metadata resolution (before build hooks) to ensure

--- a/packages/data-designer/pyproject.toml
+++ b/packages/data-designer/pyproject.toml
@@ -42,7 +42,7 @@ raw-options = { root = "../.." }
 version-file = "src/data_designer/interface/_version.py"
 
 [tool.hatch.metadata.hooks.custom]
-path = "hatch_build.py"
+path = "dev-tools/hatch_build.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/data_designer"]

--- a/scripts/update_license_headers.py
+++ b/scripts/update_license_headers.py
@@ -363,8 +363,8 @@ if __name__ == "__main__":
             if not package_dir.is_dir():
                 continue
 
-            # Process src/ and tests/ within each package
-            for subfolder in ["src", "tests"]:
+            # Process src/, tests/, and dev-tools/ within each package
+            for subfolder in ["src", "tests", "dev-tools"]:
                 folder_path = package_dir / subfolder
                 if not folder_path.exists():
                     continue


### PR DESCRIPTION
## 📋 Summary

Adds a hatchling metadata hook to automatically copy the root README.md to the data-designer package during builds, eliminating the need for manual copy steps in the Makefile.

## 🔄 Changes

### ✨ Added
- [`packages/data-designer/hatch_build.py`](packages/data-designer/hatch_build.py) - Custom hatch metadata hook that copies README from repository root before hatchling validates metadata

### 🔧 Changed
- [`packages/data-designer/pyproject.toml`](packages/data-designer/pyproject.toml) - Registered the custom metadata hook via `[tool.hatch.metadata.hooks.custom]`

### 🗑️ Removed
- Manual `cp README.md` steps from 6 Makefile targets: `install`, `install-dev`, `install-dev-notebooks`, `test-interface-isolated`, `test-e2e`, `build-interface`

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`packages/data-designer/hatch_build.py`](packages/data-designer/hatch_build.py) - This is a **metadata hook** (not a build hook) because hatchling validates README existence during metadata resolution, before build hooks run. This was tested to work correctly.

---
🤖 *Generated with AI*