### PR TITLE
feat: add generic and OpenRouter attribution headers

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -298,6 +298,15 @@ OPENROUTER_PROVIDER_NAME = "openrouter"
 
 OPENROUTER_API_KEY_ENV_VAR_NAME = "OPENROUTER_API_KEY"
 
+ATTRIBUTION_TITLE = "NeMo Data Designer"
+ATTRIBUTION_REFERER = "https://github.com/NVIDIA-NeMo/DataDesigner"
+
+OPENROUTER_ATTRIBUTION_HEADERS: dict[str, str] = {
+    "HTTP-Referer": ATTRIBUTION_REFERER,
+    "X-OpenRouter-Title": ATTRIBUTION_TITLE,
+    "X-OpenRouter-Categories": "programming-app",
+}
+
 PREDEFINED_PROVIDERS = [
     {
         "name": NVIDIA_PROVIDER_NAME,
@@ -316,6 +325,7 @@ PREDEFINED_PROVIDERS = [
         "endpoint": "https://openrouter.ai/api/v1",
         "provider_type": "openai",
         "api_key": OPENROUTER_API_KEY_ENV_VAR_NAME,
+        "extra_headers": OPENROUTER_ATTRIBUTION_HEADERS,
     },
 ]
 

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -307,6 +307,8 @@ OPENROUTER_ATTRIBUTION_HEADERS: dict[str, str] = {
     "X-OpenRouter-Categories": "programming-app",
 }
 
+# OpenRouter attribution is injected in the engine so telemetry opt-out can
+# suppress it cleanly for both default and existing provider configs.
 PREDEFINED_PROVIDERS = [
     {
         "name": NVIDIA_PROVIDER_NAME,
@@ -325,7 +327,6 @@ PREDEFINED_PROVIDERS = [
         "endpoint": "https://openrouter.ai/api/v1",
         "provider_type": "openai",
         "api_key": OPENROUTER_API_KEY_ENV_VAR_NAME,
-        "extra_headers": OPENROUTER_ATTRIBUTION_HEADERS,
     },
 ]
 

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -100,14 +100,21 @@ def test_get_builtin_model_providers():
     assert builtin_model_providers[0].endpoint == "https://integrate.api.nvidia.com/v1"
     assert builtin_model_providers[0].provider_type == "openai"
     assert builtin_model_providers[0].api_key == "NVIDIA_API_KEY"
+    assert builtin_model_providers[0].extra_headers is None
     assert builtin_model_providers[1].name == "openai"
     assert builtin_model_providers[1].endpoint == "https://api.openai.com/v1"
     assert builtin_model_providers[1].provider_type == "openai"
     assert builtin_model_providers[1].api_key == "OPENAI_API_KEY"
+    assert builtin_model_providers[1].extra_headers is None
     assert builtin_model_providers[2].name == "openrouter"
     assert builtin_model_providers[2].endpoint == "https://openrouter.ai/api/v1"
     assert builtin_model_providers[2].provider_type == "openai"
     assert builtin_model_providers[2].api_key == "OPENROUTER_API_KEY"
+    assert builtin_model_providers[2].extra_headers == {
+        "HTTP-Referer": "https://github.com/NVIDIA-NeMo/DataDesigner",
+        "X-OpenRouter-Title": "NeMo Data Designer",
+        "X-OpenRouter-Categories": "programming-app",
+    }
 
 
 def test_get_default_model_configs_path_exists(tmp_path: Path):

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -110,11 +110,7 @@ def test_get_builtin_model_providers():
     assert builtin_model_providers[2].endpoint == "https://openrouter.ai/api/v1"
     assert builtin_model_providers[2].provider_type == "openai"
     assert builtin_model_providers[2].api_key == "OPENROUTER_API_KEY"
-    assert builtin_model_providers[2].extra_headers == {
-        "HTTP-Referer": "https://github.com/NVIDIA-NeMo/DataDesigner",
-        "X-OpenRouter-Title": "NeMo Data Designer",
-        "X-OpenRouter-Categories": "programming-app",
-    }
+    assert builtin_model_providers[2].extra_headers is None
 
 
 def test_get_default_model_configs_path_exists(tmp_path: Path):

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -10,7 +10,11 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from data_designer.config.models import GenerationType, ModelConfig, ModelProvider
-from data_designer.config.utils.constants import ATTRIBUTION_TITLE
+from data_designer.config.utils.constants import (
+    ATTRIBUTION_TITLE,
+    OPENROUTER_ATTRIBUTION_HEADERS,
+    OPENROUTER_PROVIDER_NAME,
+)
 from data_designer.config.utils.image_helpers import is_image_diffusion_model
 from data_designer.engine.mcp.errors import MCPConfigurationError
 from data_designer.engine.model_provider import ModelProviderRegistry
@@ -165,6 +169,14 @@ class ModelFacade:
             headers = kwargs.get("extra_headers") or {}
             if "X-Title" not in headers:
                 kwargs["extra_headers"] = {"X-Title": ATTRIBUTION_TITLE, **headers}
+            # Inject OpenRouter-specific attribution headers when the provider is
+            # OpenRouter.  This ensures attribution works even when existing users
+            # have ``extra_headers: null`` in their provider config.  Provider- or
+            # user-supplied values take precedence (only missing keys are filled).
+            if self.model_provider.name == OPENROUTER_PROVIDER_NAME:
+                headers = kwargs.get("extra_headers") or {}
+                merged = {**OPENROUTER_ATTRIBUTION_HEADERS, **headers}
+                kwargs["extra_headers"] = merged
         return kwargs
 
     # --- completion / acompletion ---

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from data_designer.config.models import GenerationType, ModelConfig, ModelProvider
+from data_designer.config.utils.constants import ATTRIBUTION_TITLE
 from data_designer.config.utils.image_helpers import is_image_diffusion_model
 from data_designer.engine.mcp.errors import MCPConfigurationError
 from data_designer.engine.model_provider import ModelProviderRegistry
@@ -30,6 +31,7 @@ from data_designer.engine.models.errors import (
     get_exception_primary_cause,
 )
 from data_designer.engine.models.parsers.errors import ParserException
+from data_designer.engine.models.telemetry import TELEMETRY_ENABLED
 from data_designer.engine.models.usage import ImageUsageStats, ModelUsageStats, RequestUsageStats, TokenUsageStats
 from data_designer.engine.models.utils import ChatMessage, prompt_to_messages
 
@@ -157,6 +159,12 @@ class ModelFacade:
             kwargs["extra_body"] = {**kwargs.get("extra_body", {}), **self.model_provider.extra_body}
         if self.model_provider.extra_headers:
             kwargs["extra_headers"] = {**kwargs.get("extra_headers", {}), **self.model_provider.extra_headers}
+        # Inject framework-level attribution header when telemetry is enabled.
+        # Applied last so that user-supplied or provider-level headers take precedence.
+        if TELEMETRY_ENABLED:
+            headers = kwargs.get("extra_headers", {})
+            if "X-Title" not in headers:
+                kwargs["extra_headers"] = {"X-Title": ATTRIBUTION_TITLE, **headers}
         return kwargs
 
     # --- completion / acompletion ---

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -158,11 +158,11 @@ class ModelFacade:
         if self.model_provider.extra_body:
             kwargs["extra_body"] = {**kwargs.get("extra_body", {}), **self.model_provider.extra_body}
         if self.model_provider.extra_headers:
-            kwargs["extra_headers"] = {**kwargs.get("extra_headers", {}), **self.model_provider.extra_headers}
+            kwargs["extra_headers"] = {**(kwargs.get("extra_headers") or {}), **self.model_provider.extra_headers}
         # Inject framework-level attribution header when telemetry is enabled.
         # Applied last so that user-supplied or provider-level headers take precedence.
         if TELEMETRY_ENABLED:
-            headers = kwargs.get("extra_headers", {})
+            headers = kwargs.get("extra_headers") or {}
             if "X-Title" not in headers:
                 kwargs["extra_headers"] = {"X-Title": ATTRIBUTION_TITLE, **headers}
         return kwargs

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -271,6 +271,81 @@ def test_consolidate_kwargs_with_explicit_none_extra_headers(
     assert result["extra_headers"] == {"X-Title": "NeMo Data Designer", "hello": "world"}
 
 
+def test_consolidate_kwargs_openrouter_attribution(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """OpenRouter-specific attribution headers are injected when provider is openrouter."""
+    stub_model_facade.model_provider.name = "openrouter"
+    stub_model_facade.model_provider.extra_headers = None  # simulates existing user config
+    result = stub_model_facade.consolidate_kwargs()
+    assert result["extra_headers"] == {
+        "X-Title": "NeMo Data Designer",
+        "HTTP-Referer": "https://github.com/NVIDIA-NeMo/DataDesigner",
+        "X-OpenRouter-Title": "NeMo Data Designer",
+        "X-OpenRouter-Categories": "programming-app",
+    }
+
+
+def test_consolidate_kwargs_openrouter_user_override_preserved(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """User-supplied OpenRouter headers take precedence over framework defaults."""
+    stub_model_facade.model_provider.name = "openrouter"
+    stub_model_facade.model_provider.extra_headers = None
+    result = stub_model_facade.consolidate_kwargs(
+        extra_headers={"X-OpenRouter-Title": "Custom App", "X-Custom": "value"}
+    )
+    # User-supplied X-OpenRouter-Title should NOT be overwritten
+    assert result["extra_headers"]["X-OpenRouter-Title"] == "Custom App"
+    assert result["extra_headers"]["X-Custom"] == "value"
+    # Framework defaults still fill in missing keys
+    assert result["extra_headers"]["HTTP-Referer"] == "https://github.com/NVIDIA-NeMo/DataDesigner"
+    assert result["extra_headers"]["X-OpenRouter-Categories"] == "programming-app"
+    assert result["extra_headers"]["X-Title"] == "NeMo Data Designer"
+
+
+def test_consolidate_kwargs_openrouter_provider_headers_preserved(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """Provider-level OpenRouter headers override programmatic injection."""
+    stub_model_facade.model_provider.name = "openrouter"
+    stub_model_facade.model_provider.extra_headers = {
+        "HTTP-Referer": "https://custom-site.example.com",
+        "X-OpenRouter-Title": "Provider Title",
+    }
+    result = stub_model_facade.consolidate_kwargs()
+    # Provider-level values take precedence
+    assert result["extra_headers"]["HTTP-Referer"] == "https://custom-site.example.com"
+    assert result["extra_headers"]["X-OpenRouter-Title"] == "Provider Title"
+    # Framework still fills in what's missing
+    assert result["extra_headers"]["X-OpenRouter-Categories"] == "programming-app"
+    assert result["extra_headers"]["X-Title"] == "NeMo Data Designer"
+
+
+@patch("data_designer.engine.models.facade.TELEMETRY_ENABLED", False)
+def test_consolidate_kwargs_openrouter_no_attribution_when_telemetry_off(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """OpenRouter attribution headers are NOT injected when telemetry is disabled."""
+    stub_model_facade.model_provider.name = "openrouter"
+    stub_model_facade.model_provider.extra_headers = None
+    result = stub_model_facade.consolidate_kwargs()
+    assert "extra_headers" not in result
+
+
+def test_consolidate_kwargs_non_openrouter_no_openrouter_headers(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """Non-openrouter providers do NOT get OpenRouter-specific headers."""
+    stub_model_facade.model_provider.name = "nvidia"
+    stub_model_facade.model_provider.extra_headers = None
+    result = stub_model_facade.consolidate_kwargs()
+    assert result["extra_headers"] == {"X-Title": "NeMo Data Designer"}
+    assert "HTTP-Referer" not in result["extra_headers"]
+    assert "X-OpenRouter-Title" not in result["extra_headers"]
+    assert "X-OpenRouter-Categories" not in result["extra_headers"]
+
+
 @pytest.mark.parametrize(
     "skip_usage_tracking",
     [

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -252,10 +252,23 @@ def test_consolidate_kwargs_telemetry_disabled(stub_model_configs: list[Any], st
 def test_consolidate_kwargs_user_x_title_override(
     stub_model_configs: list[Any], stub_model_facade: ModelFacade
 ) -> None:
-    """User-supplied X-Title via provider extra_headers takes precedence over framework default."""
+    """User-supplied X-Title takes precedence over the framework default."""
     stub_model_facade.model_provider.extra_headers = {"X-Title": "My Custom App"}
     result = stub_model_facade.consolidate_kwargs()
     assert result["extra_headers"]["X-Title"] == "My Custom App"
+
+    stub_model_facade.model_provider.extra_headers = None
+    result = stub_model_facade.consolidate_kwargs(extra_headers={"X-Title": "Caller App"})
+    assert result["extra_headers"]["X-Title"] == "Caller App"
+
+
+def test_consolidate_kwargs_with_explicit_none_extra_headers(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """Explicit None extra_headers does not break provider merges or framework attribution."""
+    stub_model_facade.model_provider.extra_headers = {"hello": "world"}
+    result = stub_model_facade.consolidate_kwargs(extra_headers=None)
+    assert result["extra_headers"] == {"X-Title": "NeMo Data Designer", "hello": "world"}
 
 
 @pytest.mark.parametrize(

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -276,7 +276,7 @@ def test_consolidate_kwargs_openrouter_attribution(
 ) -> None:
     """OpenRouter-specific attribution headers are injected when provider is openrouter."""
     stub_model_facade.model_provider.name = "openrouter"
-    stub_model_facade.model_provider.extra_headers = None  # simulates existing user config
+    stub_model_facade.model_provider.extra_headers = None
     result = stub_model_facade.consolidate_kwargs()
     assert result["extra_headers"] == {
         "X-Title": "NeMo Data Designer",

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -202,13 +202,21 @@ def test_usage_stats_property(stub_model_facade: ModelFacade) -> None:
 
 
 def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: ModelFacade) -> None:
-    # Model config generate kwargs are used as base, and purpose is removed
+    # Model config generate kwargs are used as base, and purpose is removed.
+    # When telemetry is enabled (default), X-Title is injected.
     result = stub_model_facade.consolidate_kwargs(purpose="test")
-    assert result == stub_model_configs[0].inference_parameters.generate_kwargs
+    assert result == {
+        **stub_model_configs[0].inference_parameters.generate_kwargs,
+        "extra_headers": {"X-Title": "NeMo Data Designer"},
+    }
 
     # kwargs overrides model config generate kwargs
     result = stub_model_facade.consolidate_kwargs(temperature=0.01, purpose="test")
-    assert result == {**stub_model_configs[0].inference_parameters.generate_kwargs, "temperature": 0.01}
+    assert result == {
+        **stub_model_configs[0].inference_parameters.generate_kwargs,
+        "temperature": 0.01,
+        "extra_headers": {"X-Title": "NeMo Data Designer"},
+    }
 
     # Provider extra_body overrides all other kwargs
     stub_model_facade.model_provider.extra_body = {"foo_provider": "bar_provider"}
@@ -216,6 +224,7 @@ def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: Mo
     assert result == {
         **stub_model_configs[0].inference_parameters.generate_kwargs,
         "extra_body": {"foo_provider": "bar_provider", "foo": "bar"},
+        "extra_headers": {"X-Title": "NeMo Data Designer"},
     }
 
     # Provider extra_headers merges with caller headers (provider takes precedence)
@@ -224,8 +233,29 @@ def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: Mo
     result = stub_model_facade.consolidate_kwargs(extra_headers={"hello": "caller", "X-Trace-ID": "abc"})
     assert result == {
         **stub_model_configs[0].inference_parameters.generate_kwargs,
-        "extra_headers": {"hello": "world", "hola": "mundo", "X-Trace-ID": "abc"},
+        "extra_headers": {"X-Title": "NeMo Data Designer", "hello": "world", "hola": "mundo", "X-Trace-ID": "abc"},
     }
+
+
+@patch("data_designer.engine.models.facade.TELEMETRY_ENABLED", False)
+def test_consolidate_kwargs_telemetry_disabled(stub_model_configs: list[Any], stub_model_facade: ModelFacade) -> None:
+    """Framework attribution headers are omitted when telemetry is disabled."""
+    result = stub_model_facade.consolidate_kwargs()
+    assert "extra_headers" not in result
+
+    # Provider extra_headers still applied even with telemetry off
+    stub_model_facade.model_provider.extra_headers = {"Custom": "header"}
+    result = stub_model_facade.consolidate_kwargs()
+    assert result["extra_headers"] == {"Custom": "header"}
+
+
+def test_consolidate_kwargs_user_x_title_override(
+    stub_model_configs: list[Any], stub_model_facade: ModelFacade
+) -> None:
+    """User-supplied X-Title via provider extra_headers takes precedence over framework default."""
+    stub_model_facade.model_provider.extra_headers = {"X-Title": "My Custom App"}
+    result = stub_model_facade.consolidate_kwargs()
+    assert result["extra_headers"]["X-Title"] == "My Custom App"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 📋 Summary

Add outbound attribution headers to all model requests (`X-Title: NeMo Data Designer`) and OpenRouter-specific headers on the built-in OpenRouter provider, gated on the existing `NEMO_TELEMETRY_ENABLED` opt-out.

## 🔗 Related Issue

Closes #519

## 🔄 Changes

- Add `ATTRIBUTION_TITLE`, `ATTRIBUTION_REFERER`, and `OPENROUTER_ATTRIBUTION_HEADERS` constants
- Wire `extra_headers` into the predefined OpenRouter provider entry in `PREDEFINED_PROVIDERS`
- Inject `X-Title` in `ModelFacade.consolidate_kwargs()` when telemetry is enabled, applied last so user-supplied or provider-level values take precedence
- No framework headers injected when `NEMO_TELEMETRY_ENABLED=false`; user `extra_headers` still honored

## 🧪 Testing

- [x] `make test` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Added:
- `test_consolidate_kwargs_telemetry_disabled` — no framework headers when opted out
- `test_consolidate_kwargs_user_x_title_override` — user `X-Title` takes precedence

Updated:
- `test_consolidate_kwargs` — verify `X-Title` injection under default telemetry-on
- `test_get_builtin_model_providers` — verify OpenRouter `extra_headers` and confirm NVIDIA/OpenAI have none

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)