### PR TITLE
docs: fix structure outputs blog format

### DIFF
--- a/docs/devnotes/posts/structured-outputs-from-nemotron.md
+++ b/docs/devnotes/posts/structured-outputs-from-nemotron.md
@@ -8,6 +8,8 @@ authors:
 
 Using [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner), an orchestration framework for generating high-quality synthetic data at scale, we built an iterative pipeline that generates diverse, schema-constrained structured outputs across JSON, YAML, and XML. Through multiple rounds of prompt refinement, rejection sampling, and programmatic validation, we produced a 9,949-sample dataset of verified structured output training data.
 
+<!-- more -->
+
 The dataset is publicly available: **[Download it on HuggingFace](https://huggingface.co/datasets/nvidia/Nemotron-RL-instruction_following-structured_outputs)** (CC BY 4.0).
 
 This post walks through the full SDG pipeline: schema generation, multi-format rollouts, rejection sampling, and the caveats we discovered along the way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,9 +66,10 @@ nav:
       - analysis: code_reference/analysis.md
   - Dev Notes:
       - devnotes/index.md
-      - Design Principles: devnotes/posts/design-principles.md
-      - RQA Dataset: devnotes/posts/rqa.md
+      - Structured Outputs from Nemotron: devnotes/posts/structured-outputs-from-nemotron.md
       - Deep Research Trajectories: devnotes/posts/deep-research-trajectories.md
+      - RQA Dataset: devnotes/posts/rqa.md
+      - Design Principles: devnotes/posts/design-principles.md
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- Rename the structured outputs dev note file to a Nemotron-specific slug and update the Dev Notes nav entry.
- Add a `<!-- more -->` marker near the top of the post so blog previews truncate cleanly.
- Keep content unchanged otherwise (rename detected at 99% similarity).

## Test plan
- [x] Confirm `mkdocs.yml` nav entry opens `Structured Outputs from Nemotron` correctly.
- [x] Verify blog preview/excerpt behavior renders as expected with the new `<!-- more -->` marker.