### PR TITLE
fix: persist side-effect columns to row buffer in async engine

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -87,6 +87,7 @@ class AsyncTaskScheduler:
         tracker: CompletionTracker,
         row_groups: list[tuple[int, int]],
         buffer_manager: RowGroupBufferManager | None = None,
+        side_effect_map: dict[str, str] | None = None,
         *,
         max_concurrent_row_groups: int = 3,
         max_submitted_tasks: int = DEFAULT_TASK_POOL_SIZE,
@@ -136,6 +137,14 @@ class AsyncTaskScheduler:
         for col, gen in generators.items():
             instance_to_columns.setdefault(id(gen), []).append(col)
         self._instance_to_columns = instance_to_columns
+
+        # Extend with side-effect columns for buffer write-back only.
+        # _instance_to_columns stays unchanged for completion tracking / dispatch dedup.
+        write_cols: dict[int, list[str]] = {k: list(v) for k, v in instance_to_columns.items()}
+        for se_col, primary_col in (side_effect_map or {}).items():
+            gen = generators[primary_col]
+            write_cols.setdefault(id(gen), []).append(se_col)
+        self._instance_to_write_columns = write_cols
 
         # Stateful generator tracking: instance_id → asyncio.Lock
         self._stateful_locks: dict[int, asyncio.Lock] = {}
@@ -767,7 +776,7 @@ class AsyncTaskScheduler:
 
         # Write results to buffer
         if self._buffer_manager is not None:
-            output_cols = self._instance_to_columns.get(id(generator), [task.column])
+            output_cols = self._instance_to_write_columns.get(id(generator), [task.column])
             for col in output_cols:
                 if col in result_df.columns:
                     values = result_df[col].tolist()
@@ -793,16 +802,9 @@ class AsyncTaskScheduler:
 
         # Write back to buffer
         if self._buffer_manager is not None and not self._tracker.is_dropped(task.row_group, task.row_index):
-            output_cols = self._instance_to_columns.get(id(generator), [task.column])
-            written: set[str] = set()
+            output_cols = self._instance_to_write_columns.get(id(generator), [task.column])
             for col in output_cols:
                 if col in result:
-                    self._buffer_manager.update_cell(task.row_group, task.row_index, col, result[col])
-                    written.add(col)
-            # Also persist side-effect columns (e.g. __trace, __reasoning_content)
-            # produced by the generator but not tracked in _instance_to_columns.
-            for col in result.keys() - written:
-                if col not in row_data:
                     self._buffer_manager.update_cell(task.row_group, task.row_index, col, result[col])
 
         return result
@@ -824,27 +826,20 @@ class AsyncTaskScheduler:
 
         # Merge result columns back to buffer
         if self._buffer_manager is not None:
-            output_cols = self._instance_to_columns.get(id(generator), [task.column])
+            output_cols = self._instance_to_write_columns.get(id(generator), [task.column])
             active_rows = rg_size - len(pre_dropped)
             if len(result_df) != active_rows:
                 raise ValueError(
                     f"Batch generator for '{task.column}' returned {len(result_df)} rows "
                     f"but {active_rows} were expected (rg={task.row_group})."
                 )
-            # Include side-effect columns (e.g. __trace, __reasoning_content)
-            # that the generator produced but aren't tracked in _instance_to_columns.
-            all_write_cols = list(output_cols)
-            existing_cols = set(batch_df.columns) if batch_df is not None else set()
-            for col in result_df.columns:
-                if col not in all_write_cols and col not in existing_cols:
-                    all_write_cols.append(col)
             result_idx = 0
             for ri in range(rg_size):
                 if ri in pre_dropped:
                     continue
                 # Skip writing to rows dropped by concurrent tasks during the await
                 if not self._buffer_manager.is_dropped(task.row_group, ri):
-                    for col in all_write_cols:
+                    for col in output_cols:
                         if col in result_df.columns:
                             self._buffer_manager.update_cell(task.row_group, ri, col, result_df.iloc[result_idx][col])
                 result_idx += 1

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -794,8 +794,15 @@ class AsyncTaskScheduler:
         # Write back to buffer
         if self._buffer_manager is not None and not self._tracker.is_dropped(task.row_group, task.row_index):
             output_cols = self._instance_to_columns.get(id(generator), [task.column])
+            written: set[str] = set()
             for col in output_cols:
                 if col in result:
