### PR TITLE
Refactor filesystem seed reader cleanup

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 import codecs
 from abc import ABC
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Self
 
-from data_designer.config.errors import InvalidFilePathError
 from data_designer.config.utils.io_helpers import (
+    RELATIVE_PATH_CWD_RESOLUTION_DESCRIPTION,
     VALID_DATASET_FILE_EXTENSIONS,
     validate_dataset_file_path,
+    validate_directory_path,
     validate_path_contains_files_of_type,
 )
 
@@ -37,10 +37,7 @@ class LocalFileSeedSource(SeedSource):
 
     path: str = Field(
         ...,
-        description=(
-            "Path to a local seed dataset file or wildcard pattern. Relative paths are resolved from the "
-            "current working directory when the config is loaded, not from the config file location."
-        ),
+        description=f"Path to a local seed dataset file or wildcard pattern. {RELATIVE_PATH_CWD_RESOLUTION_DESCRIPTION}",
     )
 
     @field_validator("path", mode="after")
@@ -79,10 +76,7 @@ class HuggingFaceSeedSource(SeedSource):
 class FileSystemSeedSource(SeedSource, ABC):
     path: str = Field(
         ...,
-        description=(
-            "Directory containing seed artifacts. Relative paths are resolved from the current working "
-            "directory when the config is loaded, not from the config file location."
-        ),
+        description=f"Directory containing seed artifacts. {RELATIVE_PATH_CWD_RESOLUTION_DESCRIPTION}",
     )
     file_pattern: str = Field(
         "*",
@@ -98,9 +92,7 @@ class FileSystemSeedSource(SeedSource, ABC):
 
     @field_validator("path", mode="after")
     def validate_path(cls, value: str) -> str:
-        path = Path(value).expanduser().resolve()
-        if not path.is_dir():
-            raise InvalidFilePathError(f"🛑 Path {path} is not a directory.")
+        validate_directory_path(value)
         return value
 
     @field_validator("file_pattern", mode="after")

--- a/packages/data-designer-config/src/data_designer/config/utils/io_helpers.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/io_helpers.py
@@ -27,6 +27,10 @@ logger = logging.getLogger(__name__)
 MAX_CONFIG_URL_SIZE_BYTES = 1 * 1024 * 1024  # 1 MB
 VALID_DATASET_FILE_EXTENSIONS = {".parquet", ".csv", ".json", ".jsonl"}
 VALID_CONFIG_FILE_EXTENSIONS = {".yaml", ".yml", ".json"}
+RELATIVE_PATH_CWD_RESOLUTION_DESCRIPTION = (
+    "Relative paths are resolved from the current working directory when the config is loaded, "
+    "not from the config file location."
+)
 
 
 def ensure_config_dir_exists(config_dir: Path) -> None:
@@ -175,6 +179,14 @@ def validate_path_contains_files_of_type(path: str | Path, file_extension: str) 
     """
     if not any(Path(path).glob(f"*.{file_extension}")):
         raise InvalidFilePathError(f"🛑 Path {path!r} does not contain files of type {file_extension!r}.")
+
+
+def validate_directory_path(directory_path: str | Path) -> Path:
+    """Validate that a path points to an existing directory."""
+    directory_path = Path(directory_path).expanduser().resolve()
+    if not directory_path.is_dir():
+        raise InvalidFilePathError(f"🛑 Path {directory_path} is not a directory.")
+    return directory_path
 
 
 def smart_load_dataframe(dataframe: str | Path | pd.DataFrame) -> pd.DataFrame:

--- a/packages/data-designer-config/tests/config/test_seed_source.py
+++ b/packages/data-designer-config/tests/config/test_seed_source.py
@@ -84,19 +84,6 @@ def test_directory_seed_source_requires_directory(tmp_path: Path) -> None:
         DirectorySeedSource(path=str(file_path))
 
 
-def test_directory_seed_source_preserves_relative_path_input(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    seed_dir = tmp_path / "seed-dir"
-    seed_dir.mkdir()
-    monkeypatch.chdir(tmp_path)
-
-    source = DirectorySeedSource(path="seed-dir")
-
-    assert source.path == "seed-dir"
-    assert source.model_dump(mode="json")["path"] == "seed-dir"
-    assert source.file_pattern == "*"
-    assert source.recursive is True
-
-
 def test_file_contents_seed_source_defaults() -> None:
     source = FileContentsSeedSource(path=".", file_pattern="*.md", recursive=False)
 
@@ -106,7 +93,16 @@ def test_file_contents_seed_source_defaults() -> None:
     assert source.encoding == "utf-8"
 
 
-def test_file_contents_seed_source_preserves_relative_path_input(
+@pytest.mark.parametrize(
+    ("source_type", "kwargs"),
+    [
+        pytest.param(DirectorySeedSource, {}, id="directory"),
+        pytest.param(FileContentsSeedSource, {"file_pattern": "*.txt"}, id="file-contents"),
+    ],
+)
+def test_filesystem_seed_sources_preserve_relative_path_input(
+    source_type: type[DirectorySeedSource] | type[FileContentsSeedSource],
+    kwargs: dict[str, str],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -114,23 +110,23 @@ def test_file_contents_seed_source_preserves_relative_path_input(
     seed_dir.mkdir()
     monkeypatch.chdir(tmp_path)
 
-    source = FileContentsSeedSource(path="seed-dir", file_pattern="*.txt")
+    source = source_type(path="seed-dir", **kwargs)
 
     assert source.path == "seed-dir"
     assert source.model_dump(mode="json")["path"] == "seed-dir"
 
 
-def test_seed_source_path_descriptions_document_cwd_resolution() -> None:
-    local_path_description = LocalFileSeedSource.model_json_schema()["properties"]["path"]["description"]
-    directory_path_description = DirectorySeedSource.model_json_schema()["properties"]["path"]["description"]
-    file_contents_path_description = FileContentsSeedSource.model_json_schema()["properties"]["path"]["description"]
+@pytest.mark.parametrize(
+    "source_type",
+    [LocalFileSeedSource, DirectorySeedSource, FileContentsSeedSource],
+)
+def test_seed_source_path_descriptions_document_cwd_resolution(
+    source_type: type[LocalFileSeedSource] | type[DirectorySeedSource] | type[FileContentsSeedSource],
+) -> None:
+    path_description = source_type.model_json_schema()["properties"]["path"]["description"]
 
-    assert "current working directory" in local_path_description
-    assert "config file location" in local_path_description
-    assert "current working directory" in directory_path_description
-    assert "config file location" in directory_path_description
-    assert "current working directory" in file_contents_path_description
-    assert "config file location" in file_contents_path_description
+    assert "current working directory" in path_description
+    assert "config file location" in path_description
 
 
 def test_seed_sources_are_exported_from_config_module(tmp_path: Path) -> None:

--- a/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/seed_dataset.py
+++ b/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/seed_dataset.py
@@ -108,10 +108,11 @@ class SeedDatasetColumnGenerator(FromScratchColumnGenerator[SeedDatasetMultiColu
 
         while len(df_sample) < num_records:
             try:
-                df_batch = self._batch_reader.read_next_batch().to_pandas()
+                df_batch = self._batch_reader.read_next_batch()
                 df_sample = lazy.pd.concat([df_sample, df_batch], ignore_index=True)
             except StopIteration:
                 self._reset_batch_reader(num_records)
+                continue
 
             if len(df_batch) == 0:
                 num_zero_record_responses += 1

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -44,20 +44,8 @@ class SeedReaderFileSystemContext:
     root_path: Path
 
 
-class SeedReaderBatch(Protocol):
-    def to_pandas(self) -> pd.DataFrame: ...
-
-
 class SeedReaderBatchReader(Protocol):
-    def read_next_batch(self) -> SeedReaderBatch: ...
-
-
-@dataclass
-class PandasSeedReaderBatch:
-    dataframe: pd.DataFrame
-
-    def to_pandas(self) -> pd.DataFrame:
-        return self.dataframe
+    def read_next_batch(self) -> pd.DataFrame: ...
 
 
 def create_seed_reader_output_dataframe(
@@ -107,29 +95,30 @@ class DuckDBSeedReaderBatchReader:
         else:
             self._batch_reader = query_result.fetch_arrow_reader(batch_size=batch_size)
 
-    def read_next_batch(self) -> SeedReaderBatch:
-        return self._batch_reader.read_next_batch()
+    def read_next_batch(self) -> pd.DataFrame:
+        return self._batch_reader.read_next_batch().to_pandas()
 
 
-class HydratingSeedReaderBatchReader:
+class FileSystemSeedReaderBatchReader:
     def __init__(
         self,
         *,
-        manifest_batch_reader: SeedReaderBatchReader,
-        hydrate_records: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
-        output_columns: list[str],
+        manifest_dataframe: pd.DataFrame,
+        batch_size: int,
+        hydrate_manifest_dataframe: Callable[[pd.DataFrame], pd.DataFrame],
     ) -> None:
-        self._manifest_batch_reader = manifest_batch_reader
-        self._hydrate_records = hydrate_records
-        self._output_columns = output_columns
+        self._manifest_dataframe = manifest_dataframe.reset_index(drop=True)
+        self._batch_size = batch_size
+        self._hydrate_manifest_dataframe = hydrate_manifest_dataframe
+        self._next_row_index = 0
 
-    def read_next_batch(self) -> SeedReaderBatch:
-        manifest_batch = self._manifest_batch_reader.read_next_batch()
-        manifest_records = manifest_batch.to_pandas().to_dict(orient="records")
-        hydrated_records = self._hydrate_records(manifest_records)
-        return PandasSeedReaderBatch(
-            create_seed_reader_output_dataframe(records=hydrated_records, output_columns=self._output_columns)
-        )
+    def read_next_batch(self) -> pd.DataFrame:
+        if self._next_row_index >= len(self._manifest_dataframe):
+            raise StopIteration
+
+        batch_df = self._manifest_dataframe.iloc[self._next_row_index : self._next_row_index + self._batch_size]
+        self._next_row_index += self._batch_size
+        return self._hydrate_manifest_dataframe(batch_df.reset_index(drop=True))
 
 
 SourceT = TypeVar("SourceT", bound=SeedSource)
@@ -205,38 +194,6 @@ class SeedReader(ABC, Generic[SourceT]):
         )
         query_result = conn.query(read_query)
         return DuckDBSeedReaderBatchReader(conn=conn, query_result=query_result, batch_size=batch_size)
-
-    def create_filesystem_context(self, root_path: Path | str) -> SeedReaderFileSystemContext:
-        """Create a rooted filesystem context for directory-backed seed readers."""
-        resolved_root_path = Path(root_path).expanduser().resolve()
-        rooted_fs = DirFileSystem(path=str(resolved_root_path), fs=LocalFileSystem())
-        return SeedReaderFileSystemContext(fs=rooted_fs, root_path=resolved_root_path)
-
-    def get_matching_relative_paths(
-        self,
-        *,
-        context: SeedReaderFileSystemContext,
-        file_pattern: str,
-        recursive: bool,
-    ) -> list[str]:
-        # In fsspec, maxdepth=1 means files directly under the root
-        # (depth 0 = the root itself, depth 1 = direct children).
-        max_depth = None if recursive else 1
-        relative_paths = [
-            _normalize_relative_path(path) for path in context.fs.find("", withdirs=False, maxdepth=max_depth)
-        ]
-        matched_paths = [
-            relative_path
-            for relative_path in relative_paths
-            if fnmatchcase(PurePosixPath(relative_path).name, file_pattern)
-        ]
-        matched_paths.sort()
-
-        if not matched_paths:
-            search_scope = "under" if recursive else "directly under"
-            raise SeedReaderError(f"No files matched file_pattern {file_pattern!r} {search_scope} {context.root_path}")
-
-        return matched_paths
 
     def get_column_names(self) -> list[str]:
         """Returns the seed dataset's column names"""
@@ -350,6 +307,7 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
     """
 
     output_columns: list[str] | None = None
+    source_kind: str
 
     def _reset_attachment_state(self) -> None:
         super()._reset_attachment_state()
@@ -397,26 +355,58 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         shuffle: bool,
     ) -> SeedReaderBatchReader:
         self._ensure_attached()
-        context = self._get_filesystem_context()
-        conn = self.create_dataframe_duckdb_connection(
-            table_name=self._get_manifest_dataset_uri(),
-            dataframe=self._get_row_manifest_dataframe(),
+        return FileSystemSeedReaderBatchReader(
+            manifest_dataframe=self._select_manifest_dataframe(index_range=index_range, shuffle=shuffle),
+            batch_size=batch_size,
+            hydrate_manifest_dataframe=self._hydrate_manifest_dataframe,
         )
-        read_query = self.build_dataset_read_query(
-            dataset_uri=self._get_manifest_dataset_uri(),
-            index_range=index_range,
-            shuffle=shuffle,
+
+    def create_filesystem_context(self, root_path: Path | str) -> SeedReaderFileSystemContext:
+        """Create a rooted filesystem context for directory-backed seed readers."""
+        resolved_root_path = Path(root_path).expanduser().resolve()
+        rooted_fs = DirFileSystem(path=str(resolved_root_path), fs=LocalFileSystem())
+        return SeedReaderFileSystemContext(fs=rooted_fs, root_path=resolved_root_path)
+
+    def get_matching_relative_paths(
+        self,
+        *,
+        context: SeedReaderFileSystemContext,
+        file_pattern: str,
+        recursive: bool,
+    ) -> list[str]:
+        # In fsspec, maxdepth=1 means files directly under the root
+        # (depth 0 = the root itself, depth 1 = direct children).
+        max_depth = None if recursive else 1
+        relative_paths = [
+            _normalize_relative_path(path) for path in context.fs.find("", withdirs=False, maxdepth=max_depth)
+        ]
+        matched_paths = [
+            relative_path
+            for relative_path in relative_paths
+            if fnmatchcase(PurePosixPath(relative_path).name, file_pattern)
+        ]
+        matched_paths.sort()
+
+        if not matched_paths:
+            search_scope = "under" if recursive else "directly under"
+            raise SeedReaderError(f"No files matched file_pattern {file_pattern!r} {search_scope} {context.root_path}")
+
+        return matched_paths
+
+    def _build_metadata_manifest(self, *, context: SeedReaderFileSystemContext) -> list[dict[str, str]]:
+        matched_paths = self.get_matching_relative_paths(
+            context=context,
+            file_pattern=self.source.file_pattern,
+            recursive=self.source.recursive,
         )
-        query_result = conn.query(read_query)
-        manifest_batch_reader = DuckDBSeedReaderBatchReader(conn=conn, query_result=query_result, batch_size=batch_size)
-        return HydratingSeedReaderBatchReader(
-            manifest_batch_reader=manifest_batch_reader,
-            hydrate_records=lambda manifest_records: self._hydrate_rows(
-                manifest_rows=manifest_records,
+        return [
+            _build_metadata_record(
                 context=context,
-            ),
-            output_columns=self.get_output_column_names(),
-        )
+                relative_path=relative_path,
+                source_kind=self.source_kind,
+            )
+            for relative_path in matched_paths
+        ]
 
     def _get_row_manifest_dataframe(self) -> pd.DataFrame:
         self._ensure_attached()
@@ -439,17 +429,9 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         if output_df is not None:
             return output_df
 
-        context = self._get_filesystem_context()
-        hydrated_records = self._hydrate_rows(
-            manifest_rows=self._get_row_manifest_dataframe().to_dict(orient="records"),
-            context=context,
-        )
-        if not hydrated_records:
-            raise SeedReaderError(f"Seed source at {self.source.path} did not produce any rows")
-
-        self._output_df = create_seed_reader_output_dataframe(
-            records=hydrated_records,
-            output_columns=self.get_output_column_names(),
+        self._output_df = self._hydrate_manifest_dataframe(
+            self._get_row_manifest_dataframe(),
+            raise_on_empty=True,
         )
         return self._output_df
 
@@ -461,9 +443,6 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
             self._filesystem_context = context
         return context
 
-    def _get_manifest_dataset_uri(self) -> str:
-        return self._build_internal_table_name("manifest")
-
     def _build_internal_table_name(self, suffix: str) -> str:
         seed_type = self.get_seed_type().replace("-", "_")
         return f"seed_reader_{seed_type}_{suffix}"
@@ -472,6 +451,37 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         if isinstance(rows, lazy.pd.DataFrame):
             return rows.copy()
         return lazy.pd.DataFrame(rows)
+
+    def _select_manifest_dataframe(
+        self,
+        *,
+        index_range: IndexRange | None,
+        shuffle: bool,
+    ) -> pd.DataFrame:
+        manifest_df = self._get_row_manifest_dataframe()
+        if index_range is not None:
+            manifest_df = manifest_df.iloc[index_range.start : index_range.end + 1]
+        if shuffle:
+            manifest_df = manifest_df.sample(frac=1)
+        return manifest_df.reset_index(drop=True)
+
+    def _hydrate_manifest_dataframe(
+        self,
+        manifest_dataframe: pd.DataFrame,
+        *,
+        raise_on_empty: bool = False,
+    ) -> pd.DataFrame:
+        context = self._get_filesystem_context()
+        hydrated_records = self._hydrate_rows(
+            manifest_rows=manifest_dataframe.to_dict(orient="records"),
+            context=context,
+        )
+        if raise_on_empty and not hydrated_records:
+            raise SeedReaderError(f"Seed source at {self.source.path} did not produce any rows")
+        return create_seed_reader_output_dataframe(
+            records=hydrated_records,
+            output_columns=self.get_output_column_names(),
+        )
 
     def _hydrate_rows(
         self,
@@ -483,39 +493,18 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
 
 
 class DirectorySeedReader(FileSystemSeedReader[DirectorySeedSource]):
+    source_kind = "directory_file"
+
     def build_manifest(self, *, context: SeedReaderFileSystemContext) -> pd.DataFrame | list[dict[str, Any]]:
-        matched_paths = self.get_matching_relative_paths(
-            context=context,
-            file_pattern=self.source.file_pattern,
-            recursive=self.source.recursive,
-        )
-        return [
-            _build_metadata_record(
-                context=context,
-                relative_path=relative_path,
-                source_kind="directory_file",
-            )
-            for relative_path in matched_paths
-        ]
+        return self._build_metadata_manifest(context=context)
 
 
 class FileContentsSeedReader(FileSystemSeedReader[FileContentsSeedSource]):
+    source_kind = "file_contents"
     output_columns = ["source_kind", "source_path", "relative_path", "file_name", "content"]
 
     def build_manifest(self, *, context: SeedReaderFileSystemContext) -> pd.DataFrame | list[dict[str, Any]]:
-        matched_paths = self.get_matching_relative_paths(
-            context=context,
-            file_pattern=self.source.file_pattern,
-            recursive=self.source.recursive,
-        )
-        return [
-            _build_metadata_record(
-                context=context,
-                relative_path=relative_path,
-                source_kind="file_contents",
-            )
-            for relative_path in matched_paths
-        ]
+        return self._build_metadata_manifest(context=context)
 
     def hydrate_row(
         self,

--- a/packages/data-designer-engine/tests/engine/column_generators/generators/test_seed_dataset.py
+++ b/packages/data-designer-engine/tests/engine/column_generators/generators/test_seed_dataset.py
@@ -245,12 +245,8 @@ def test_seed_dataset_column_generator_reset_batch_reader_forwards_index_range(
 def test_seed_dataset_column_generator_sample_records_simple(stub_seed_dataset_generator):
     gen = stub_seed_dataset_generator
 
-    # Mock batch reader to return data
-    mock_batch = Mock()
-    mock_batch.to_pandas.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3]})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.return_value = mock_batch
+    gen._batch_reader.read_next_batch.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3]})
 
     result = gen._sample_records(3)
 
@@ -263,12 +259,8 @@ def test_seed_dataset_column_generator_sample_records_simple(stub_seed_dataset_g
 def test_seed_dataset_column_generator_sample_records_with_remaining(stub_seed_dataset_generator):
     gen = stub_seed_dataset_generator
 
-    # Mock batch reader to return more data than requested
-    mock_batch = Mock()
-    mock_batch.to_pandas.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3, 4, 5]})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.return_value = mock_batch
+    gen._batch_reader.read_next_batch.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3, 4, 5]})
 
     result = gen._sample_records(3)
 
@@ -284,12 +276,8 @@ def test_seed_dataset_column_generator_sample_records_with_previous_remaining(st
     gen = stub_seed_dataset_generator
     gen._df_remaining = lazy.pd.DataFrame({"col1": [10, 11]})
 
-    # Mock batch reader to return additional data
-    mock_batch = Mock()
-    mock_batch.to_pandas.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3]})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.return_value = mock_batch
+    gen._batch_reader.read_next_batch.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3]})
 
     result = gen._sample_records(4)
 
@@ -304,15 +292,11 @@ def test_seed_dataset_column_generator_sample_records_with_previous_remaining(st
 def test_seed_dataset_column_generator_sample_records_with_stop_iteration(stub_seed_dataset_generator):
     gen = stub_seed_dataset_generator
 
-    # First call raises StopIteration, then returns data after reset
-    mock_batch1 = Mock()
-    mock_batch1.to_pandas.side_effect = StopIteration()
-
-    mock_batch2 = Mock()
-    mock_batch2.to_pandas.return_value = lazy.pd.DataFrame({"col1": [1, 2, 3]})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.side_effect = [mock_batch1, mock_batch2]
+    gen._batch_reader.read_next_batch.side_effect = [
+        StopIteration(),
+        lazy.pd.DataFrame({"col1": [1, 2, 3]}),
+    ]
 
     gen._reset_batch_reader = Mock()
 
@@ -326,12 +310,8 @@ def test_seed_dataset_column_generator_sample_records_with_stop_iteration(stub_s
 def test_seed_dataset_column_generator_sample_records_zero_record_error(stub_seed_dataset_generator):
     gen = stub_seed_dataset_generator
 
-    # Mock batch reader to always return empty dataframes
-    mock_batch = Mock()
-    mock_batch.to_pandas.return_value = lazy.pd.DataFrame({"col1": []})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.return_value = mock_batch
+    gen._batch_reader.read_next_batch.return_value = lazy.pd.DataFrame({"col1": []})
 
     with pytest.raises(RuntimeError, match="🛑 Something went wrong while reading from the datastore"):
         gen._sample_records(3)
@@ -340,15 +320,11 @@ def test_seed_dataset_column_generator_sample_records_zero_record_error(stub_see
 def test_seed_dataset_column_generator_sample_records_multiple_batches(stub_seed_dataset_generator):
     gen = stub_seed_dataset_generator
 
-    # Mock batch reader to return data in multiple batches
-    mock_batch1 = Mock()
-    mock_batch1.to_pandas.return_value = lazy.pd.DataFrame({"col1": [1, 2]})
-
-    mock_batch2 = Mock()
-    mock_batch2.to_pandas.return_value = lazy.pd.DataFrame({"col1": [3, 4]})
-
     gen._batch_reader = Mock()
-    gen._batch_reader.read_next_batch.side_effect = [mock_batch1, mock_batch2]
+    gen._batch_reader.read_next_batch.side_effect = [
+        lazy.pd.DataFrame({"col1": [1, 2]}),
+        lazy.pd.DataFrame({"col1": [3, 4]}),
+    ]
 
     result = gen._sample_records(4)
 

--- a/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
+++ b/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
@@ -332,7 +332,7 @@ def test_file_contents_seed_reader_hydrates_only_selected_manifest_rows(tmp_path
         index_range=IndexRange(start=1, end=1),
         shuffle=False,
     )
-    batch_df = batch_reader.read_next_batch().to_pandas()
+    batch_df = batch_reader.read_next_batch()
 
     assert list(batch_df["relative_path"]) == ["beta.txt"]
     assert list(batch_df["content"]) == ["beta"]
@@ -384,7 +384,7 @@ def test_filesystem_seed_reader_raises_for_undeclared_hydrated_columns(
                 index_range=IndexRange(start=0, end=0),
                 shuffle=False,
             )
-            batch_reader.read_next_batch().to_pandas()
+            batch_reader.read_next_batch()
         else:
             reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
 
@@ -407,7 +407,7 @@ def test_filesystem_seed_reader_raises_for_missing_declared_hydrated_columns(
                 index_range=IndexRange(start=0, end=1),
                 shuffle=False,
             )
-            batch_reader.read_next_batch().to_pandas()
+            batch_reader.read_next_batch()
         else:
             reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
 
@@ -434,7 +434,7 @@ def test_filesystem_seed_reader_reuses_filesystem_context_until_reattach(tmp_pat
         index_range=IndexRange(start=0, end=0),
         shuffle=False,
     )
-    assert list(batch_reader.read_next_batch().to_pandas()["relative_path"]) == ["alpha.txt"]
+    assert list(batch_reader.read_next_batch()["relative_path"]) == ["alpha.txt"]
     assert reader.filesystem_context_calls == 1
 
     first_df = reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
@@ -459,7 +459,7 @@ def test_seed_reader_reuses_cached_duckdb_connection_until_reattach() -> None:
         shuffle=False,
     )
 
-    assert list(batch_reader.read_next_batch().to_pandas()["value"]) == [1, 2]
+    assert list(batch_reader.read_next_batch()["value"]) == [1, 2]
     assert reader.create_duckdb_connection_calls == 1
 
     reader.attach(DataFrameSeedSource(df=lazy.pd.DataFrame({"value": [9]})), PlaintextResolver())

--- a/packages/data-designer/src/data_designer/interface/data_designer.py
+++ b/packages/data-designer/src/data_designer/interface/data_designer.py
@@ -97,6 +97,10 @@ for plugin in PluginRegistry().get_plugins(PluginType.SEED_READER):
     DEFAULT_SEED_READERS.append(plugin.impl_cls())
 
 
+def _create_default_seed_readers() -> list[SeedReader]:
+    return [type(reader)() for reader in DEFAULT_SEED_READERS]
+
+
 class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
     """Main interface for creating datasets with Data Designer.
 
@@ -143,7 +147,8 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         self._model_provider_registry = resolve_model_provider_registry(
             self._model_providers, get_default_provider_name()
         )
-        self._seed_reader_registry = SeedReaderRegistry(readers=seed_readers or DEFAULT_SEED_READERS)
+        default_seed_readers = _create_default_seed_readers() if seed_readers is None else seed_readers
+        self._seed_reader_registry = SeedReaderRegistry(readers=default_seed_readers)
 
     @property
     def info(self) -> InterfaceInfo:

--- a/packages/data-designer/tests/interface/test_data_designer.py
+++ b/packages/data-designer/tests/interface/test_data_designer.py
@@ -19,7 +19,6 @@ from data_designer.config.models import ModelProvider
 from data_designer.config.processors import DropColumnsProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.sampler_params import CategorySamplerParams, SamplerType
-from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy
 from data_designer.config.seed_source import DirectorySeedSource, FileContentsSeedSource, HuggingFaceSeedSource
 from data_designer.engine.resources.seed_reader import (
     FileSystemSeedReader,
@@ -70,6 +69,22 @@ def _add_irrelevant_sampler_column(builder: DataDesignerConfigBuilder) -> None:
             sampler_type=SamplerType.CATEGORY,
             params=CategorySamplerParams(values=["irrelevant"]),
         )
+    )
+
+
+def _create_data_designer(
+    *,
+    artifact_path: Path,
+    model_providers: list[ModelProvider],
+    managed_assets_path: Path,
+    seed_readers: list[FileSystemSeedReader[Any]] | None = None,
+) -> DataDesigner:
+    return DataDesigner(
+        artifact_path=artifact_path,
+        model_providers=model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=managed_assets_path,
+        seed_readers=seed_readers,
     )
 
 
