### PR TITLE
chore: gitignore Cerebro knowledge base files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ NOTEPAD.md
 
 # Build-time copy of README for data-designer package (copied from top-level during build)
 packages/data-designer/README.md
+
+# Cerebro knowledge base
+.cerebro/
+.cursor/rules/cerebro.mdc
+.cursor/mcp.json
+.claude/rules/cerebro.md


### PR DESCRIPTION
## 📋 Summary

Add gitignore rules for Cerebro-related files so we can experiment with the Cerebro persistent knowledge base locally without polluting the repo.

## 🔄 Changes

### ✨ Added
- `.gitignore` entries for Cerebro knowledge base files:
  - `.cerebro/` — local knowledge base storage
  - `.cursor/rules/cerebro.mdc` — Cursor agent rule for Cerebro
  - `.cursor/mcp.json` — MCP server configuration
  - `.claude/rules/cerebro.md` — Claude agent rule for Cerebro

---
🤖 *Generated with AI*