+                    self._buffer_manager.update_cell(task.row_group, task.row_index, col, result[col])
+                    written.add(col)
+            # Also persist side-effect columns (e.g. __trace, __reasoning_content)
+            # produced by the generator but not tracked in _instance_to_columns.
+            for col in result.keys() - written:
+                if col not in row_data:
                     self._buffer_manager.update_cell(task.row_group, task.row_index, col, result[col])
 
         return result
@@ -824,13 +831,20 @@ class AsyncTaskScheduler:
                     f"Batch generator for '{task.column}' returned {len(result_df)} rows "
                     f"but {active_rows} were expected (rg={task.row_group})."
                 )
+            # Include side-effect columns (e.g. __trace, __reasoning_content)
+            # that the generator produced but aren't tracked in _instance_to_columns.
+            all_write_cols = list(output_cols)
+            existing_cols = set(batch_df.columns) if batch_df is not None else set()
+            for col in result_df.columns:
+                if col not in all_write_cols and col not in existing_cols:
+                    all_write_cols.append(col)
             result_idx = 0
             for ri in range(rg_size):
                 if ri in pre_dropped:
                     continue
                 # Skip writing to rows dropped by concurrent tasks during the await
                 if not self._buffer_manager.is_dropped(task.row_group, ri):
-                    for col in output_cols:
+                    for col in all_write_cols:
                         if col in result_df.columns:
                             self._buffer_manager.update_cell(task.row_group, ri, col, result_df.iloc[result_idx][col])
                 result_idx += 1

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
@@ -325,14 +325,19 @@ class DatasetBuilder:
         """
         strategies: dict[str, GenerationStrategy] = {}
         gen_map: dict[str, ColumnGenerator] = {}
+        side_effect_map: dict[str, str] = {}
         for gen in generators:
             if isinstance(gen.config, MultiColumnConfig):
                 for sub in gen.config.columns:
                     strategies[sub.name] = gen.get_generation_strategy()
                     gen_map[sub.name] = gen
+                    for se_col in sub.side_effect_columns:
+                        side_effect_map[se_col] = sub.name
             else:
                 strategies[gen.config.name] = gen.get_generation_strategy()
                 gen_map[gen.config.name] = gen
+                for se_col in gen.config.side_effect_columns:
+                    side_effect_map[se_col] = gen.config.name
 
         graph = ExecutionGraph.create(self._column_configs, strategies)
 
@@ -379,6 +384,7 @@ class DatasetBuilder:
             tracker=tracker,
             row_groups=row_groups,
             buffer_manager=buffer_manager,
+            side_effect_map=side_effect_map,
             max_submitted_tasks=DEFAULT_TASK_POOL_SIZE,
             max_llm_wait_tasks=max(DEFAULT_TASK_POOL_SIZE, LLM_WAIT_POOL_MULTIPLIER * aggregate),
             on_finalize_row_group=on_finalize_row_group,

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -1583,7 +1583,9 @@ async def test_scheduler_side_effect_columns_written_to_buffer() -> None:
 
     configs = [
         SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
-        LLMTextColumnConfig(name="answer", prompt="{{ seed }}", model_alias=MODEL_ALIAS),
+        LLMTextColumnConfig(
+            name="answer", prompt="{{ seed }}", model_alias=MODEL_ALIAS, extract_reasoning_content=True
+        ),
         LLMTextColumnConfig(name="judge", prompt=f"{{{{ {side_effect_col} }}}}", model_alias=MODEL_ALIAS),
     ]
     strategies = {
@@ -1614,6 +1616,7 @@ async def test_scheduler_side_effect_columns_written_to_buffer() -> None:
         tracker=tracker,
         row_groups=row_groups,
         buffer_manager=buffer_manager,
+        side_effect_map={side_effect_col: "answer"},
     )
     await scheduler.run()
 

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -1551,3 +1551,74 @@ async def test_scheduler_downstream_interleaves_with_upstream() -> None:
         f"First judge dispatched at {first_judge_dispatched:.4f}, "
         f"last gen dispatched at {last_gen_dispatched:.4f}."
     )
+
+
+class MockCellGeneratorWithSideEffect(ColumnGenerator[ExpressionColumnConfig]):
+    """Cell generator that produces a side-effect column alongside its primary output."""
+
+    def __init__(self, *args: Any, side_effect_col: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._side_effect_col = side_effect_col
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def generate(self, data: dict) -> dict:
+        data[self.config.name] = f"primary_{data.get('seed', '?')}"
+        data[self._side_effect_col] = f"side_effect_{data.get('seed', '?')}"
+        return data
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_scheduler_side_effect_columns_written_to_buffer() -> None:
+    """Side-effect columns (e.g. __reasoning_content) are persisted to the buffer.
+
+    Reproduces the bug where a generator produces extra columns (like trace or
+    reasoning_content) that aren't tracked in _instance_to_columns. Downstream
+    columns that reference these side-effect values must find them in the buffer.
+    """
+    provider = _mock_provider()
+    side_effect_col = "answer__reasoning_content"
+
+    configs = [
+        SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
+        LLMTextColumnConfig(name="answer", prompt="{{ seed }}", model_alias=MODEL_ALIAS),
+        LLMTextColumnConfig(name="judge", prompt=f"{{{{ {side_effect_col} }}}}", model_alias=MODEL_ALIAS),
+    ]
+    strategies = {
+        "seed": GenerationStrategy.FULL_COLUMN,
+        "answer": GenerationStrategy.CELL_BY_CELL,
+        "judge": GenerationStrategy.CELL_BY_CELL,
+    }
+
+    answer_gen = MockCellGeneratorWithSideEffect(
+        config=_expr_config("answer"),
+        resource_provider=provider,
+        side_effect_col=side_effect_col,
+    )
+    generators: dict[str, ColumnGenerator] = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "answer": answer_gen,
+        "judge": MockCellGenerator(config=_expr_config("judge"), resource_provider=provider),
+    }
+
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, 3)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    buffer_manager = RowGroupBufferManager(MagicMock())
+
+    scheduler = AsyncTaskScheduler(
+        generators=generators,
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        buffer_manager=buffer_manager,
+    )
+    await scheduler.run()
+
+    assert tracker.is_row_group_complete(0, 3, ["seed", "answer", "judge"])
+    for ri in range(3):
+        row = buffer_manager.get_row(0, ri)
+        assert side_effect_col in row, f"Side-effect column missing from row {ri}"
+        assert row[side_effect_col].startswith("side_effect_")


### PR DESCRIPTION
## 📋 Summary

The async engine's `_run_cell`, `_run_batch`, and `_run_from_scratch` only wrote columns tracked in `_instance_to_columns` back to the `RowGroupBufferManager`, silently dropping side-effect columns produced by generators (e.g. `__trace`, `__reasoning_content`). Downstream columns referencing these values would fail with missing column errors.

This fix introduces an explicit `_instance_to_write_columns` map that extends `_instance_to_columns` with side-effect columns declared by each config. The original `_instance_to_columns` remains unchanged for completion tracking and dispatch dedup, while `_instance_to_write_columns` is used at all three buffer write-back sites.

## 🔗 Related Issue

Fixes #523

## 🔄 Changes

### 🔧 Changed

- [`dataset_builder.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix/523-async-side-effect-columns-not-persisted/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py): In `_prepare_async_run`, collect a `side_effect_map` (side-effect column → primary column) from each generator's config and pass it to `AsyncTaskScheduler`
- [`async_scheduler.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix/523-async-side-effect-columns-not-persisted/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py): Accept `side_effect_map` in `__init__`, build `_instance_to_write_columns` by extending `_instance_to_columns` with side-effect entries. Use `_instance_to_write_columns` at the three buffer write sites (`_run_from_scratch`, `_run_cell`, `_run_batch`)

### 🧪 Tests

- [`test_async_scheduler.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix/523-async-side-effect-columns-not-persisted/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py): Added `MockCellGeneratorWithSideEffect` and `test_scheduler_side_effect_columns_written_to_buffer` — verifies side-effect columns are persisted to the buffer and available to downstream generators. Config uses `extract_reasoning_content=True` so the `ExecutionGraph` properly registers the side-effect alias.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`async_scheduler.py` — `_instance_to_write_columns` construction](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix/523-async-side-effect-columns-not-persisted/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py#L141-L147): New map that extends `_instance_to_columns` with side-effect columns. `_instance_to_columns` is intentionally left unchanged for `CompletionTracker` and dispatch dedup.

## 🧪 Testing

- [x] `make test` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated — N/A, covered by unit test on the scheduler

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A, no architectural change

Made with [Cursor](https://cursor.com)