@@ -521,6 +536,39 @@ def test_initialize_interface_runtime_runs_once(monkeypatch: pytest.MonkeyPatch)
         mock_resolve.assert_called_once()
 
 
+def test_init_clones_default_seed_readers_per_instance(
+    stub_artifact_path: Path,
+    stub_model_providers: list[ModelProvider],
+    stub_managed_assets_path: Path,
+) -> None:
+    first = _create_data_designer(
+        artifact_path=stub_artifact_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=stub_managed_assets_path,
+    )
+    second = _create_data_designer(
+        artifact_path=stub_artifact_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=stub_managed_assets_path,
+    )
+
+    for seed_type in {"directory", "file_contents"}:
+        assert first._seed_reader_registry._readers[seed_type] is not second._seed_reader_registry._readers[seed_type]
+        assert type(first._seed_reader_registry._readers[seed_type]) is type(
+            second._seed_reader_registry._readers[seed_type]
+        )
+        assert (
+            first._seed_reader_registry._readers[seed_type]
+            is not dd_mod.DEFAULT_SEED_READERS[
+                next(
+                    index
+                    for index, reader in enumerate(dd_mod.DEFAULT_SEED_READERS)
+                    if reader.get_seed_type() == seed_type
+                )
+            ]
+        )
+
+
 def test_create_dataset_e2e_with_directory_seed_source(
     stub_artifact_path: Path,
     stub_model_providers: list[ModelProvider],
@@ -536,14 +584,11 @@ def test_create_dataset_e2e_with_directory_seed_source(
     builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir)))
     builder.add_column(ExpressionColumnConfig(name="path_label", expr="{{ source_kind }}::{{ relative_path }}"))
 
