### PR TITLE
fix: correct broken dev note links in recipe pages

### DIFF
--- a/docs/recipes/code_generation/enterprise_text_to_sql.md
+++ b/docs/recipes/code_generation/enterprise_text_to_sql.md
@@ -1,7 +1,7 @@
 # Nemotron Super Text to SQL
 
 !!! note "Dev Note"
-    For a deep dive into the pipeline design, distractor injection strategy, quality waterfall analysis, and BIRD benchmark results, see [Engineering an Enterprise-Grade Text-to-SQL Dataset with NeMo Data Designer](../../devnotes/engineering-an-enterprise-grade-text-to-sql-dataset-with-nemo-data-designer/).
+    For a deep dive into the pipeline design, distractor injection strategy, quality waterfall analysis, and BIRD benchmark results, see [Engineering an Enterprise-Grade Text-to-SQL Dataset with NeMo Data Designer](../../../devnotes/engineering-an-enterprise-grade-text-to-sql-dataset-with-nemo-data-designer/).
 
 [Download Code :octicons-download-24:](../../../assets/recipes/code_generation/enterprise_text_to_sql.py){ .md-button download="enterprise_text_to_sql.py" }
 

--- a/docs/recipes/mcp_and_tooluse/search_agent.md
+++ b/docs/recipes/mcp_and_tooluse/search_agent.md
@@ -1,7 +1,7 @@
 # Nemotron Super Search Agent
 
 !!! note "Dev Note"
-    For a deep dive into the pipeline design, production yield analysis, correctness challenges, and key takeaways, see [Search Agent SFT Data: Teaching LLMs to Browse the Web](../../devnotes/search-agent-sft-data-teaching-llms-to-browse-the-web/).
+    For a deep dive into the pipeline design, production yield analysis, correctness challenges, and key takeaways, see [Search Agent SFT Data: Teaching LLMs to Browse the Web](../../../devnotes/search-agent-sft-data-teaching-llms-to-browse-the-web/).
 
 !!! tip "Seed Dataset"
     This recipe includes built-in demo seeds (3 Wikidata knowledge graph paths) for quick testing. For production use, generate your own seed dataset from Wikidata random walks -- the dev note above describes the seed generation process (SPARQL queries, anti-meta filters, hop range 4-8). Each seed row needs: `seed_entity`, `final_answer_entity`, `readable_path`, `num_hops_in_graph`, and `ground_truth`. Pass your seed file via `--seed-path`.


### PR DESCRIPTION
### Summary
- Recipe pages are 3 levels deep (recipes/category/recipe/), so links to dev notes need ../../../devnotes/ not ../../devnotes/
- The extra level was missing, causing links to resolve to recipes/devnotes/ instead of devnotes/