### PR TITLE
fix: normalize trace content blocks to prevent parquet write crashes

### DIFF
--- a/docs/assets/recipes/mcp_and_tooluse/pdf_qa.py
+++ b/docs/assets/recipes/mcp_and_tooluse/pdf_qa.py
@@ -391,10 +391,31 @@ def _truncate(text: str, max_length: int = 100) -> str:
     return text[: max_length - 3] + "..."
 
 
+def _summarize_content(content: object) -> str:
+    """Summarize ChatML-style content blocks for display."""
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                block_type = block.get("type", "block")
+                if block_type == "text":
+                    text = str(block.get("text", ""))
+                    if text:
+                        parts.append(text)
+                elif block_type == "image_url":
+                    parts.append("[image]")
+                else:
+                    parts.append(f"[{block_type}]")
+            else:
+                parts.append(str(block))
+        return " ".join(parts)
+    return str(content)
+
+
 def _format_trace_step(msg: dict[str, object]) -> str:
     """Format a single trace message as a concise one-liner."""
     role = msg.get("role", "unknown")
-    content = msg.get("content", "")
+    content = _summarize_content(msg.get("content", ""))
     reasoning = msg.get("reasoning_content")
     tool_calls = msg.get("tool_calls")
     tool_call_id = msg.get("tool_call_id")

--- a/docs/concepts/traces.md
+++ b/docs/concepts/traces.md
@@ -68,10 +68,10 @@ Each trace is a `list[dict]` where each dict represents a message in the convers
 
 | Role | Fields | Description |
 |------|--------|-------------|
-| `system` | `role`, `content` | System prompt setting model behavior |
-| `user` | `role`, `content` | User prompt (rendered from template) |
-| `assistant` | `role`, `content`, `tool_calls`, `reasoning_content` | Model response; `content` may be `None` if only requesting tools |
-| `tool` | `role`, `content`, `tool_call_id` | Tool execution result; `tool_call_id` links to the request |
+| `system` | `role`, `content` | System prompt setting model behavior. `content` is a list of blocks in ChatML format. |
+| `user` | `role`, `content` | User prompt (rendered from template). `content` is a list of blocks (text + multimodal). |
+| `assistant` | `role`, `content`, `tool_calls`, `reasoning_content` | Model response; `content` may be empty if only requesting tools. |
+| `tool` | `role`, `content`, `tool_call_id` | Tool execution result; `tool_call_id` links to the request. |
 
 ### Example Trace (Simple Generation)
 
@@ -82,17 +82,17 @@ A basic trace without tool use:
     # System message (if configured)
     {
         "role": "system",
-        "content": "You are a helpful assistant that provides clear, concise answers."
+        "content": [{"type": "text", "text": "You are a helpful assistant that provides clear, concise answers."}]
     },
     # User message (the rendered prompt)
     {
         "role": "user",
-        "content": "What is the capital of France?"
+        "content": [{"type": "text", "text": "What is the capital of France?"}]
     },
     # Final assistant response
     {
         "role": "assistant",
-        "content": "The capital of France is Paris.",
+        "content": [{"type": "text", "text": "The capital of France is Paris."}],
         "reasoning_content": None  # May contain reasoning if model supports it
     }
 ]
@@ -107,17 +107,17 @@ When tool use is enabled, traces capture the full conversation including tool ca
     # System message
     {
         "role": "system",
-        "content": "You must call tools before answering. Only use tool results."
+        "content": [{"type": "text", "text": "You must call tools before answering. Only use tool results."}]
     },
     # User message (the rendered prompt)
     {
         "role": "user",
-        "content": "What documents are in the knowledge base about machine learning?"
+        "content": [{"type": "text", "text": "What documents are in the knowledge base about machine learning?"}]
     },
     # Assistant requests tool calls
     {
         "role": "assistant",
-        "content": None,
+        "content": [{"type": "text", "text": ""}],
         "tool_calls": [
             {
                 "id": "call_abc123",
@@ -132,13 +132,13 @@ When tool use is enabled, traces capture the full conversation including tool ca
     # Tool response (linked by tool_call_id)
     {
         "role": "tool",
-        "content": "Found 3 documents: intro_ml.pdf, neural_networks.pdf, transformers.pdf",
+        "content": [{"type": "text", "text": "Found 3 documents: intro_ml.pdf, neural_networks.pdf, transformers.pdf"}],
         "tool_call_id": "call_abc123"
     },
     # Final assistant response
     {
         "role": "assistant",
-        "content": "The knowledge base contains three documents about machine learning: ..."
+        "content": [{"type": "text", "text": "The knowledge base contains three documents about machine learning: ..."}]
     }
 ]
 ```


### PR DESCRIPTION
## Summary
- Fixes a parquet/pyarrow conversion failure when writing `__trace` columns containing mixed `messages[].content` types.
- Normalizes `ChatMessage.to_dict()` so `content` is always a ChatML/OpenAI-style list of content blocks (e.g. `[{"type":"text","text":...}]`), including for plain-text prompts.
- Updates docs + recipe trace rendering and adds tests covering multimodal + text traces.

## Problem
When traces are enabled (`with_trace=True` or `RunConfig.debug_override_save_all_column_traces=True`), we persist a `list[dict]` message history into `{column}__trace`.

In some runs, `messages[].content` is a **string** (typical text-only prompts) and in others it becomes a **list of content blocks** (multimodal context / tool-use flows). When these land in the same parquet column, pyarrow fails schema inference with errors like:

- `cannot mix list and non-list, non-null values`
- `Conversion failed for column 'answer__trace' with type object`

## Why this fixes it
By coercing **all** message `content` values to a single representation (ChatML block list) at serialization time, every row in the `__trace` column has the same nested shape. That removes the list/non-list mixing that triggers pyarrow conversion errors, and also makes traces directly reusable as ChatML-style training examples.

## Test plan
- `uv run pytest packages/data-designer-engine/tests/engine/column_generators/generators/test_llm_completion_generators.py`