-    data_designer = DataDesigner(
+    results = _create_data_designer(
         artifact_path=stub_artifact_path,
         model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
         managed_assets_path=stub_managed_assets_path,
-    )
-
-    results = data_designer.create(builder, num_records=2, dataset_name="directory-seed-test")
+    ).create(builder, num_records=2, dataset_name="directory-seed-test")
     df = results.load_dataset().sort_values("relative_path").reset_index(drop=True)
 
     assert list(df["source_kind"]) == ["directory_file", "directory_file"]
@@ -552,74 +597,6 @@ def test_create_dataset_e2e_with_directory_seed_source(
     assert list(df["path_label"]) == [
         "directory_file::alpha.txt",
         "directory_file::subdir/beta.md",
-    ]
-
-
-def test_preview_dataset_e2e_with_directory_seed_source(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "directory-preview-seed"
-    (seed_dir / "subdir").mkdir(parents=True)
-    (seed_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
-    (seed_dir / "subdir" / "beta.txt").write_text("beta", encoding="utf-8")
-    (seed_dir / "subdir" / "gamma.md").write_text("gamma", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir), file_pattern="*.txt"))
-    builder.add_column(ExpressionColumnConfig(name="path_label", expr="{{ source_kind }}::{{ relative_path }}"))
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    preview_results = data_designer.preview(builder, num_records=2)
-    df = preview_results.dataset.sort_values("relative_path").reset_index(drop=True)
-
-    assert list(df["source_kind"]) == ["directory_file", "directory_file"]
-    assert list(df["relative_path"]) == ["alpha.txt", "subdir/beta.txt"]
-    assert list(df["path_label"]) == [
-        "directory_file::alpha.txt",
-        "directory_file::subdir/beta.txt",
-    ]
-
-
-def test_create_dataset_e2e_with_file_contents_seed_source(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "file-contents-seed"
-    seed_dir.mkdir(parents=True)
-    (seed_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
-    (seed_dir / "beta.txt").write_text("beta", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"))
-    builder.add_column(ExpressionColumnConfig(name="content_label", expr="{{ file_name }}::{{ content }}"))
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    results = data_designer.create(builder, num_records=2, dataset_name="file-contents-seed-test")
-    df = results.load_dataset().sort_values("file_name").reset_index(drop=True)
-
-    assert list(df["source_kind"]) == ["file_contents", "file_contents"]
-    assert list(df["file_name"]) == ["alpha.txt", "beta.txt"]
-    assert list(df["content"]) == ["alpha", "beta"]
-    assert list(df["content_label"]) == [
-        "alpha.txt::alpha",
-        "beta.txt::beta",
     ]
 
 
@@ -638,14 +615,11 @@ def test_preview_dataset_e2e_with_file_contents_seed_source(
     builder.with_seed_dataset(FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"))
     builder.add_column(ExpressionColumnConfig(name="content_label", expr="{{ file_name }}::{{ content }}"))
 
-    data_designer = DataDesigner(
+    preview_results = _create_data_designer(
         artifact_path=stub_artifact_path,
         model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
         managed_assets_path=stub_managed_assets_path,
-    )
-
-    preview_results = data_designer.preview(builder, num_records=2)
+    ).preview(builder, num_records=2)
     df = preview_results.dataset.sort_values("file_name").reset_index(drop=True)
 
     assert list(df["source_kind"]) == ["file_contents", "file_contents"]
@@ -654,122 +628,6 @@ def test_preview_dataset_e2e_with_file_contents_seed_source(
         "alpha.txt::alpha",
         "beta.txt::beta",
     ]
-
-
-def test_create_dataset_e2e_with_directory_seed_source_index_range_cycles_within_selection(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "directory-index-range-seed"
-    seed_dir.mkdir(parents=True)
-    for index in range(4):
-        (seed_dir / f"file-{index}.txt").write_text(f"value-{index}", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(
-        DirectorySeedSource(path=str(seed_dir), file_pattern="*.txt"),
-        selection_strategy=IndexRange(start=1, end=2),
-    )
-    _add_irrelevant_sampler_column(builder)
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    results = data_designer.create(builder, num_records=5, dataset_name="directory-index-range-test")
-    df = results.load_dataset().reset_index(drop=True)
-
-    assert list(df["relative_path"]) == [
-        "file-1.txt",
-        "file-2.txt",
-        "file-1.txt",
-        "file-2.txt",
-        "file-1.txt",
-    ]
-
-
-def test_create_dataset_e2e_with_file_contents_seed_source_partition_block_cycles_within_selection(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "file-contents-partition-seed"
-    seed_dir.mkdir(parents=True)
-    for index in range(6):
-        (seed_dir / f"file-{index}.txt").write_text(f"value-{index}", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(
-        FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"),
-        selection_strategy=PartitionBlock(index=1, num_partitions=3),
-    )
-    _add_irrelevant_sampler_column(builder)
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    results = data_designer.create(builder, num_records=5, dataset_name="file-contents-partition-test")
-    df = results.load_dataset().reset_index(drop=True)
-
-    assert list(df["relative_path"]) == [
-        "file-2.txt",
-        "file-3.txt",
-        "file-2.txt",
-        "file-3.txt",
-        "file-2.txt",
-    ]
-    assert list(df["content"]) == [
-        "value-2",
-        "value-3",
-        "value-2",
-        "value-3",
-        "value-2",
-    ]
-
-
-def test_create_dataset_e2e_with_file_contents_seed_source_shuffle_within_selection(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "file-contents-shuffle-seed"
-    seed_dir.mkdir(parents=True)
-    for index in range(6):
-        (seed_dir / f"file-{index}.txt").write_text(f"value-{index}", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(
-        FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"),
-        sampling_strategy=SamplingStrategy.SHUFFLE,
-        selection_strategy=IndexRange(start=0, end=4),
-    )
-    _add_irrelevant_sampler_column(builder)
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    results = data_designer.create(builder, num_records=15, dataset_name="file-contents-shuffle-test")
-    df = results.load_dataset().reset_index(drop=True)
-
-    expected_paths = [f"file-{index}.txt" for index in range(5)]
-    assert len(df) == 15
-    assert set(df["relative_path"]) == set(expected_paths)
-    assert list(df["relative_path"]) != expected_paths * 3
 
 
 def test_preview_dataset_e2e_with_custom_filesystem_seed_reader_via_seed_readers_argument(
@@ -787,15 +645,12 @@ def test_preview_dataset_e2e_with_custom_filesystem_seed_reader_via_seed_readers
     builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir), file_pattern="*.txt"))
     _add_irrelevant_sampler_column(builder)
 
-    data_designer = DataDesigner(
+    preview_results = _create_data_designer(
         artifact_path=stub_artifact_path,
         model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
         managed_assets_path=stub_managed_assets_path,
         seed_readers=[CustomDirectorySeedReader()],
-    )
-
-    preview_results = data_designer.preview(builder, num_records=2)
+    ).preview(builder, num_records=2)
     df = preview_results.dataset.sort_values("relative_path").reset_index(drop=True)
 
     assert list(df["decorated_path"]) == [
@@ -818,41 +673,12 @@ def test_create_dataset_e2e_with_directory_seed_source_no_matches_raises_generat
     builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir), file_pattern="*.md"))
     _add_irrelevant_sampler_column(builder)
 
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
     with pytest.raises(DataDesignerGenerationError, match="No files matched file_pattern '\\*\\.md'") as exc_info:
-        data_designer.create(builder, num_records=1, dataset_name="directory-no-matches-test")
-    assert isinstance(exc_info.value.__cause__, SeedReaderError)
-
-
-def test_preview_dataset_e2e_with_directory_seed_source_no_matches_raises_generation_error(
-    stub_artifact_path: Path,
-    stub_model_providers: list[ModelProvider],
-    stub_managed_assets_path: Path,
-    tmp_path: Path,
-) -> None:
-    seed_dir = tmp_path / "directory-preview-no-matches-seed"
-    seed_dir.mkdir(parents=True)
-    (seed_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
-
-    builder = DataDesignerConfigBuilder()
-    builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir), file_pattern="*.md"))
-    _add_irrelevant_sampler_column(builder)
-
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    with pytest.raises(DataDesignerGenerationError, match="No files matched file_pattern '\\*\\.md'") as exc_info:
-        data_designer.preview(builder, num_records=1)
+        _create_data_designer(
+            artifact_path=stub_artifact_path,
+            model_providers=stub_model_providers,
+            managed_assets_path=stub_managed_assets_path,
+        ).create(builder, num_records=1, dataset_name="directory-no-matches-test")
     assert isinstance(exc_info.value.__cause__, SeedReaderError)
 
 
@@ -870,42 +696,32 @@ def test_create_dataset_e2e_with_file_contents_seed_source_decode_failure_raises
     builder.with_seed_dataset(FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"))
     _add_irrelevant_sampler_column(builder)
 
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
     with pytest.raises(DataDesignerGenerationError, match="Failed to decode file"):
-        data_designer.create(builder, num_records=1, dataset_name="file-contents-decode-error-test")
+        _create_data_designer(
+            artifact_path=stub_artifact_path,
+            model_providers=stub_model_providers,
+            managed_assets_path=stub_managed_assets_path,
+        ).create(builder, num_records=1, dataset_name="file-contents-decode-error-test")
 
 
-def test_create_dataset_e2e_with_file_contents_seed_source_unreadable_file_raises_generation_error(
+def test_create_dataset_e2e_with_file_contents_seed_source_read_error_raises_generation_error(
     stub_artifact_path: Path,
     stub_model_providers: list[ModelProvider],
     stub_managed_assets_path: Path,
     tmp_path: Path,
 ) -> None:
-    seed_dir = tmp_path / "file-contents-permissions-seed"
+    seed_dir = tmp_path / "file-contents-read-error-seed"
     seed_dir.mkdir(parents=True)
-    unreadable_path = seed_dir / "blocked.txt"
-    unreadable_path.write_text("blocked", encoding="utf-8")
-    unreadable_path.chmod(0)
+    (seed_dir / "blocked.txt").write_text("blocked", encoding="utf-8")
 
     builder = DataDesignerConfigBuilder()
     builder.with_seed_dataset(FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"))
     _add_irrelevant_sampler_column(builder)
 
-    data_designer = DataDesigner(
-        artifact_path=stub_artifact_path,
-        model_providers=stub_model_providers,
-        secret_resolver=PlaintextResolver(),
-        managed_assets_path=stub_managed_assets_path,
-    )
-
-    try:
+    with patch("data_designer.engine.resources.seed_reader.DirFileSystem.open", side_effect=OSError("blocked")):
         with pytest.raises(DataDesignerGenerationError, match="Failed to read file"):
-            data_designer.create(builder, num_records=1, dataset_name="file-contents-permissions-test")
-    finally:
-        unreadable_path.chmod(0o644)
+            _create_data_designer(
+                artifact_path=stub_artifact_path,
+                model_providers=stub_model_providers,
+                managed_assets_path=stub_managed_assets_path,
+            ).create(builder, num_records=1, dataset_name="file-contents-read-error-test")


### PR DESCRIPTION
## Summary
- simplify the filesystem seed-reader batching path to operate directly on manifest DataFrames
- keep `DEFAULT_SEED_READERS` in place while cloning fresh per-instance default readers inside `DataDesigner`
- reduce duplicated config and interface-test coverage introduced by the filesystem reader PR without changing the feature set

## Validation
- `uv run ruff format --check` on changed files
- `uv run ruff check` on changed files
- targeted `pytest` for config, engine, and interface slices: `119 passed`
- `uv run --directory tests_e2e pytest tests/test_e2e.py -k filesystem_seed_reader_plugin`: `1 passed`