### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -298,6 +298,10 @@ OPENROUTER_PROVIDER_NAME = "openrouter"
 
 OPENROUTER_API_KEY_ENV_VAR_NAME = "OPENROUTER_API_KEY"
 
+MINIMAX_PROVIDER_NAME = "minimax"
+
+MINIMAX_API_KEY_ENV_VAR_NAME = "MINIMAX_API_KEY"
+
 PREDEFINED_PROVIDERS = [
     {
         "name": NVIDIA_PROVIDER_NAME,
@@ -317,6 +321,12 @@ PREDEFINED_PROVIDERS = [
         "provider_type": "openai",
         "api_key": OPENROUTER_API_KEY_ENV_VAR_NAME,
     },
+    {
+        "name": MINIMAX_PROVIDER_NAME,
+        "endpoint": "https://api.minimax.io/v1",
+        "provider_type": "openai",
+        "api_key": MINIMAX_API_KEY_ENV_VAR_NAME,
+    },
 ]
 
 
@@ -326,6 +336,7 @@ DEFAULT_VISION_INFERENCE_PARAMS = {"temperature": 0.85, "top_p": 0.95}
 DEFAULT_EMBEDDING_INFERENCE_PARAMS = {"encoding_format": "float"}
 NEMOTRON_3_NANO_30B_A3B_INFERENCE_PARAMS = {"temperature": 1.0, "top_p": 1.0}
 GPT5_INFERENCE_PARAMS = {"extra_body": {"reasoning_effort": "medium"}}
+MINIMAX_INFERENCE_PARAMS = {"temperature": 1.0}
 
 PREDEFINED_PROVIDERS_MODEL_MAP = {
     NVIDIA_PROVIDER_NAME: {
@@ -356,6 +367,16 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
         "embedding": {
             "model": "openai/text-embedding-3-large",
             "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS,
+        },
+    },
+    MINIMAX_PROVIDER_NAME: {
+        "text": {
+            "model": "MiniMax-M2.7",
+            "inference_parameters": MINIMAX_INFERENCE_PARAMS,
+        },
+        "reasoning": {
+            "model": "MiniMax-M2.7-highspeed",
+            "inference_parameters": MINIMAX_INFERENCE_PARAMS,
         },
     },
 }

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -19,6 +19,7 @@ from data_designer.config.default_model_settings import (
     resolve_seed_default_model_settings,
 )
 from data_designer.config.models import ChatCompletionInferenceParams, EmbeddingInferenceParams, ModelProvider
+from data_designer.config.utils.constants import MINIMAX_API_KEY_ENV_VAR_NAME
 from data_designer.config.utils.visualization import get_nvidia_api_key, get_openai_api_key
 
 
@@ -54,7 +55,7 @@ def test_get_default_inference_parameters():
 
 def test_get_builtin_model_configs():
     builtin_model_configs = get_builtin_model_configs()
-    assert len(builtin_model_configs) == 12
+    assert len(builtin_model_configs) == 14
     assert builtin_model_configs[0].alias == "nvidia-text"
     assert builtin_model_configs[0].model == "nvidia/nemotron-3-nano-30b-a3b"
     assert builtin_model_configs[0].provider == "nvidia"
@@ -91,11 +92,17 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[11].alias == "openrouter-embedding"
     assert builtin_model_configs[11].model == "openai/text-embedding-3-large"
     assert builtin_model_configs[11].provider == "openrouter"
+    assert builtin_model_configs[12].alias == "minimax-text"
+    assert builtin_model_configs[12].model == "MiniMax-M2.7"
+    assert builtin_model_configs[12].provider == "minimax"
+    assert builtin_model_configs[13].alias == "minimax-reasoning"
+    assert builtin_model_configs[13].model == "MiniMax-M2.7-highspeed"
+    assert builtin_model_configs[13].provider == "minimax"
 
 
 def test_get_builtin_model_providers():
     builtin_model_providers = get_builtin_model_providers()
-    assert len(builtin_model_providers) == 3
+    assert len(builtin_model_providers) == 4
     assert builtin_model_providers[0].name == "nvidia"
     assert builtin_model_providers[0].endpoint == "https://integrate.api.nvidia.com/v1"
     assert builtin_model_providers[0].provider_type == "openai"
@@ -108,6 +115,10 @@ def test_get_builtin_model_providers():
     assert builtin_model_providers[2].endpoint == "https://openrouter.ai/api/v1"
     assert builtin_model_providers[2].provider_type == "openai"
     assert builtin_model_providers[2].api_key == "OPENROUTER_API_KEY"
+    assert builtin_model_providers[3].name == "minimax"
+    assert builtin_model_providers[3].endpoint == "https://api.minimax.io/v1"
+    assert builtin_model_providers[3].provider_type == "openai"
+    assert builtin_model_providers[3].api_key == MINIMAX_API_KEY_ENV_VAR_NAME
 
 
 def test_get_default_model_configs_path_exists(tmp_path: Path):


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a predefined model provider in DataDesigner, allowing users to generate synthetic data using MiniMax's chat models via the OpenAI-compatible API.

### Changes

- Add `MiniMax` as a predefined provider with endpoint `https://api.minimax.io/v1`
- Add `MINIMAX_API_KEY` environment variable support
- Register `MiniMax-M2.7` as the default text model
- Register `MiniMax-M2.7-highspeed` as the reasoning model
- Add unit tests for the new provider and model configurations

### Usage

After setting `MINIMAX_API_KEY`, users can generate datasets using MiniMax:

```python
import data_designer as dd

config = dd.DataDesignerConfig(
    model_configs=[dd.ModelConfig(alias="text", model="MiniMax-M2.7", provider="minimax")],
)
```

Or using the built-in alias:

```python
import data_designer as dd

dd.DataDesigner(provider="minimax")
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api