### PR TITLE
chore: update tutorial notebooks to use dd. notation consistently

### DIFF
--- a/docs/colab_notebooks/1-the-basics.ipynb
+++ b/docs/colab_notebooks/1-the-basics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2af6c991",
+   "id": "c79eea7a",
    "metadata": {},
    "source": [
     "# 🎨 Data Designer Tutorial: The Basics\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e365f58",
+   "id": "2476f160",
    "metadata": {},
    "source": [
     "### 📦 Import Data Designer\n",
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6b60c35",
+   "id": "3646f62e",
    "metadata": {},
    "source": [
     "### ⚡ Colab Setup\n",
@@ -37,7 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "352ad006",
+   "id": "3348e5c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d48fcd7d",
+   "id": "19cd9249",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fa5c652",
+   "id": "5a6d13a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,12 +76,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c70454d5",
+   "id": "d445af5b",
    "metadata": {},
    "source": [
     "### ⚙️ Initialize the Data Designer interface\n",
     "\n",
-    "- `DataDesigner` is the main object is responsible for managing the data generation process.\n",
+    "- `DataDesigner` is the main object responsible for managing the data generation process.\n",
     "\n",
     "- When initialized without arguments, the [default model providers](https://nvidia-nemo.github.io/DataDesigner/latest/concepts/models/default-model-settings/) are used.\n"
    ]
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb2765d2",
+   "id": "4df0031d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cd5279b",
+   "id": "0f69b576",
    "metadata": {},
    "source": [
     "### 🎛️ Define model configurations\n",
@@ -115,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd90811a",
+   "id": "65d9be99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca306aca",
+   "id": "72582d09",
    "metadata": {},
    "source": [
     "### 🏗️ Initialize the Data Designer Config Builder\n",
@@ -160,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8dda0de2",
+   "id": "8d7992b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bc4a65c",
+   "id": "741a15a0",
    "metadata": {},
    "source": [
     "## 🎲 Getting started with sampler columns\n",
@@ -186,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bc65ad1",
+   "id": "c3879c70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34f81d0b",
+   "id": "1575ef81",
    "metadata": {},
    "source": [
     "Let's start designing our product review dataset by adding product category and subcategory columns.\n"
@@ -204,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2318c75a",
+   "id": "87a88d7b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8c68da2",
+   "id": "8c74b738",
    "metadata": {},
    "source": [
     "Next, let's add samplers to generate data related to the customer and their review.\n"
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8cb78e5",
+   "id": "4eb1da1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57b604d5",
+   "id": "4324d869",
    "metadata": {},
    "source": [
     "## 🦜 LLM-generated columns\n",
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b615760d",
+   "id": "1302a503",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eeb124f7",
+   "id": "7cf8241b",
    "metadata": {},
    "source": [
     "### 🔁 Iteration is key – preview the dataset!\n",
@@ -399,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fffc9d8e",
+   "id": "6fc6cf39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "643ee6a1",
+   "id": "c929e068",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69dfb926",
+   "id": "dfb04e2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f38ca0d",
+   "id": "adb879da",
    "metadata": {},
    "source": [
     "### 📊 Analyze the generated data\n",
@@ -443,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a044678d",
+   "id": "ff58dd9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c7147ab",
+   "id": "57c7355d",
    "metadata": {},
    "source": [
     "### 🆙 Scale up!\n",
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6a92b76",
+   "id": "df49db99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb888621",
+   "id": "2bbc48dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "521d34ae",
+   "id": "dc0673fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "910b21a2",
+   "id": "7688217b",
    "metadata": {},
    "source": [
     "## ⏭️ Next Steps\n",

--- a/docs/colab_notebooks/2-structured-outputs-and-jinja-expressions.ipynb
+++ b/docs/colab_notebooks/2-structured-outputs-and-jinja-expressions.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "040374c7",
+   "id": "258752cd",
    "metadata": {},
    "source": [
     "# 🎨 Data Designer Tutorial: Structured Outputs and Jinja Expressions\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c63f4819",
+   "id": "fc4217c3",
    "metadata": {},
    "source": [
     "### 📦 Import Data Designer\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91b3c60c",
+   "id": "2b831130",
    "metadata": {},
    "source": [
     "### ⚡ Colab Setup\n",
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0760772a",
+   "id": "fa1eda43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b19f9bf2",
+   "id": "5f014571",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "210a068d",
+   "id": "f7409282",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0761a71",
+   "id": "8234dd4b",
    "metadata": {},
    "source": [
     "### ⚙️ Initialize the Data Designer interface\n",
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f9b1d18",
+   "id": "21633aed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8b4f1ce",
+   "id": "9b215265",
    "metadata": {},
    "source": [
     "### 🎛️ Define model configurations\n",
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6f51bfc",
+   "id": "76260638",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0995e464",
+   "id": "e6bfd93d",
    "metadata": {},
    "source": [
     "### 🏗️ Initialize the Data Designer Config Builder\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9efa17ad",
+   "id": "a0fbd497",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d389e01",
+   "id": "7faae40e",
    "metadata": {},
    "source": [
     "### 🧑‍🎨 Designing our data\n",
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73d4df9d",
+   "id": "f2f94909",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b3c39bb",
+   "id": "696f19f4",
    "metadata": {},
    "source": [
     "Next, let's design our product review dataset using a few more tricks compared to the previous notebook.\n"
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a89cea7",
+   "id": "312b50cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c4516e1",
+   "id": "ecd971ca",
    "metadata": {},
    "source": [
     "Next, we will use more advanced Jinja expressions to create new columns.\n",
@@ -361,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05eeb4c8",
+   "id": "bda01ffc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12f335eb",
+   "id": "059613e1",
    "metadata": {},
    "source": [
     "### 🔁 Iteration is key – preview the dataset!\n",
@@ -431,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f764a9b",
+   "id": "23c9b839",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8e53f72",
+   "id": "e5adcdbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52b424a2",
+   "id": "1cc39cae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc6493bc",
+   "id": "bcca3f06",
    "metadata": {},
    "source": [
     "### 📊 Analyze the generated data\n",
@@ -475,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36f2ed36",
+   "id": "6e1957ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7d3c0f0",
+   "id": "9db283d3",
    "metadata": {},
    "source": [
     "### 🆙 Scale up!\n",
@@ -498,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0344849d",
+   "id": "30826883",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b2f7868",
+   "id": "88d4d3bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08fc7a73",
+   "id": "8762a2bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d89092b",
+   "id": "0375fcd2",
    "metadata": {},
    "source": [
     "## ⏭️ Next Steps\n",
@@ -542,7 +542,7 @@
     "\n",
     "- [Seeding synthetic data generation with an external dataset](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/3-seeding-with-a-dataset/)\n",
     "\n",
-    "- [Providing images as context](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/4-providing-images-as-context/)A\n"
+    "- [Providing images as context](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/4-providing-images-as-context/)\n"
    ]
   }
  ],

--- a/docs/colab_notebooks/3-seeding-with-a-dataset.ipynb
+++ b/docs/colab_notebooks/3-seeding-with-a-dataset.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8c0685e9",
+   "id": "b2a3e544",
    "metadata": {},
    "source": [
     "# 🎨 Data Designer Tutorial: Seeding Synthetic Data Generation with an External Dataset\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3db0af74",
+   "id": "d57c4f0a",
    "metadata": {},
    "source": [
     "### 📦 Import Data Designer\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f6961b0",
+   "id": "f7da8723",
    "metadata": {},
    "source": [
     "### ⚡ Colab Setup\n",
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9529c65f",
+   "id": "90a12556",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136bf26e",
+   "id": "8fcdfde5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca2fa0b2",
+   "id": "5899e85c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,12 +78,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "564d20a1",
+   "id": "6c093c90",
    "metadata": {},
    "source": [
     "### ⚙️ Initialize the Data Designer interface\n",
     "\n",
-    "- `DataDesigner` is the main object is responsible for managing the data generation process.\n",
+    "- `DataDesigner` is the main object responsible for managing the data generation process.\n",
     "\n",
     "- When initialized without arguments, the [default model providers](https://nvidia-nemo.github.io/DataDesigner/latest/concepts/models/default-model-settings/) are used.\n"
    ]
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2076e8e8",
+   "id": "6a2066fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf4d999a",
+   "id": "f5e81142",
    "metadata": {},
    "source": [
     "### 🎛️ Define model configurations\n",
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27042d5c",
+   "id": "880012ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "258959d8",
+   "id": "4b77a92c",
    "metadata": {},
    "source": [
     "### 🏗️ Initialize the Data Designer Config Builder\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "774c877c",
+   "id": "f4ab6628",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cb3f9fd",
+   "id": "26fb0a63",
    "metadata": {},
    "source": [
     "## 🏥 Prepare a seed dataset\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b144803",
+   "id": "84908e88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,16 +214,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "296e9b88",
+   "id": "1947e70a",
    "metadata": {},
    "source": [
     "## 🎨 Designing our synthetic patient notes dataset\n",
     "\n",
-    "- Here we use `add_column` with keyword arguments (rather than imported config objects).\n",
-    "\n",
-    "- Generally, we recommend using concrete objects, but this is a convenient shorthand.\n",
-    "\n",
-    "- **Note**: The prompt template can reference fields from our seed dataset:\n",
+    "- The prompt template can reference fields from our seed dataset:\n",
     "  - `{{ diagnosis }}` - the medical diagnosis from the seed data\n",
     "  - `{{ patient_summary }}` - the symptom description from the seed data\n"
    ]
@@ -231,76 +227,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "514d642d",
+   "id": "be2fbad1",
    "metadata": {},
    "outputs": [],
    "source": [
     "config_builder.add_column(\n",
-    "    name=\"patient_sampler\",\n",
-    "    column_type=\"sampler\",\n",
-    "    sampler_type=\"person_from_faker\",\n",
+    "    dd.SamplerColumnConfig(\n",
+    "        name=\"patient_sampler\",\n",
+    "        sampler_type=dd.SamplerType.PERSON_FROM_FAKER,\n",
+    "        params=dd.PersonFromFakerSamplerParams(),\n",
+    "    )\n",
     ")\n",
     "\n",
     "config_builder.add_column(\n",
-    "    name=\"doctor_sampler\",\n",
-    "    column_type=\"sampler\",\n",
-    "    sampler_type=\"person_from_faker\",\n",
+    "    dd.SamplerColumnConfig(\n",
+    "        name=\"doctor_sampler\",\n",
+    "        sampler_type=dd.SamplerType.PERSON_FROM_FAKER,\n",
+    "        params=dd.PersonFromFakerSamplerParams(),\n",
+    "    )\n",
     ")\n",
     "\n",
     "config_builder.add_column(\n",
-    "    name=\"patient_id\",\n",
-    "    column_type=\"sampler\",\n",
-    "    sampler_type=\"uuid\",\n",
-    "    params={\n",
-    "        \"prefix\": \"PT-\",\n",
-    "        \"short_form\": True,\n",
-    "        \"uppercase\": True,\n",
-    "    },\n",
+    "    dd.SamplerColumnConfig(\n",
+    "        name=\"patient_id\",\n",
+    "        sampler_type=dd.SamplerType.UUID,\n",
+    "        params=dd.UUIDSamplerParams(\n",
+    "            prefix=\"PT-\",\n",
+    "            short_form=True,\n",
+    "            uppercase=True,\n",
+    "        ),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "config_builder.add_column(dd.ExpressionColumnConfig(name=\"first_name\", expr=\"{{ patient_sampler.first_name }}\"))\n",
+    "\n",
+    "config_builder.add_column(dd.ExpressionColumnConfig(name=\"last_name\", expr=\"{{ patient_sampler.last_name }}\"))\n",
+    "\n",
+    "config_builder.add_column(dd.ExpressionColumnConfig(name=\"dob\", expr=\"{{ patient_sampler.birth_date }}\"))\n",
+    "\n",
+    "config_builder.add_column(\n",
+    "    dd.SamplerColumnConfig(\n",
+    "        name=\"symptom_onset_date\",\n",
+    "        sampler_type=dd.SamplerType.DATETIME,\n",
+    "        params=dd.DatetimeSamplerParams(start=\"2024-01-01\", end=\"2024-12-31\"),\n",
+    "    )\n",
     ")\n",
     "\n",
     "config_builder.add_column(\n",
-    "    name=\"first_name\",\n",
-    "    column_type=\"expression\",\n",
-    "    expr=\"{{ patient_sampler.first_name}}\",\n",
+    "    dd.SamplerColumnConfig(\n",
+    "        name=\"date_of_visit\",\n",
+    "        sampler_type=dd.SamplerType.TIMEDELTA,\n",
+    "        params=dd.TimeDeltaSamplerParams(dt_min=1, dt_max=30, reference_column_name=\"symptom_onset_date\"),\n",
+    "    )\n",
     ")\n",
     "\n",
-    "config_builder.add_column(\n",
-    "    name=\"last_name\",\n",
-    "    column_type=\"expression\",\n",
-    "    expr=\"{{ patient_sampler.last_name }}\",\n",
-    ")\n",
-    "\n",
+    "config_builder.add_column(dd.ExpressionColumnConfig(name=\"physician\", expr=\"Dr. {{ doctor_sampler.last_name }}\"))\n",
     "\n",
     "config_builder.add_column(\n",
-    "    name=\"dob\",\n",
-    "    column_type=\"expression\",\n",
-    "    expr=\"{{ patient_sampler.birth_date }}\",\n",
-    ")\n",
-    "\n",
-    "config_builder.add_column(\n",
-    "    name=\"symptom_onset_date\",\n",
-    "    column_type=\"sampler\",\n",
-    "    sampler_type=\"datetime\",\n",
-    "    params={\"start\": \"2024-01-01\", \"end\": \"2024-12-31\"},\n",
-    ")\n",
-    "\n",
-    "config_builder.add_column(\n",
-    "    name=\"date_of_visit\",\n",
-    "    column_type=\"sampler\",\n",
-    "    sampler_type=\"timedelta\",\n",
-    "    params={\"dt_min\": 1, \"dt_max\": 30, \"reference_column_name\": \"symptom_onset_date\"},\n",
-    ")\n",
-    "\n",
-    "config_builder.add_column(\n",
-    "    name=\"physician\",\n",
-    "    column_type=\"expression\",\n",
-    "    expr=\"Dr. {{ doctor_sampler.last_name }}\",\n",
-    ")\n",
-    "\n",
-    "config_builder.add_column(\n",
-    "    name=\"physician_notes\",\n",
-    "    column_type=\"llm-text\",\n",
-    "    prompt=\"\"\"\\\n",
+    "    dd.LLMTextColumnConfig(\n",
+    "        name=\"physician_notes\",\n",
+    "        prompt=\"\"\"\\\n",
     "You are a primary-care physician who just had an appointment with {{ first_name }} {{ last_name }},\n",
     "who has been struggling with symptoms from {{ diagnosis }} since {{ symptom_onset_date }}.\n",
     "The date of today's visit is {{ date_of_visit }}.\n",
@@ -313,7 +299,8 @@
     "Format the notes as a busy doctor might.\n",
     "Respond with only the notes, no other text.\n",
     "\"\"\",\n",
-    "    model_alias=MODEL_ALIAS,\n",
+    "        model_alias=MODEL_ALIAS,\n",
+    "    )\n",
     ")\n",
     "\n",
     "data_designer.validate(config_builder)"
@@ -321,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4aa32dd",
+   "id": "8fcce5dc",
    "metadata": {},
    "source": [
     "### 🔁 Iteration is key – preview the dataset!\n",
@@ -338,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4be850e8",
+   "id": "82dc02f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fd581ca",
+   "id": "1f2d1583",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "206445c9",
+   "id": "62a9173b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c0a2806",
+   "id": "5263e705",
    "metadata": {},
    "source": [
     "### 📊 Analyze the generated data\n",
@@ -382,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e826d8de",
+   "id": "5295320f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e786fe6d",
+   "id": "3ecc195f",
    "metadata": {},
    "source": [
     "### 🆙 Scale up!\n",
@@ -405,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "528e8462",
+   "id": "3865fb59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "214b5fd5",
+   "id": "a7acf2b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -428,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a21c2dca",
+   "id": "81a6e999",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5ca5cc0",
+   "id": "4503b1cf",
    "metadata": {},
    "source": [
     "## ⏭️ Next Steps\n",

--- a/docs/colab_notebooks/4-providing-images-as-context.ipynb
+++ b/docs/colab_notebooks/4-providing-images-as-context.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9a8f4f64",
+   "id": "90dda708",
    "metadata": {},
    "source": [
     "# 🎨 Data Designer Tutorial: Providing Images as Context for Vision-Based Data Generation"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d85440f7",
+   "id": "52ccb1e5",
    "metadata": {},
    "source": [
     "#### 📚 What you'll learn\n",
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d90bd46",
+   "id": "9627c4eb",
    "metadata": {},
    "source": [
     "### 📦 Import Data Designer\n",
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9a8e1a9",
+   "id": "1817171a",
    "metadata": {},
    "source": [
     "### ⚡ Colab Setup\n",
@@ -48,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f715c28a",
+   "id": "1f15a669",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e33732b",
+   "id": "1201c93b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc63dfe9",
+   "id": "f814b76c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,12 +100,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c40cb71",
+   "id": "ac423d57",
    "metadata": {},
    "source": [
     "### ⚙️ Initialize the Data Designer interface\n",
     "\n",
-    "- `DataDesigner` is the main object is responsible for managing the data generation process.\n",
+    "- `DataDesigner` is the main object responsible for managing the data generation process.\n",
     "\n",
     "- When initialized without arguments, the [default model providers](https://nvidia-nemo.github.io/DataDesigner/latest/concepts/models/default-model-settings/) are used.\n"
    ]
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2eb51e97",
+   "id": "3c655c2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cc7aca4",
+   "id": "7d41e922",
    "metadata": {},
    "source": [
     "### 🎛️ Define model configurations\n",
@@ -139,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63404d3f",
+   "id": "a8b5f4bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1ee89b0",
+   "id": "6455fc58",
    "metadata": {},
    "source": [
     "### 🏗️ Initialize the Data Designer Config Builder\n",
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61077e2e",
+   "id": "462c2e01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8af0928",
+   "id": "31369d10",
    "metadata": {},
    "source": [
     "### 🌱 Seed Dataset Creation\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ebc13e3",
+   "id": "55d9432a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02e9aeb6",
+   "id": "8614c4e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba81b496",
+   "id": "80550e46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa08941d",
+   "id": "65ced9bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a40e41d6",
+   "id": "34b210e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,10 +306,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f89ae56",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "id": "d506903d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Add a column to generate detailed document summaries\n",
@@ -330,20 +328,14 @@
     "            )\n",
     "        ],\n",
     "    )\n",
-    ")"
+    ")\n",
+    "\n",
+    "data_designer.validate(config_builder)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1e28672e",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18c97f17",
+   "id": "b91032a2",
    "metadata": {},
    "source": [
     "### 🔁 Iteration is key – preview the dataset!\n",
@@ -360,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "838e3fe0",
+   "id": "4bd947de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e8e9a18",
+   "id": "d0ff4c07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdf635f7",
+   "id": "e97e4dfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f94b2ba8",
+   "id": "0a284c12",
    "metadata": {},
    "source": [
     "### 📊 Analyze the generated data\n",
@@ -404,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f38cc55",
+   "id": "2570e7fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc6616a7",
+   "id": "28b8eb5a",
    "metadata": {},
    "source": [
     "### 🔎 Visual Inspection\n",
@@ -425,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35405370",
+   "id": "5d0d9336",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -449,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c7a2b96",
+   "id": "1c257a81",
    "metadata": {},
    "source": [
     "### 🆙 Scale up!\n",
@@ -462,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a158540",
+   "id": "e6d840e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183cd111",
+   "id": "909e6f3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6a3eac1",
+   "id": "adbb4cae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe3bff71",
+   "id": "d085584c",
    "metadata": {},
    "source": [
     "## ⏭️ Next Steps\n",

--- a/docs/notebook_source/1-the-basics.py
+++ b/docs/notebook_source/1-the-basics.py
@@ -35,7 +35,7 @@ from data_designer.interface import DataDesigner
 # %% [markdown]
 # ### ⚙️ Initialize the Data Designer interface
 #
-# - `DataDesigner` is the main object is responsible for managing the data generation process.
+# - `DataDesigner` is the main object responsible for managing the data generation process.
 #
 # - When initialized without arguments, the [default model providers](https://nvidia-nemo.github.io/DataDesigner/latest/concepts/models/default-model-settings/) are used.
 #

--- a/docs/notebook_source/2-structured-outputs-and-jinja-expressions.py
+++ b/docs/notebook_source/2-structured-outputs-and-jinja-expressions.py
@@ -370,5 +370,5 @@ analysis.to_report()
 #
 # - [Seeding synthetic data generation with an external dataset](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/3-seeding-with-a-dataset/)
 #
-# - [Providing images as context](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/4-providing-images-as-context/)A
+# - [Providing images as context](https://nvidia-nemo.github.io/DataDesigner/latest/notebooks/4-providing-images-as-context/)
 #

--- a/docs/notebook_source/4-providing-images-as-context.py
+++ b/docs/notebook_source/4-providing-images-as-context.py
@@ -54,7 +54,7 @@ from data_designer.interface import DataDesigner
 # %% [markdown]
 # ### ⚙️ Initialize the Data Designer interface
 #
-# - `DataDesigner` is the main object is responsible for managing the data generation process.
+# - `DataDesigner` is the main object responsible for managing the data generation process.
 #
 # - When initialized without arguments, the [default model providers](https://nvidia-nemo.github.io/DataDesigner/latest/concepts/models/default-model-settings/) are used.
 #
@@ -206,10 +206,7 @@ config_builder.add_column(
     )
 )
 
-
-# %% [markdown]
-#
-
+data_designer.validate(config_builder)
 
 # %% [markdown]
 # ### 🔁 Iteration is key – preview the dataset!


### PR DESCRIPTION
## 📋 Summary

Update tutorial notebooks to use the `dd.` prefix consistently for all Data Designer config classes, improving code clarity and alignment with documentation standards.

## 🔄 Changes

### 🔧 Changed
- Convert notebook 3 from string-based column definitions to class specs (`dd.SamplerColumnConfig`, `dd.ExpressionColumnConfig`, `dd.LLMTextColumnConfig`, etc.)
- Fix grammar in all notebooks: "is the main object is responsible" → "is the main object responsible"
- Remove stray "A" character at end of URL in notebook 2
- Remove empty markdown cell in notebook 4
- Add missing `data_designer.validate()` call in notebook 4
- Regenerate colab notebooks from source files

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`docs/notebook_source/3-seeding-with-a-dataset.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/chore/tutorial-notebooks-update/docs/notebook_source/3-seeding-with-a-dataset.py) - Main changes converting string-based columns to class specs

---
🤖 *Generated with AI*