### PR TITLE
fix: use --bare and --tools in health probe CLI check

### DIFF
--- a/.github/workflows/agentic-ci-health-probe.yml
+++ b/.github/workflows/agentic-ci-health-probe.yml
@@ -87,11 +87,13 @@ jobs:
 
           echo "Claude CLI version: $(claude --version 2>&1 || true)"
 
-          # Run a minimal prompt to verify auth + model + tool usage work end-to-end
+          # Run a minimal prompt to verify auth + model work end-to-end
           RESULT=$(claude \
+            --bare \
             --model "$MODEL" \
             -p "Reply with exactly: HEALTH_CHECK_OK" \
             --max-turns 1 \
+            --tools "" \
             --output-format text \
             2>&1) || {
               echo "::error::Claude CLI failed"


### PR DESCRIPTION
## 📋 Summary

Fix the "Verify Claude CLI" step in the agentic CI health probe, which has failed on all 3 runs since merge. The raw API curl passes but the Claude CLI invocation fails because it tries to initialize keychain, LSP, plugins, and CLAUDE.md discovery on a bare CI runner.

## 🐛 Fixed
- Add `--bare` to skip all CLI initialization and force `ANTHROPIC_API_KEY` auth (no keychain/OAuth reads)
- Add `--tools ""` to disable tool definitions in the API request (health check doesn't need them)

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`agentic-ci-health-probe.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/health-probe-cli/.github/workflows/agentic-ci-health-probe.yml#L91-L99) - The two new flags in the `claude` invocation. Validated via [workflow_dispatch run](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/23908902669) which passes all steps.

---
🤖 *Generated with AI*