### PR TITLE
Fix #471: chore: replace softprops/action-gh-release with gh CLI in p...

### DIFF
--- a/.github/workflows/pack-tutorials.yml
+++ b/.github/workflows/pack-tutorials.yml
@@ -65,12 +65,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload zip file as release asset
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.get_release.outputs.tag }}
-          files: ${{ env.ZIP_FILE_NAME }}
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.get_release.outputs.tag }}" "${{ env.ZIP_FILE_NAME }}"
           
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Closes #471

Replaces the `softprops/action-gh-release@v2` third-party action in the pack-tutorials workflow with a native `gh release upload` CLI call.

## Changes

**`.github/workflows/pack-tutorials.yml`** (lines 68–73): The `Upload zip file as release asset` step no longer uses `softprops/action-gh-release@v2`. The `uses`/`with` block (specifying `tag_name`, `files`, `draft`, and `prerelease`) is replaced with an `env`/`run` block that authenticates via `GH_TOKEN: ${{ github.token }}` and executes `gh release upload "${{ steps.get_release.outputs.tag }}" "${{ env.ZIP_FILE_NAME }}"` directly. Net change: -5 lines, +3 lines.

## Motivation

`softprops/action-gh-release` is a personally-maintained action pinned via a mutable `v2` tag — the same supply chain risk pattern exploited in CVE-2025-30066 (tj-actions/changed-files). A compromised or tampered tag would silently execute arbitrary code with the workflow's token during a release.

Additionally, the action currently runs on Node.js 20. GitHub will deprecate Node.js 20 runner support on September 16, 2026, and no Node.js 24-compatible release of this action exists yet, meaning the step would begin emitting warnings after June 2, 2026 and break entirely by September.

`gh` is pre-installed on all GitHub-hosted runners and is maintained by GitHub directly, eliminating the third-party dependency with no functional change to the upload behavior.

## Testing

Verify by triggering the `pack-tutorials` workflow against a test release tag and confirming:
1. The workflow completes without error on the `Upload zip file as release asset` step.
2. The `.zip` archive named by `ZIP_FILE_NAME` appears as an asset on the target release (`steps.get_release.outputs.tag`).
3. `gh release view <tag> --json assets` lists the uploaded file with the expected name and size.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*