### PR TITLE
fix: include seed dataset in builder repr for seed-only configs

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/config_builder.py
+++ b/packages/data-designer-config/src/data_designer/config/config_builder.py
@@ -705,7 +705,7 @@ class DataDesignerConfigBuilder:
         Returns:
             A formatted string showing the builder's configuration including seed dataset and column information grouped by type.
         """
-        if len(self._column_configs) == 0:
+        if len(self._column_configs) == 0 and self._seed_config is None:
             return f"{self.__class__.__name__}()"
 
         props_to_repr = {

--- a/packages/data-designer-config/tests/config/test_config_builder.py
+++ b/packages/data-designer-config/tests/config/test_config_builder.py
@@ -768,6 +768,16 @@ def test_with_seed_dataset_sampling_strategy(stub_empty_builder):
     assert seed_config.sampling_strategy == SamplingStrategy.SHUFFLE
 
 
+def test_repr_includes_seed_dataset_when_no_columns(stub_empty_builder) -> None:
+    """repr should still show seed dataset when it is the only configured item."""
+    source = HuggingFaceSeedSource(path="datasets/test-repo/testing/data.csv")
+    stub_empty_builder.with_seed_dataset(source)
+
+    repr_string = repr(stub_empty_builder)
+
+    assert "seed_dataset: hf seed" in repr_string
+
+
 def test_add_model_config(stub_empty_builder):
     assert len(stub_empty_builder.model_configs) == 1
     assert stub_empty_builder.model_configs[0].alias == "stub-model"


### PR DESCRIPTION
## 📋 Summary

Fixes `DataDesignerConfigBuilder` repr behavior so seed-only configurations no longer appear empty in interactive use. Adds a regression test to ensure seed datasets remain visible when no columns are configured.

## 🔄 Changes

### 🐛 Fixed
- Updated `DataDesignerConfigBuilder.__repr__` to return `DataDesignerConfigBuilder()` only when both no columns and no seed dataset are configured.
- Preserves seed dataset visibility in notebook/REPL output after calling `with_seed_dataset(...)`.

### 🧪 Tests
- Added `test_repr_includes_seed_dataset_when_no_columns` in [`packages/data-designer-config/tests/config/test_config_builder.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/builder-repr-seed-only/packages/data-designer-config/tests/config/test_config_builder.py).
- Includes the behavior change in [`packages/data-designer-config/src/data_designer/config/config_builder.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/builder-repr-seed-only/packages/data-designer-config/src/data_designer/config/config_builder.py).
- Commit reference: `7af89c1b`.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`packages/data-designer-config/src/data_designer/config/config_builder.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/builder-repr-seed-only/packages/data-designer-config/src/data_designer/config/config_builder.py) - This is a public-facing repr path used in notebook and interactive workflows.

---
🤖 *Generated with AI*