### PR TITLE
fix: use reasoning_effort for gpt-5 inference params

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -324,6 +324,7 @@ DEFAULT_REASONING_INFERENCE_PARAMS = {"temperature": 0.35, "top_p": 0.95}
 DEFAULT_VISION_INFERENCE_PARAMS = {"temperature": 0.85, "top_p": 0.95}
 DEFAULT_EMBEDDING_INFERENCE_PARAMS = {"encoding_format": "float"}
 NEMOTRON_3_NANO_30B_A3B_INFERENCE_PARAMS = {"temperature": 1.0, "top_p": 1.0}
+GPT5_INFERENCE_PARAMS = {"extra_body": {"reasoning_effort": "medium"}}
 
 PREDEFINED_PROVIDERS_MODEL_MAP = {
     NVIDIA_PROVIDER_NAME: {
@@ -340,8 +341,8 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
     },
     OPENAI_PROVIDER_NAME: {
         "text": {"model": "gpt-4.1", "inference_parameters": DEFAULT_TEXT_INFERENCE_PARAMS},
-        "reasoning": {"model": "gpt-5", "inference_parameters": DEFAULT_REASONING_INFERENCE_PARAMS},
-        "vision": {"model": "gpt-5", "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS},
+        "reasoning": {"model": "gpt-5", "inference_parameters": GPT5_INFERENCE_PARAMS},
+        "vision": {"model": "gpt-5", "inference_parameters": GPT5_INFERENCE_PARAMS},
         "embedding": {"model": "text-embedding-3-large", "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS},
     },
     OPENROUTER_PROVIDER_NAME: {


### PR DESCRIPTION
## 📋 Summary

Fix health check failures for OpenAI `gpt-5` reasoning and vision models. `gpt-5` is a reasoning model that doesn't support `temperature`/`top_p` (see e.g. [this discussion](https://community.openai.com/t/temperature-in-gpt-5-models/1337133)) — use `reasoning_effort` via `extra_body` instead.

## 🔄 Changes

### 🐛 Fixed
- [`constants.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/test/health-checks-gpt5-fix/packages/data-designer-config/src/data_designer/config/utils/constants.py#L328) — Add `GPT5_INFERENCE_PARAMS` with `reasoning_effort: "medium"` and use it for OpenAI reasoning/vision entries instead of `DEFAULT_REASONING_INFERENCE_PARAMS`/`DEFAULT_VISION_INFERENCE_PARAMS`

Closes #314
---
🤖 *Generated with AI*