### PR TITLE
ci: add daily audit suites with 5 rotating recipes and scheduled workflow

### DIFF
--- a/.agents/recipes/_runner.md
+++ b/.agents/recipes/_runner.md
@@ -34,5 +34,6 @@ Write all output to a temp file (e.g., `/tmp/recipe-output.md`). The workflow
 will handle posting it. Do not post directly to GitHub - the workflow controls
 output routing.
 
-If your recipe produces code changes, make them on the current branch. The
-workflow will open a PR from the diff.
+If your recipe produces code changes, commit them on a new branch and use
+`/create-pr` to open a pull request. The branch name should follow the
+pattern `agentic-ci/chore/{suite}-YYYYMMDD`.

--- a/.agents/recipes/_runner.md
+++ b/.agents/recipes/_runner.md
@@ -9,6 +9,48 @@ DataDesigner is an NVIDIA NeMo framework for creating synthetic datasets.
 See AGENTS.md at the repo root for an overview and links to detailed docs
 (architecture, style guide, development workflow).
 
+## Environment
+
+The workflow runs `make install-dev` and adds `.venv/bin` to PATH before
+your recipe executes. All three DataDesigner packages are installed in
+development mode. You can use `python` directly to run code - it resolves
+to the project venv.
+
+## Runner memory
+
+Each recipe has access to `{{memory_path}}/runner-state.json`. The workflow
+loads it from cache before your run and saves it after. Use this schema:
+
+```json
+{
+  "suite": "test-health",
+  "last_run": "2026-04-14T08:00:00Z",
+  "known_issues": [
+    {
+      "id": "short-hash-of-finding",
+      "category": "hollow-test",
+      "summary": "test_foo only asserts not None",
+      "first_seen": "2026-04-07",
+      "last_seen": "2026-04-14"
+    }
+  ],
+  "baselines": {
+    "test_to_source_ratio": "45/52",
+    "type_coverage_pct": 78,
+    "import_time_s": 1.8
+  }
+}
+```
+
+Rules:
+- **`known_issues`**: skip re-reporting issues already here. Update
+  `last_seen` if the issue is still present. Remove entries whose
+  `last_seen` is more than 4 weeks old - the issue was likely fixed.
+- **`baselines`**: store current metric values. Compare against these on
+  the next run to detect trends (improving or regressing).
+- **Keep it small.** The whole file should stay under 50KB. If
+  `known_issues` grows past 100 entries, prune the oldest resolved ones.
+
 ## Constraints
 
 - **No interactive prompts.** If something is ambiguous, make a reasonable choice

--- a/.agents/recipes/code-quality/recipe.md
+++ b/.agents/recipes/code-quality/recipe.md
@@ -106,7 +106,63 @@ Known gap: `packages/data-designer-config/src/data_designer/custom_column.py`
 and `packages/data-designer-config/src/data_designer/analysis/` have been
 flagged before.
 
-### 4. TODO/FIXME/HACK aging
+### 4. Executable quality checks
+
+Run a few checks that exercise real code paths to catch regressions that
+static analysis misses. The workflow puts `.venv/bin` on PATH via
+`make install-dev`, so `python` resolves to the project venv.
+
+#### 4a. Error type hierarchy (fixed - run as written)
+
+Verify that the project's error types are importable and properly
+structured. Silent breakage here means third-party exceptions leak to users:
+
+```bash
+python -c "
+from data_designer.errors import DataDesignerError
+assert issubclass(DataDesignerError, Exception), 'DataDesignerError must be an Exception'
+print('OK: error hierarchy intact')
+" 2>&1 || echo "WARN: error hierarchy check failed"
+```
+
+#### 4b. Input validation checks (creative - vary each run)
+
+Verify the config builder rejects bad inputs rather than silently
+producing corrupt configs. **Design your own invalid inputs each run**
+to maximize coverage over time.
+
+Examples of things to test (pick 2-3 per run, and invent new ones):
+- Invalid `column_type` string (should raise)
+- `column_type='sampler'` without `sampler_type` (should raise)
+- Empty builder `.build()` (should handle gracefully)
+- Duplicate column names (should raise or deduplicate clearly)
+- Invalid sampler params (e.g., `gaussian` with negative `std`, `category`
+  with empty `values` list)
+- Column names with special characters or very long strings
+- Recently changed validators (check `git log --oneline -10 -- packages/*/src/data_designer/config/`)
+
+**API reference:**
+
+```python
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+
+# Test that invalid input is rejected (not silently accepted)
+try:
+    DataDesignerConfigBuilder().add_column(
+        name='x', column_type='nonexistent_type'
+    ).build()
+    print('FAIL: invalid column type was silently accepted')
+except Exception as e:
+    print(f'OK: invalid column type rejected ({type(e).__name__})')
+```
+
+The pattern: try something that should fail, print FAIL if it succeeds
+silently, print OK if it raises. A FAIL means a validation regression
+that could lead to silent data corruption.
+
+Report what you tested and why. Any FAIL is a critical finding.
+
+### 5. TODO/FIXME/HACK aging
 
 Inventory markers with their git blame age:
 
@@ -155,6 +211,14 @@ Write the report to `/tmp/audit-{{suite}}.md`:
 
 **Coverage:** ~X% of public functions fully annotated (previous: Y%)
 
+### Executable quality checks
+
+| Check | Type | Status | Detail |
+|-------|------|--------|--------|
+| Error hierarchy | fixed | OK/FAIL | DataDesignerError is properly structured |
+| (describe input tested) | creative | OK/FAIL | (what was tested and why) |
+| ... | creative | ... | ... |
+
 ### TODO/FIXME/HACK inventory
 
 | File | Line | Marker | Age (days) | Commit |
@@ -168,6 +232,7 @@ Write the report to `/tmp/audit-{{suite}}.md`:
 - N complexity hotspots (M trending up)
 - N exception hygiene issues (M new)
 - Type coverage: X% (delta: +/-N% from last run)
+- Executable checks: N/2 passed (any FAIL is critical)
 - N aging TODO/FIXME markers (M new)
 ```
 

--- a/.agents/recipes/code-quality/recipe.md
+++ b/.agents/recipes/code-quality/recipe.md
@@ -1,0 +1,186 @@
+---
+name: code-quality
+description: Audit code quality gaps not covered by ruff - complexity trends, exception hygiene, type coverage, TODO aging
+trigger: schedule
+tool: claude-code
+timeout_minutes: 20
+max_turns: 30
+permissions:
+  contents: write
+---
+
+# Code Quality Audit
+
+Catch quality drift that CI doesn't cover. Write findings to
+`/tmp/audit-{{suite}}.md`.
+
+**What CI already enforces** (do NOT duplicate):
+- Ruff rules: W, F, I, ICN, PIE, TID, UP006, UP007, UP045
+- Ruff format with 120-char line length, double quotes
+- Test coverage >= 90% aggregate
+
+**What CI does NOT enforce** (this recipe's focus):
+- C901 cyclomatic complexity (not in ruff select)
+- ANN type annotation completeness (not in ruff select)
+- BLE001 bare except handling (not in ruff select)
+- Google-style docstring format (D* rules not enabled)
+- Complexity growth trends over time
+- TODO/FIXME aging
+
+## Runner memory
+
+Read `{{memory_path}}/runner-state.json` for baselines from previous runs
+(complexity scores, type coverage, TODO inventory). After the audit, update
+`baselines` with current values and `known_issues` with new findings. Skip
+re-reporting known issues. Flag metrics that are trending in the wrong
+direction compared to the previous baseline.
+
+## Instructions
+
+### 1. Complexity hotspots
+
+Try ruff C901 first (may not be in the config but can be invoked directly):
+```bash
+ruff check packages/*/src/ --select C901 --output-format json 2>/dev/null || true
+```
+
+If ruff is not available or C901 produces no output, manually inspect the
+largest source files for functions with:
+- Deep nesting (3+ levels of if/for/try)
+- Many branches (>5 if/elif chains)
+- Long method bodies (>60 lines)
+
+**Track trends**: compare against the previous run's baseline in runner
+memory. A function at complexity 12 that was 8 last week is more concerning
+than one that has been at 15 for months. Report the delta.
+
+Focus on `packages/data-designer-engine/src/` (core execution) and
+`packages/data-designer/src/data_designer/interface/` (public API) where
+complexity tends to accumulate.
+
+### 2. Exception hygiene
+
+Check for patterns that violate the project's "errors normalize at
+boundaries" principle (AGENTS.md):
+
+```bash
+# Bare except clauses (should use specific exception types)
+grep -rn "except:" packages/*/src/ --include='*.py' | grep -v "# noqa"
+
+# Swallowed exceptions (except + pass/continue with no logging)
+grep -rn -A1 "except" packages/*/src/ --include='*.py' | grep -B1 "pass$\|continue$"
+```
+
+The key principle: internal code should NOT leak raw third-party exceptions.
+Module boundary functions (public API, entry points) should wrap external
+exceptions in `data_designer` error types. Check:
+- Functions in `packages/data-designer/src/` that catch third-party exceptions
+  (httpx, pydantic, etc.) - are they re-raised as `data_designer` errors?
+- Plugin loading code (`data_designer/plugins/`) - bare `except:` has been
+  found here before
+
+### 3. Type annotation coverage
+
+The repo requires typed code (AGENTS.md: "all functions, methods, and class
+attributes require type annotations") but has no ANN ruff rules enforcing
+this. Check for gaps:
+
+```bash
+# Public functions missing return type annotations
+grep -rn "def " packages/*/src/ --include='*.py' \
+  | grep -v "-> " \
+  | grep -v "def _" \
+  | grep -v "__init__\|__repr__\|__str__\|__eq__\|__hash__" \
+  | grep -v "test_"
+```
+
+Also check for `Any` usage that could be more specific:
+```bash
+grep -rn ": Any\| -> Any" packages/*/src/ --include='*.py'
+```
+
+**Track coverage percentage**: count public functions with full annotations
+vs total public functions. Compare against previous baseline.
+
+Known gap: `packages/data-designer-config/src/data_designer/custom_column.py`
+and `packages/data-designer-config/src/data_designer/analysis/` have been
+flagged before.
+
+### 4. TODO/FIXME/HACK aging
+
+Inventory markers with their git blame age:
+
+```bash
+grep -rn "TODO\|FIXME\|HACK" packages/*/src/ --include='*.py'
+```
+
+For each marker, get the commit date:
+```bash
+# Example: get blame date for a specific line
+git blame -L 42,42 --date=short path/to/file.py
+```
+
+**Only flag items older than 30 days.** Recent TODOs are part of normal
+development flow. For old items, include:
+- File and line number
+- The marker text
+- Age in days
+- The commit that introduced it (short SHA)
+
+## Output format
+
+Write the report to `/tmp/audit-{{suite}}.md`:
+
+```markdown
+<!-- agentic-ci-daily-{{suite}} -->
+## Code Quality Audit - {{date}}
+
+### Complexity hotspots
+
+| File | Function | Complexity | Trend |
+|------|----------|-----------|-------|
+| ... | ... | C901: 18 | +3 since last run |
+
+### Exception hygiene
+
+| File | Line | Pattern | Recommendation |
+|------|------|---------|----------------|
+| plugins/plugin.py | 99 | bare except | Catch ImportError/ModuleNotFoundError |
+
+### Type annotation coverage
+
+| File | Function | Issue |
+|------|----------|-------|
+| custom_column.py | generate | Missing return type |
+
+**Coverage:** ~X% of public functions fully annotated (previous: Y%)
+
+### TODO/FIXME/HACK inventory
+
+| File | Line | Marker | Age (days) | Commit |
+|------|------|--------|-----------|--------|
+| ... | ... | TODO: fix this | 45 | abc1234 |
+
+**Aging items:** N markers older than 30 days (M new since last run)
+
+### Summary
+
+- N complexity hotspots (M trending up)
+- N exception hygiene issues (M new)
+- Type coverage: X% (delta: +/-N% from last run)
+- N aging TODO/FIXME markers (M new)
+```
+
+If no findings in any category, write `NO_FINDINGS` on the first line instead.
+
+## Constraints
+
+- Do not modify any files. This is a read-only audit.
+- Do not flag test files for type coverage or exception hygiene. Tests have
+  different standards.
+- Do not duplicate ruff checks (W, F, I, ICN, PIE, TID, UP*). Those are
+  already enforced in CI.
+- For complexity, focus on growth trends rather than absolute values.
+- For TODOs, only flag items older than 30 days.
+- For type annotations, focus on public API surface. Internal helpers with
+  obvious types from context are lower priority.

--- a/.agents/recipes/dependencies/recipe.md
+++ b/.agents/recipes/dependencies/recipe.md
@@ -1,0 +1,165 @@
+---
+name: dependencies
+description: Audit dependency health - version pinning, transitive gaps, CVEs, unused deps, cross-package consistency
+trigger: schedule
+tool: claude-code
+timeout_minutes: 20
+max_turns: 30
+permissions:
+  contents: write
+---
+
+# Dependency Audit
+
+Audit the dependency graph across all three packages. Write findings to
+`/tmp/audit-{{suite}}.md`.
+
+Dependabot handles version bump PRs. This recipe focuses on what Dependabot
+can't do: cross-package consistency, transitive dependency gaps, unused deps,
+and pinning strategy review that requires understanding the library's
+stability history.
+
+## Runner memory
+
+Read `{{memory_path}}/runner-state.json` for known issues and previously seen
+dependency versions. After the audit, update `known_issues` and
+`baselines.dependency_versions` with the current state. Skip reporting issues
+that already appear in `known_issues`.
+
+## Instructions
+
+### 1. Inventory current dependencies
+
+Read the `pyproject.toml` for each package:
+```bash
+cat packages/data-designer-config/pyproject.toml
+cat packages/data-designer-engine/pyproject.toml
+cat packages/data-designer/pyproject.toml
+```
+
+Note: engine and interface packages use `uv-dynamic-versioning` to inject
+dependencies. Check both static declarations and the dynamic versioning
+config.
+
+### 2. Transitive dependency gaps
+
+This is the highest-value check. A package may import a library that it
+doesn't declare as a dependency, relying on another package to pull it in
+transitively. This works until the packages are installed separately.
+
+For each package, verify that every imported third-party library is declared
+in that package's own `[project.dependencies]`:
+
+```bash
+# Find all third-party imports in engine source
+grep -rhn "^import \|^from " packages/data-designer-engine/src/ --include='*.py' \
+  | grep -v "data_designer" | grep -v "^from __future__" \
+  | sort -u
+
+# Compare against declared deps in engine's pyproject.toml
+```
+
+Known issue to check: `numpy` and `pandas` are used by the engine but may
+only be declared in the config package. Each package should declare what it
+directly imports.
+
+Also check lazy imports in `data_designer/lazy_heavy_imports.py` - these
+are intentionally deferred but still need to be declared as dependencies.
+
+### 3. Cross-package version consistency
+
+Check that shared dependencies use consistent version constraints:
+```bash
+# Extract dependency specs from all three pyproject.toml files
+grep -E "^\s+\"[a-zA-Z]" packages/*/pyproject.toml
+```
+
+Flag cases where the same package has conflicting version ranges across
+packages (e.g., `pandas>=2.0` in config but `pandas>=1.5` in engine).
+
+Also check the CVE minimum version constraints already established in the
+repo (look for `[tool.uv.constraint-dependencies]` sections) and verify
+they haven't been bypassed by a looser pin elsewhere.
+
+### 4. Unused dependency detection
+
+For each declared dependency, check if it is actually imported anywhere in
+the corresponding package:
+```bash
+# Example: check if 'lxml' is imported in data-designer-engine
+grep -r "import lxml\|from lxml" packages/data-designer-engine/src/
+```
+
+A dependency is "unused" if:
+- Not imported directly anywhere in the package source
+- Not used via the lazy import system (`lazy_heavy_imports`)
+- Not a plugin entry point or runtime-only requirement
+- Not a build/test-only dependency incorrectly in `[project.dependencies]`
+
+### 5. Version pinning review
+
+For each dependency, assess the pinning strategy. The repo currently uses
+a mix of bounded ranges (`>=X,<Y`) and loose pins (`>=X`).
+
+Flag only high-risk cases:
+- **Unbounded pins on libraries with breaking-change history**: litellm,
+  pydantic, and similar libraries that have broken APIs between minor
+  versions should use strict or compatible-release pins
+- **Overly strict pins that block security updates**: if a dependency has
+  a CVE fix in a newer minor version but the pin prevents upgrading
+
+Do NOT recommend blanket strict-pinning. This repo intentionally uses
+bounded ranges for stable libraries. Only flag pins that are genuinely
+risky given the specific library's track record.
+
+## Output format
+
+Write the report to `/tmp/audit-{{suite}}.md`:
+
+```markdown
+<!-- agentic-ci-daily-{{suite}} -->
+## Dependency Audit - {{date}}
+
+### Transitive dependency gaps
+
+| Package | Import | Declared in | Should be declared in |
+|---------|--------|-------------|----------------------|
+| engine | numpy | config only | engine (direct import in ...) |
+
+### Cross-package inconsistencies
+
+| Dependency | config pin | engine pin | interface pin | Issue |
+|-----------|-----------|-----------|--------------|-------|
+| ... | >=2.0,<3 | >=1.5 | (not declared) | Conflicting ranges |
+
+### Unused dependencies
+
+| Package | Dependency | Evidence |
+|---------|-----------|----------|
+| ... | ... | No imports found in src/ |
+
+### Version pinning concerns
+
+| Package | Dependency | Current pin | Concern |
+|---------|-----------|-------------|---------|
+| ... | litellm | >=1.0 | History of breaking changes; add upper bound |
+
+### Summary
+
+- N transitive gaps (M new since last run)
+- N cross-package inconsistencies
+- N unused dependencies (M new)
+- N pinning concerns
+```
+
+If no findings in any category, write `NO_FINDINGS` on the first line instead.
+
+## Constraints
+
+- Do not modify any files. This is a read-only audit.
+- Do not install packages or run `pip install`. Only inspect `pyproject.toml`
+  and source files.
+- Do not run `pip audit` (may not be available on the runner). Focus on
+  structural dependency analysis, not CVE scanning (Dependabot handles that).
+- Do not recommend changes to dependencies you haven't verified are actually
+  problematic. False positives erode trust in the audit.

--- a/.agents/recipes/docs-and-references/recipe.md
+++ b/.agents/recipes/docs-and-references/recipe.md
@@ -1,0 +1,160 @@
+---
+name: docs-and-references
+description: Audit documentation freshness - docstrings vs signatures, broken links, architecture refs, docs site content accuracy
+trigger: schedule
+tool: claude-code
+timeout_minutes: 20
+max_turns: 30
+permissions:
+  contents: write
+---
+
+# Documentation and References Audit
+
+Check that documentation stays in sync with code. Write findings to
+`/tmp/audit-{{suite}}.md`.
+
+This repo has no ruff D* docstring rules enabled, so docstring quality is
+not enforced by CI. This recipe fills that gap with cross-referencing that
+a linter can't do: checking docstrings against actual signatures, docs
+against actual code, and links against actual targets.
+
+## Runner memory
+
+Read `{{memory_path}}/runner-state.json` for known issues from previous runs.
+After completing the audit, update the file with any new findings (add to
+`known_issues` array with a short hash of the finding). Skip reporting issues
+that already appear in `known_issues`.
+
+## Instructions
+
+### 1. Docstring vs signature drift
+
+This repo uses Google-style docstrings (`Args:`, `Returns:`, `Raises:`).
+Scan public functions and methods in `packages/` for mismatches between the
+docstring and the actual function signature:
+
+- Parameters in the `Args:` section that no longer exist in the signature
+- Parameters in the signature that are missing from `Args:`
+- `Returns:` section that contradicts the return type annotation
+- `Raises:` section listing exceptions the function can no longer raise
+
+Focus on public API surface: `__init__`, public methods (no leading
+underscore), and module-level functions in `packages/*/src/`. Skip test
+files, private methods, and `__dunder__` methods other than `__init__`.
+
+**Prioritize by impact**: start with `packages/data-designer/src/` (public
+interface), then `packages/data-designer-engine/src/`, then config. The
+interface package is what users see first.
+
+### 2. Broken internal links
+
+Check links in these locations:
+- `README.md` - all relative links and URLs
+- `architecture/*.md` - cross-references to other architecture docs and code
+- `docs/` - MkDocs content links, code references, cross-page links
+- `CONTRIBUTING.md`, `DEVELOPMENT.md`, `STYLEGUIDE.md` - relative links
+
+For each link, verify the target file or anchor exists. Report broken links
+with the source file, line number, and broken target.
+
+### 3. Architecture doc references
+
+The 10 files in `architecture/` reference specific classes, functions, files,
+and registries by name. These are high-value docs that agents and developers
+rely on for orientation. For each code reference:
+- Verify the referenced class, function, or module still exists at the stated
+  location
+- If renamed or moved, flag with the old and new location
+
+```bash
+ls architecture/
+# Key files: overview.md, config.md, engine.md, dataset-builders.md,
+# models.md, sampling.md, cli.md, plugins.md, mcp.md, agent-introspection.md
+```
+
+### 4. Docs site content accuracy
+
+The MkDocs site under `docs/` is the primary user-facing documentation.
+Review for accuracy against the current code:
+
+**Concepts pages** (`docs/concepts/`):
+- Do code examples use correct imports, class names, and method signatures?
+  Check against actual source - e.g., verify `DataDesigner.create()`,
+  `DataDesigner.preview()`, builder patterns match the real API.
+- Are there documented config options or column types that have been removed
+  or renamed?
+- Are new features or column types missing from the docs?
+
+**Recipes** (`docs/recipes/`):
+- Do step-by-step instructions reference correct file paths, class names,
+  and CLI commands? Run `grep` for class names mentioned in recipe docs and
+  verify they resolve in the source.
+
+**Dev notes** (`docs/devnotes/posts/`):
+- Dev notes describe implementation details that may have changed. Spot-check
+  the most recent 3-5 posts for references to functions, classes, or
+  architecture that have since been modified.
+
+**Code reference** (`docs/code_reference/`):
+- Check that autodoc module paths point to modules that still exist.
+
+**Prioritize by risk of drift**: pages with the most code symbols referenced
+are most likely to be stale. Don't read every page - sample 5-10 high-value
+pages and flag patterns.
+
+## Output format
+
+Write the report to `/tmp/audit-{{suite}}.md`:
+
+```markdown
+<!-- agentic-ci-daily-{{suite}} -->
+## Documentation Audit - {{date}}
+
+**Workflow run:** see GitHub Actions
+
+### Docstring vs signature drift
+
+| File | Function | Issue |
+|------|----------|-------|
+| ... | ... | Param `x` removed from signature but still in Args |
+
+### Broken links
+
+| Source file | Line | Target | Status |
+|-------------|------|--------|--------|
+| ... | ... | ... | 404 / anchor missing |
+
+### Stale architecture references
+
+| Doc | Reference | Issue |
+|-----|-----------|-------|
+| ... | `FooClass` | Renamed to `BarClass` in engine/... |
+
+### Docs site accuracy
+
+| Page | Issue | Severity |
+|------|-------|----------|
+| ... | `DataDesigner.foo()` removed in v0.3 | high - user-facing |
+
+### Summary
+
+- N docstring mismatches (M new since last run)
+- N broken links (M new)
+- N stale architecture refs (M new)
+- N docs accuracy issues (M new)
+```
+
+If no findings in any category, write `NO_FINDINGS` on the first line instead.
+
+## Constraints
+
+- Do not modify any files. This is a read-only audit.
+- Do not read file contents unless needed to verify a specific reference.
+  Use `grep` and `head` for targeted checks rather than reading entire files.
+- Skip vendored or generated files.
+- License headers are already enforced by the `license-headers` CI job.
+  Do not check for SPDX headers.
+- Ruff lint and format are already enforced by CI. Do not duplicate those
+  checks. Focus on cross-references that require understanding both the docs
+  and the code.

--- a/.agents/recipes/structure/recipe.md
+++ b/.agents/recipes/structure/recipe.md
@@ -93,7 +93,7 @@ Exclude:
 - Files that are themselves optional/heavy modules
 
 This directly affects startup time, which has a 3-second budget tested by
-`tests/test_import_perf.py`.
+`packages/data-designer/tests/test_import_perf.py`.
 
 ### 3. Future annotations compliance
 

--- a/.agents/recipes/structure/recipe.md
+++ b/.agents/recipes/structure/recipe.md
@@ -1,0 +1,185 @@
+---
+name: structure
+description: Audit structural integrity - import boundaries, lazy import compliance, future annotations, dead exports
+trigger: schedule
+tool: claude-code
+timeout_minutes: 20
+max_turns: 30
+permissions:
+  contents: write
+---
+
+# Structural Integrity Audit
+
+Verify the multi-package layering that DataDesigner depends on. Write findings
+to `/tmp/audit-{{suite}}.md`.
+
+## Background
+
+Before starting, read the authoritative sources for the structural rules:
+
+1. **`AGENTS.md`** (repo root) - "The Layering Is Structural" section defines
+   the three packages, their ownership, and the dependency direction rule.
+2. **`architecture/overview.md`** - system architecture diagram, package layout,
+   and the "no reverse imports" rule.
+
+The canonical rules:
+
+```
+data-designer (interface) -> data-designer-engine -> data-designer-config
+```
+
+- `packages/data-designer-config/` must NOT import from `data_designer.engine`,
+  `data_designer.interface`, or `data_designer.cli`
+- `packages/data-designer-engine/` must NOT import from
+  `data_designer.interface` or `data_designer.cli`
+- `packages/data-designer/` CAN import from both engine and config
+
+**What CI already enforces**: ruff rule `TID` catches relative imports. The
+CI test matrix runs config, engine, and interface tests in isolation (separate
+jobs with only the package's own deps installed), which catches most boundary
+violations at test time.
+
+**What CI does NOT catch**: violations that only manifest with all packages
+installed (e.g., an engine file importing from interface, which works when
+interface is installed but fails in the isolated engine test only if that
+code path is exercised). This recipe does static analysis to catch these
+regardless of test coverage.
+
+## Runner memory
+
+Read `{{memory_path}}/runner-state.json` for known issues from previous runs.
+Update after the audit. Skip re-reporting known issues.
+
+## Instructions
+
+### 1. Import boundary violations
+
+Scan each package's source for imports that violate the dependency direction:
+
+```bash
+# Config must not import from engine or interface
+grep -rn "from data_designer\.engine\|import data_designer\.engine\|from data_designer\.interface\|import data_designer\.interface\|from data_designer\.cli\|import data_designer\.cli" \
+  packages/data-designer-config/src/
+
+# Engine must not import from interface
+grep -rn "from data_designer\.interface\|import data_designer\.interface\|from data_designer\.cli\|import data_designer\.cli" \
+  packages/data-designer-engine/src/
+```
+
+**Important**: exclude `TYPE_CHECKING` blocks. Imports guarded by
+`if TYPE_CHECKING:` are allowed since they don't execute at runtime. Read
+the surrounding context of each match to check.
+
+As of the last audit, import boundaries were clean. If this section has no
+findings, that's expected - it's a guardrail, not a bug finder.
+
+### 2. Lazy import compliance
+
+The repo uses `data_designer.lazy_heavy_imports` for heavy third-party
+libraries (AGENTS.md: "heavy third-party libraries are lazy-loaded").
+Check for direct top-level imports that bypass the lazy system:
+
+```bash
+# Known heavy libraries that should use lazy imports
+grep -rn "^import pandas\|^from pandas\|^import numpy\|^from numpy\|^import polars\|^from polars\|^import torch\|^from torch\|^import duckdb\|^from duckdb\|^import sqlfluff\|^from sqlfluff\|^import faker\|^from faker" \
+  packages/*/src/ --include='*.py'
+```
+
+Exclude:
+- The lazy import system itself (`lazy_heavy_imports.py`)
+- `TYPE_CHECKING` blocks
+- Test files
+- Files that are themselves optional/heavy modules
+
+This directly affects startup time, which has a 3-second budget tested by
+`tests/test_import_perf.py`.
+
+### 3. Future annotations compliance
+
+AGENTS.md requires `from __future__ import annotations` in every Python
+source file:
+
+```bash
+find packages/*/src/ -name '*.py' -not -name '__init__.py' | while read f; do
+  if ! grep -q "from __future__ import annotations" "$f"; then
+    echo "$f"
+  fi
+done
+```
+
+This enables modern type syntax (`list[str]` instead of `List[str]`,
+`str | None` instead of `Optional[str]`) and defers annotation evaluation.
+
+### 4. Dead exports
+
+Find symbols in `__all__` that nothing outside their module references:
+
+```bash
+grep -rn "__all__" packages/*/src/ --include='*.py'
+```
+
+For each symbol in `__all__`:
+- Search the codebase for imports of that symbol
+- If only referenced within its own file, flag as potentially dead
+
+**Be conservative**: symbols in `__all__` of top-level `__init__.py` files
+are part of the public API and may be used by external consumers (plugins,
+user code). Only flag symbols that are clearly internal and unused.
+
+## Output format
+
+Write the report to `/tmp/audit-{{suite}}.md`:
+
+```markdown
+<!-- agentic-ci-daily-{{suite}} -->
+## Structural Integrity Audit - {{date}}
+
+**Rules checked against:** AGENTS.md, architecture/overview.md
+
+### Import boundary violations
+
+| Package | File | Line | Import | Rule violated |
+|---------|------|------|--------|---------------|
+| ... | ... | ... | ... | config -> engine (forbidden per AGENTS.md) |
+
+### Lazy import violations
+
+| File | Line | Import | Should use |
+|------|------|--------|-----------|
+| ... | ... | import pandas | lazy_heavy_imports |
+
+### Missing future annotations
+
+| File |
+|------|
+| ... |
+
+### Dead exports
+
+| Package | Module | Symbol | Evidence |
+|---------|--------|--------|----------|
+| ... | ... | ... | No external imports found |
+
+### Summary
+
+- N import boundary violations (M new since last run)
+- N lazy import violations (M new)
+- N files missing future annotations (M new)
+- N potentially dead exports (M new)
+```
+
+If no findings in any category, write `NO_FINDINGS` on the first line instead.
+
+## Constraints
+
+- Do not modify any files. This is a read-only audit.
+- Imports inside `if TYPE_CHECKING:` blocks are allowed and should not be
+  flagged for any check.
+- Lazy imports in `__init__.py` (via `__getattr__`) are deferred and should
+  not be treated as violations.
+- Dead export detection has false positives. Mark uncertain cases as
+  "potentially dead" rather than definitively dead.
+- Always cite which rule or doc is violated so maintainers can verify.
+- Import boundaries are currently clean. No findings in that section is
+  normal and expected.

--- a/.agents/recipes/test-health/recipe.md
+++ b/.agents/recipes/test-health/recipe.md
@@ -111,7 +111,132 @@ These should use `data_designer.lazy_heavy_imports`. Cross-reference with
 the structure recipe's findings if available in runner memory, but don't
 skip this check - it directly affects user experience.
 
-### 4. Test isolation verification
+### 4. Executable smoke checks
+
+Run lightweight checks that exercise real code paths. These catch silent
+data corruption, column registration gaps, and config wiring issues that
+static analysis misses. None of these require an LLM provider.
+
+**Important**: the workflow puts `.venv/bin` on PATH via `make install-dev`,
+so `python` resolves to the project venv with all packages installed.
+
+There are two kinds of smoke checks: **fixed canaries** that must run
+identically every time (deterministic regressions), and **creative checks**
+where you should vary the inputs each run to maximize coverage over time.
+
+#### Fixed canaries (run these exactly as written)
+
+**4a. Package import verification**
+
+```bash
+python -c "
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.engine.compiler import compile_data_designer_config
+from data_designer.interface.data_designer import DataDesigner
+print('OK: all packages import')
+"
+```
+
+If any import fails, this is a critical finding - it means the package
+layering is broken.
+
+**4b. Import performance timing**
+
+```bash
+python -c "
+import time
+start = time.monotonic()
+from data_designer.interface.data_designer import DataDesigner
+elapsed = time.monotonic() - start
+budget = 3.0
+status = 'OK' if elapsed < budget else 'FAIL'
+print(f'{status}: import took {elapsed:.2f}s (budget: {budget:.0f}s)')
+"
+```
+
+**4c. Column type registry completeness**
+
+```bash
+python -c "
+from data_designer.config.column_types import (
+    DataDesignerColumnType,
+    get_column_config_cls_from_type,
+)
+
+missing = []
+for ct in DataDesignerColumnType:
+    try:
+        cls = get_column_config_cls_from_type(ct)
+        if cls is None:
+            missing.append(ct.value)
+    except Exception as e:
+        missing.append(f'{ct.value} ({e})')
+
+if missing:
+    for m in missing:
+        print(f'FAIL: {m}')
+else:
+    print(f'OK: all {len(list(DataDesignerColumnType))} column types resolve to config classes')
+" 2>&1 || echo "WARN: registry check could not run"
+```
+
+#### Creative checks (vary these each run)
+
+For each run, **design your own** config build and validation checks. The
+goal is to exercise different code paths over time rather than testing the
+same config every day.
+
+**What to vary:**
+- **Sampler types**: pick a different mix each run. Available sampler types:
+  `uuid`, `category`, `subcategory`, `uniform`, `gaussian`, `bernoulli`,
+  `bernoulli_mixture`, `binomial`, `poisson`, `scipy`, `person_from_faker`,
+  `datetime`, `timedelta`. Try 2-5 columns per config.
+- **Column count**: sometimes build a single-column config, sometimes 8+
+- **Edge cases**: empty params where defaults should apply, extreme param
+  values (e.g., `gaussian` with `std=0`), columns with constraints
+- **Recently changed code**: check `git log --oneline -20 -- packages/` for
+  recently modified column types or sampler params, and prioritize testing
+  those
+
+**What to always check:**
+1. Config build round-trip: column count and names survive `.build()`
+2. Validation: `DataDesigner.validate(builder)` succeeds for valid configs
+3. Rejection: invalid inputs raise, not silently produce bad configs
+
+**API reference** for writing checks:
+
+```python
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.interface.data_designer import DataDesigner
+import tempfile
+
+# Build a config - use keyword args: name, column_type, sampler_type, params
+builder = (
+    DataDesignerConfigBuilder()
+    .add_column(name='id', column_type='sampler', sampler_type='uuid')
+    .add_column(name='cat', column_type='sampler', sampler_type='category',
+                params={'values': ['A', 'B', 'C']})
+)
+config = builder.build()
+
+# Verify columns survived the build
+assert len(config.columns) >= 2
+names = {c.name for c in config.columns}
+assert 'id' in names and 'cat' in names
+
+# Validate through the full stack (no LLM needed for sampler-only)
+dd = DataDesigner(artifact_path=tempfile.mkdtemp(), model_providers=[])
+dd.validate(builder)
+```
+
+Run at least 2 creative checks per audit. Document what you chose and why
+in the report (e.g., "tested poisson+datetime combo because poisson params
+were modified in commit abc1234").
+
+**Report smoke check results in a separate table.** If any check fails,
+that is a higher-priority finding than static analysis results.
+
+### 5. Test isolation verification
 
 The CI runs three separate test jobs: config-only, engine+config, and
 full stack. Check that test files respect these boundaries:
@@ -158,6 +283,24 @@ Write the report to `/tmp/audit-{{suite}}.md`:
 | test_import_perf.py exists | yes/no |
 | Heavy top-level imports | N found |
 
+### Executable smoke checks
+
+**Fixed canaries:**
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| Package imports | OK/FAIL | All three packages import cleanly |
+| Import timing | OK/FAIL | Xms (budget: 3s) |
+| Registry completeness | OK/WARN | Column types resolve to config classes |
+
+**Creative checks** (describe what you tested and why):
+
+| Check | Sampler types used | Status | Detail |
+|-------|--------------------|--------|--------|
+| Config build #1 | e.g. uuid+poisson+datetime | OK/FAIL | ... |
+| Validate #1 | ... | OK/FAIL | ... |
+| ... | ... | ... | ... |
+
 ### Test isolation
 
 | Test file | Violation |
@@ -169,6 +312,7 @@ Write the report to `/tmp/audit-{{suite}}.md`:
 - N source files without tests (M new since last run)
 - N hollow tests detected (high confidence only)
 - Import perf: N heavy top-level imports
+- Smoke checks: N passed, M failed (list any FAILs - these are critical)
 - N test isolation violations
 ```
 

--- a/.agents/recipes/test-health/recipe.md
+++ b/.agents/recipes/test-health/recipe.md
@@ -41,7 +41,7 @@ Map source files to their corresponding test files:
 find packages/*/src/ -name '*.py' -not -name '__init__.py' -not -path '*/test*' | sort
 
 # Test files
-find tests/ packages/*/tests/ -name 'test_*.py' 2>/dev/null | sort
+find packages/*/tests/ -name 'test_*.py' 2>/dev/null | sort
 ```
 
 For each source module, check if a corresponding test file exists. Flag:
@@ -61,10 +61,10 @@ Scan test files for tests that assert nothing meaningful:
 ```bash
 # Tests that only check "is not None" (often meaningless if the function
 # can't return None)
-grep -rn "assert .* is not None$" tests/ --include='*.py'
+grep -rn "assert .* is not None$" packages/*/tests/ --include='*.py'
 
 # Test functions with no assert statements at all
-grep -l "def test_" tests/ --include='*.py' -r | while read f; do
+grep -l "def test_" packages/*/tests/ --include='*.py' -r | while read f; do
   # Count test functions vs assert statements
   TESTS=$(grep -c "def test_" "$f")
   ASSERTS=$(grep -c "assert " "$f")
@@ -92,12 +92,12 @@ Skip `tests_e2e/` - e2e tests have different assertion patterns.
 
 ### 3. Import performance
 
-The repo has a 3-second import budget tested by `tests/test_import_perf.py`.
-Check the current state:
+The repo has a 3-second import budget tested by
+`packages/data-designer/tests/test_import_perf.py`. Check the current state:
 
 ```bash
 # Verify the test exists and read its thresholds
-cat tests/test_import_perf.py 2>/dev/null || echo "not found"
+cat packages/data-designer/tests/test_import_perf.py 2>/dev/null || echo "not found"
 ```
 
 Also check for heavy imports that bypass the lazy loading system:
@@ -200,15 +200,18 @@ same config every day.
 
 **What to always check:**
 1. Config build round-trip: column count and names survive `.build()`
-2. Validation: `DataDesigner.validate(builder)` succeeds for valid configs
-3. Rejection: invalid inputs raise, not silently produce bad configs
+2. Rejection: invalid inputs raise, not silently produce bad configs
+
+**Limitation**: `DataDesigner(model_providers=[])` raises
+`NoModelProvidersError`, so you cannot call `DataDesigner.validate()`
+without at least one provider configured. Stick to config-layer checks
+(`DataDesignerConfigBuilder.build()`, column type resolution) which do
+not require providers.
 
 **API reference** for writing checks:
 
 ```python
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.interface.data_designer import DataDesigner
-import tempfile
 
 # Build a config - use keyword args: name, column_type, sampler_type, params
 builder = (
@@ -223,10 +226,6 @@ config = builder.build()
 assert len(config.columns) >= 2
 names = {c.name for c in config.columns}
 assert 'id' in names and 'cat' in names
-
-# Validate through the full stack (no LLM needed for sampler-only)
-dd = DataDesigner(artifact_path=tempfile.mkdtemp(), model_providers=[])
-dd.validate(builder)
 ```
 
 Run at least 2 creative checks per audit. Document what you chose and why
@@ -290,15 +289,15 @@ Write the report to `/tmp/audit-{{suite}}.md`:
 | Check | Status | Detail |
 |-------|--------|--------|
 | Package imports | OK/FAIL | All three packages import cleanly |
-| Import timing | OK/FAIL | Xms (budget: 3s) |
+| Import timing | OK/FAIL | X.XXs (budget: 3s) |
 | Registry completeness | OK/WARN | Column types resolve to config classes |
 
 **Creative checks** (describe what you tested and why):
 
-| Check | Sampler types used | Status | Detail |
-|-------|--------------------|--------|--------|
+| Check | What was tested | Status | Detail |
+|-------|-----------------|--------|--------|
 | Config build #1 | e.g. uuid+poisson+datetime | OK/FAIL | ... |
-| Validate #1 | ... | OK/FAIL | ... |
+| Rejection #1 | e.g. gaussian with negative std | OK/FAIL | ... |
 | ... | ... | ... | ... |
 
 ### Test isolation

--- a/.agents/recipes/test-health/recipe.md
+++ b/.agents/recipes/test-health/recipe.md
@@ -107,9 +107,9 @@ grep -rn "^import pandas\|^from pandas\|^import numpy\|^from numpy\|^import duck
   packages/*/src/ --include='*.py'
 ```
 
-These should use `data_designer.lazy_heavy_imports`. Cross-reference with
-the structure recipe's findings if available in runner memory, but don't
-skip this check - it directly affects user experience.
+These should use `data_designer.lazy_heavy_imports`. Report the count of
+violations found, then refer to Wednesday's structure audit for the full
+breakdown. Do not duplicate the detailed analysis here.
 
 ### 4. Executable smoke checks
 

--- a/.agents/recipes/test-health/recipe.md
+++ b/.agents/recipes/test-health/recipe.md
@@ -1,0 +1,186 @@
+---
+name: test-health
+description: Audit test suite health - coverage gaps, hollow tests, import perf, test-to-source mapping
+trigger: schedule
+tool: claude-code
+timeout_minutes: 20
+max_turns: 30
+permissions:
+  contents: write
+---
+
+# Test Health Audit
+
+Ensure the test suite stays meaningful, not just green. Write findings to
+`/tmp/audit-{{suite}}.md`.
+
+**What CI already enforces**: pytest with `--cov-fail-under=90` (aggregate),
+multi-version matrix (3.10-3.13), multi-OS (ubuntu, macOS), per-package
+isolation tests (config, engine, interface separately), e2e plugin tests.
+
+**What CI does NOT catch**: per-file coverage regressions (aggregate can
+stay above 90% while individual files lose coverage), hollow tests that
+inflate coverage without testing behavior, import performance regressions
+beyond the existing threshold, and new source files with no corresponding
+tests.
+
+## Runner memory
+
+Read `{{memory_path}}/runner-state.json` for baselines from previous runs
+(test-to-source mapping, import timing, known hollow tests). After the audit,
+update `baselines` with current values and `known_issues` with new findings.
+
+## Instructions
+
+### 1. Test-to-source coverage mapping
+
+Map source files to their corresponding test files:
+
+```bash
+# Source files (excluding __init__.py and test files)
+find packages/*/src/ -name '*.py' -not -name '__init__.py' -not -path '*/test*' | sort
+
+# Test files
+find tests/ packages/*/tests/ -name 'test_*.py' 2>/dev/null | sort
+```
+
+For each source module, check if a corresponding test file exists. Flag:
+- Source files with **no test file at all** (highest priority)
+- New source files added since the last run that lack tests (compare against
+  baseline in runner memory)
+
+**Track the ratio**: N test files / M source files. Compare against baseline.
+
+Focus on `packages/*/src/` only. Skip `scripts/`, `docs/`, and other
+non-package code.
+
+### 2. Hollow test detection
+
+Scan test files for tests that assert nothing meaningful:
+
+```bash
+# Tests that only check "is not None" (often meaningless if the function
+# can't return None)
+grep -rn "assert .* is not None$" tests/ --include='*.py'
+
+# Test functions with no assert statements at all
+grep -l "def test_" tests/ --include='*.py' -r | while read f; do
+  # Count test functions vs assert statements
+  TESTS=$(grep -c "def test_" "$f")
+  ASSERTS=$(grep -c "assert " "$f")
+  if [ "$ASSERTS" -lt "$TESTS" ]; then
+    echo "$f: $TESTS test functions, only $ASSERTS assertions"
+  fi
+done
+```
+
+**Be conservative**: only flag tests you've read and are confident add no
+value. A test that looks simple may catch regressions that aren't obvious.
+Read the test function body before flagging it.
+
+Patterns that ARE hollow:
+- `assert result is not None` where the return type is never Optional
+- Test only verifies a mock was called, without checking the actual behavior
+- Test calls a function and asserts nothing about the result
+
+Patterns that are NOT hollow:
+- `assert result is not None` as a guard before more specific assertions
+- Tests that verify side effects (file creation, API calls, state changes)
+- Tests that check exception behavior via `pytest.raises`
+
+Skip `tests_e2e/` - e2e tests have different assertion patterns.
+
+### 3. Import performance
+
+The repo has a 3-second import budget tested by `tests/test_import_perf.py`.
+Check the current state:
+
+```bash
+# Verify the test exists and read its thresholds
+cat tests/test_import_perf.py 2>/dev/null || echo "not found"
+```
+
+Also check for heavy imports that bypass the lazy loading system:
+```bash
+# Direct imports of known heavy libraries at module level
+grep -rn "^import pandas\|^from pandas\|^import numpy\|^from numpy\|^import duckdb\|^from duckdb\|^import faker\|^from faker" \
+  packages/*/src/ --include='*.py'
+```
+
+These should use `data_designer.lazy_heavy_imports`. Cross-reference with
+the structure recipe's findings if available in runner memory, but don't
+skip this check - it directly affects user experience.
+
+### 4. Test isolation verification
+
+The CI runs three separate test jobs: config-only, engine+config, and
+full stack. Check that test files respect these boundaries:
+
+```bash
+# Tests in packages/data-designer-config/tests/ should not import from engine
+grep -rn "from data_designer\.engine\|import data_designer\.engine" \
+  packages/data-designer-config/tests/ 2>/dev/null
+
+# Tests in packages/data-designer-engine/tests/ should not import from interface
+grep -rn "from data_designer\.interface\|import data_designer\.interface" \
+  packages/data-designer-engine/tests/ 2>/dev/null
+```
+
+These would cause the isolated CI test jobs to fail, but catching them here
+gives a clearer error message than a mysterious import failure.
+
+## Output format
+
+Write the report to `/tmp/audit-{{suite}}.md`:
+
+```markdown
+<!-- agentic-ci-daily-{{suite}} -->
+## Test Health Audit - {{date}}
+
+### Coverage gaps
+
+| Source file | Test file | Status |
+|------------|-----------|--------|
+| engine/foo.py | (none) | No test file |
+
+**Test-to-source ratio:** N test files / M source files (previous: X/Y)
+
+### Hollow tests
+
+| Test file | Test function | Issue | Confidence |
+|-----------|--------------|-------|------------|
+| ... | test_foo | Only asserts not None | high |
+
+### Import performance
+
+| Check | Status |
+|-------|--------|
+| test_import_perf.py exists | yes/no |
+| Heavy top-level imports | N found |
+
+### Test isolation
+
+| Test file | Violation |
+|-----------|-----------|
+| ... | Config test imports from engine |
+
+### Summary
+
+- N source files without tests (M new since last run)
+- N hollow tests detected (high confidence only)
+- Import perf: N heavy top-level imports
+- N test isolation violations
+```
+
+If no findings in any category, write `NO_FINDINGS` on the first line instead.
+
+## Constraints
+
+- Do not modify any test files. This is a read-only audit.
+- Do not run the full test suite or coverage tool. Analysis is based on
+  file structure and static inspection, not execution.
+- Be conservative with hollow test detection. Only flag tests you've read
+  and are confident add no value. Include confidence level in the report.
+- Skip `tests_e2e/` from hollow test analysis.
+- Do not duplicate the structure recipe's lazy import check in detail.
+  Just flag the count and refer to Wednesday's structure audit for specifics.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default code owners for all files in the repository
 * @NVIDIA-NeMo/data_designer_reviewers
+
+# Agentic CI recipes require review from the core team
+.agents/recipes/ @NVIDIA-NeMo/data_designer_reviewers

--- a/.github/workflows/agentic-ci-daily.yml
+++ b/.github/workflows/agentic-ci-daily.yml
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Agentic CI: Daily Audit"
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5"  # weekdays at 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "Override which suite to run (docs-and-references, dependencies, structure, code-quality, test-health, all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: agentic-ci-daily
+  cancel-in-progress: false
+
+jobs:
+  determine-suite:
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.pick.outputs.suites }}
+    steps:
+      - name: Pick suite(s) for today
+        id: pick
+        run: |
+          OVERRIDE="${{ github.event.inputs.suite }}"
+
+          if [ -n "$OVERRIDE" ] && [ "$OVERRIDE" != "all" ]; then
+            echo "suites=[\"${OVERRIDE}\"]" >> "$GITHUB_OUTPUT"
+            echo "Running override suite: ${OVERRIDE}"
+            exit 0
+          fi
+
+          if [ "$OVERRIDE" = "all" ]; then
+            echo 'suites=["docs-and-references","dependencies","structure","code-quality","test-health"]' >> "$GITHUB_OUTPUT"
+            echo "Running all suites"
+            exit 0
+          fi
+
+          # Day-of-week rotation: 1=Mon .. 5=Fri
+          DOW=$(date -u +%u)
+          case "$DOW" in
+            1) SUITE="docs-and-references" ;;
+            2) SUITE="dependencies" ;;
+            3) SUITE="structure" ;;
+            4) SUITE="code-quality" ;;
+            5) SUITE="test-health" ;;
+            *) echo "suites=[]" >> "$GITHUB_OUTPUT"; echo "Weekend - no suite"; exit 0 ;;
+          esac
+
+          echo "suites=[\"${SUITE}\"]" >> "$GITHUB_OUTPUT"
+          echo "Running ${DOW}/weekday suite: ${SUITE}"
+
+  audit:
+    needs: determine-suite
+    if: needs.determine-suite.outputs.suites != '[]'
+    runs-on: [self-hosted, agentic-ci]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.determine-suite.outputs.suites) }}
+
+    concurrency:
+      group: agentic-ci-daily-${{ matrix.suite }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check required config
+        env:
+          AGENTIC_CI_MODEL: ${{ vars.AGENTIC_CI_MODEL }}
+        run: |
+          if [ -z "$AGENTIC_CI_MODEL" ]; then
+            echo "::error::AGENTIC_CI_MODEL variable is not set. Configure it in repo settings."
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Restore runner memory
+        id: cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: .agentic-ci-state
+          key: agentic-ci-state-${{ matrix.suite }}-${{ github.run_id }}
+          restore-keys: |
+            agentic-ci-state-${{ matrix.suite }}-
+
+      - name: Initialize runner memory
+        env:
+          SUITE: ${{ matrix.suite }}
+        run: |
+          mkdir -p .agentic-ci-state
+          if [ ! -f .agentic-ci-state/runner-state.json ]; then
+            cat > .agentic-ci-state/runner-state.json <<EOF
+          {
+            "suite": "${SUITE}",
+            "last_run": null,
+            "known_issues": [],
+            "baselines": {}
+          }
+          EOF
+          fi
+          if [ ! -f .agentic-ci-state/audit-log.md ]; then
+            echo "# Audit Log: ${SUITE}" > .agentic-ci-state/audit-log.md
+            echo "" >> .agentic-ci-state/audit-log.md
+          fi
+          echo "Runner memory state:"
+          cat .agentic-ci-state/runner-state.json
+
+      - name: Pre-flight checks
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.AGENTIC_CI_API_BASE_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.AGENTIC_CI_API_KEY }}
+          AGENTIC_CI_MODEL: ${{ vars.AGENTIC_CI_MODEL }}
+        run: |
+          if ! command -v claude &> /dev/null; then
+            echo "::error::claude CLI not found in PATH"
+            exit 1
+          fi
+          echo "Claude CLI version: $(claude --version 2>&1 || true)"
+
+          if [ -n "$ANTHROPIC_BASE_URL" ] && [ -n "$ANTHROPIC_API_KEY" ]; then
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 \
+              -X POST "${ANTHROPIC_BASE_URL}/v1/messages" \
+              -H "Content-Type: application/json" \
+              -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+              -H "anthropic-version: 2023-06-01" \
+              -d "{\"model\":\"${AGENTIC_CI_MODEL}\",\"max_tokens\":5,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+            if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+              echo "::error::API pre-flight failed with HTTP ${HTTP_CODE}"
+              exit 1
+            fi
+            echo "API pre-flight passed (HTTP ${HTTP_CODE})"
+          fi
+
+      - name: Run audit recipe
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.AGENTIC_CI_API_BASE_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.AGENTIC_CI_API_KEY }}
+          AGENTIC_CI_MODEL: ${{ vars.AGENTIC_CI_MODEL }}
+          DISABLE_PROMPT_CACHING: "1"
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SUITE: ${{ matrix.suite }}
+        run: |
+          set -o pipefail
+
+          RECIPE_DIR=".agents/recipes/${SUITE}"
+          if [ ! -f "${RECIPE_DIR}/recipe.md" ]; then
+            echo "::error::Recipe not found: ${RECIPE_DIR}/recipe.md"
+            exit 1
+          fi
+
+          # Build prompt: _runner.md + recipe body (strip YAML frontmatter)
+          RUNNER_CTX=$(cat .agents/recipes/_runner.md)
+          RECIPE_BODY=$(sed '1,/^---$/{ /^---$/,/^---$/d }' "${RECIPE_DIR}/recipe.md")
+
+          PROMPT=$(printf '%s\n\n%s\n' "${RUNNER_CTX}" "${RECIPE_BODY}" \
+            | sed "s|{{suite}}|${SUITE}|g" \
+            | sed "s|{{date}}|$(date -u +%Y-%m-%d)|g" \
+            | sed "s|{{memory_path}}|.agentic-ci-state|g")
+
+          claude \
+            --model "$AGENTIC_CI_MODEL" \
+            -p "$PROMPT" \
+            --max-turns 30 \
+            --output-format text \
+            --verbose \
+            2>&1 | tee /tmp/claude-audit-log.txt || true
+        continue-on-error: true
+
+      - name: Update runner memory
+        if: always()
+        env:
+          SUITE: ${{ matrix.suite }}
+        run: |
+          # Update last_run timestamp in state
+          if command -v python3 &> /dev/null; then
+            python3 -c "
+          import json, datetime
+          with open('.agentic-ci-state/runner-state.json') as f:
+              state = json.load(f)
+          state['last_run'] = datetime.datetime.utcnow().isoformat() + 'Z'
+          state['suite'] = '${SUITE}'
+          with open('.agentic-ci-state/runner-state.json', 'w') as f:
+              json.dump(state, f, indent=2)
+          "
+          else
+            echo "python3 not available, skipping state update"
+          fi
+
+          # Append to audit log
+          echo "" >> .agentic-ci-state/audit-log.md
+          echo "## $(date -u +%Y-%m-%d)" >> .agentic-ci-state/audit-log.md
+          if [ -s "/tmp/audit-${SUITE}.md" ]; then
+            echo "Findings reported." >> .agentic-ci-state/audit-log.md
+          else
+            echo "No findings." >> .agentic-ci-state/audit-log.md
+          fi
+
+      - name: Write job summary
+        if: always()
+        env:
+          SUITE: ${{ matrix.suite }}
+        run: |
+          echo "## Daily Audit: ${SUITE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -s "/tmp/audit-${SUITE}.md" ]; then
+            cat "/tmp/audit-${SUITE}.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -s "/tmp/claude-audit-log.txt" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "<details><summary>Agent log</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            tail -100 /tmp/claude-audit-log.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/agentic-ci-daily.yml
+++ b/.github/workflows/agentic-ci-daily.yml
@@ -112,12 +112,18 @@ jobs:
           }
           EOF
           fi
-          if [ ! -f .agentic-ci-state/audit-log.md ]; then
-            echo "# Audit Log: ${SUITE}" > .agentic-ci-state/audit-log.md
-            echo "" >> .agentic-ci-state/audit-log.md
-          fi
           echo "Runner memory state:"
           cat .agentic-ci-state/runner-state.json
+
+      - name: Install dev environment
+        run: |
+          make install-dev
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+          .venv/bin/python -c "
+          from data_designer.config._version import __version__ as cv
+          from data_designer.engine._version import __version__ as ev
+          print(f'  config: {cv}  engine: {ev}')
+          " 2>/dev/null || echo "  (version check skipped)"
 
       - name: Pre-flight checks
         env:
@@ -183,33 +189,24 @@ jobs:
         continue-on-error: true
 
       - name: Update runner memory
-        if: always()
+        if: success()
         env:
           SUITE: ${{ matrix.suite }}
         run: |
-          # Update last_run timestamp in state
-          if command -v python3 &> /dev/null; then
-            python3 -c "
-          import json, datetime
-          with open('.agentic-ci-state/runner-state.json') as f:
-              state = json.load(f)
+          # Validate the agent didn't corrupt the state file
+          python3 -c "
+          import json, datetime, sys
+          try:
+              with open('.agentic-ci-state/runner-state.json') as f:
+                  state = json.load(f)
+          except (json.JSONDecodeError, FileNotFoundError) as e:
+              print(f'::warning::runner-state.json is invalid ({e}), resetting')
+              state = {'suite': '${SUITE}', 'known_issues': [], 'baselines': {}}
           state['last_run'] = datetime.datetime.utcnow().isoformat() + 'Z'
           state['suite'] = '${SUITE}'
           with open('.agentic-ci-state/runner-state.json', 'w') as f:
               json.dump(state, f, indent=2)
           "
-          else
-            echo "python3 not available, skipping state update"
-          fi
-
-          # Append to audit log
-          echo "" >> .agentic-ci-state/audit-log.md
-          echo "## $(date -u +%Y-%m-%d)" >> .agentic-ci-state/audit-log.md
-          if [ -s "/tmp/audit-${SUITE}.md" ]; then
-            echo "Findings reported." >> .agentic-ci-state/audit-log.md
-          else
-            echo "No findings." >> .agentic-ci-state/audit-log.md
-          fi
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/agentic-ci-daily.yml
+++ b/.github/workflows/agentic-ci-daily.yml
@@ -103,14 +103,8 @@ jobs:
         run: |
           mkdir -p .agentic-ci-state
           if [ ! -f .agentic-ci-state/runner-state.json ]; then
-            cat > .agentic-ci-state/runner-state.json <<EOF
-          {
-            "suite": "${SUITE}",
-            "last_run": null,
-            "known_issues": [],
-            "baselines": {}
-          }
-          EOF
+            printf '{"suite":"%s","last_run":null,"known_issues":[],"baselines":{}}\n' \
+              "${SUITE}" > .agentic-ci-state/runner-state.json
           fi
           echo "Runner memory state:"
           cat .agentic-ci-state/runner-state.json
@@ -189,21 +183,24 @@ jobs:
             2>&1 | tee /tmp/claude-audit-log.txt
 
       - name: Update runner memory
-        if: steps.audit.outcome == 'success'
+        if: always()
         env:
           SUITE: ${{ matrix.suite }}
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
         run: |
-          # Validate the agent didn't corrupt the state file
+          # Always validate state (cache saves regardless of outcome)
           python3 -c "
-          import json, datetime, sys
+          import json, datetime, os
           try:
               with open('.agentic-ci-state/runner-state.json') as f:
                   state = json.load(f)
           except (json.JSONDecodeError, FileNotFoundError) as e:
               print(f'::warning::runner-state.json is invalid ({e}), resetting')
-              state = {'suite': '${SUITE}', 'known_issues': [], 'baselines': {}}
-          state['last_run'] = datetime.datetime.utcnow().isoformat() + 'Z'
-          state['suite'] = '${SUITE}'
+              state = {'suite': os.environ['SUITE'], 'known_issues': [], 'baselines': {}}
+          # Only stamp last_run if the audit actually succeeded
+          if os.environ.get('AUDIT_OUTCOME') == 'success':
+              state['last_run'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+          state['suite'] = os.environ['SUITE']
           with open('.agentic-ci-state/runner-state.json', 'w') as f:
               json.dump(state, f, indent=2)
           "

--- a/.github/workflows/agentic-ci-daily.yml
+++ b/.github/workflows/agentic-ci-daily.yml
@@ -153,6 +153,7 @@ jobs:
           fi
 
       - name: Run audit recipe
+        id: audit
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.AGENTIC_CI_API_BASE_URL }}
           ANTHROPIC_API_KEY: ${{ secrets.AGENTIC_CI_API_KEY }}
@@ -185,11 +186,10 @@ jobs:
             --max-turns 30 \
             --output-format text \
             --verbose \
-            2>&1 | tee /tmp/claude-audit-log.txt || true
-        continue-on-error: true
+            2>&1 | tee /tmp/claude-audit-log.txt
 
       - name: Update runner memory
-        if: success()
+        if: steps.audit.outcome == 'success'
         env:
           SUITE: ${{ matrix.suite }}
         run: |

--- a/plans/472/agentic-ci-plan.md
+++ b/plans/472/agentic-ci-plan.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-30
+date: 2026-04-14
 status: in-progress
 authors:
   - andreatgretel
@@ -574,12 +574,11 @@ is clear:
 ### Phase 2: Daily Maintenance - first two suites
 
 **Deliverables:**
-- [ ] `docs-and-references/recipe.md` - docstrings, broken links, architecture refs
-- [ ] `dependencies/recipe.md` - version pinning, upgrade safety, CVEs, unused deps
-- [ ] GitHub workflow: `agentic-ci-daily.yml` with day-of-week suite rotation
-- [ ] Runner memory: `actions/cache` integration + state schema + optional audit branch
-- [ ] Recipe runner script (Python or bash) for template substitution,
-      tool selection, memory load/save, and output routing
+- [x] `docs-and-references/recipe.md` - docstrings, broken links, architecture refs
+- [x] `dependencies/recipe.md` - version pinning, upgrade safety, CVEs, unused deps
+- [x] GitHub workflow: `agentic-ci-daily.yml` with day-of-week suite rotation
+- [x] Runner memory: `actions/cache` integration + state schema
+- [x] Template substitution, memory load/save, and output routing (built into workflow)
 
 **Validation:**
 - Run each suite manually via `workflow_dispatch`
@@ -590,9 +589,9 @@ is clear:
 ### Phase 3: Remaining suites
 
 **Deliverables:**
-- [ ] `structure/recipe.md` - import boundaries, circular deps, dead exports
-- [ ] `code-quality/recipe.md` - complexity, exception hygiene, type gaps, TODOs
-- [ ] `test-health/recipe.md` - coverage deltas, hollow tests, fixtures, smoke tests
+- [x] `structure/recipe.md` - import boundaries, circular deps, dead exports
+- [x] `code-quality/recipe.md` - complexity, exception hygiene, type gaps, TODOs
+- [x] `test-health/recipe.md` - coverage deltas, hollow tests, fixtures, smoke tests
 
 **Validation:**
 - Run each suite manually, review output quality
@@ -605,7 +604,7 @@ is clear:
 **Deliverables:**
 - [ ] Recipe testing framework - way to dry-run a recipe locally before merging
 - [ ] Metrics / dashboard for recipe execution (success rate, cost, latency)
-- [ ] `CODEOWNERS` entry for `.agents/recipes/` to require review on recipe changes
+- [x] `CODEOWNERS` entry for `.agents/recipes/` to require review on recipe changes
 - [ ] Memory compaction - prune stale findings, archive old audit logs
 - [ ] Additional recipes based on team needs (notebook regen, etc.)
 


### PR DESCRIPTION
## 📋 Summary

Add a daily agentic CI system that runs rotating code health audits on weekdays, catching quality drift that existing CI doesn't cover (no C901/ANN/BLE ruff rules, no cross-reference validation, no transitive dep analysis, no docs-vs-code accuracy checks). Each audit runs as a Claude Code agent on the self-hosted runner, guided by a recipe, and reports findings to the GitHub Actions step summary.

Closes #472

## 🔗 Related Issue

Closes #472

## 🔄 Changes

### ✨ Added

- [`.github/workflows/agentic-ci-daily.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.github/workflows/agentic-ci-daily.yml) - Scheduled workflow with day-of-week suite rotation (Mon-Fri), per-suite concurrency, runner memory via `actions/cache`, `make install-dev` environment setup, and `workflow_dispatch` override (including "all" to run everything in parallel)
- [`.agents/recipes/docs-and-references/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/docs-and-references/recipe.md) - Monday: docstring vs signature drift, broken internal links, architecture doc references, docs site content accuracy
- [`.agents/recipes/dependencies/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/dependencies/recipe.md) - Tuesday: transitive dependency gaps, cross-package version consistency, unused deps, version pinning review
- [`.agents/recipes/structure/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/structure/recipe.md) - Wednesday: import boundary violations, lazy import compliance, future annotations, dead exports
- [`.agents/recipes/code-quality/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/code-quality/recipe.md) - Thursday: complexity hotspots (C901), exception hygiene, type annotation coverage, TODO aging, executable quality checks (error hierarchy, input validation)
- [`.agents/recipes/test-health/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/test-health/recipe.md) - Friday: test-to-source mapping, hollow test detection, import performance, executable smoke checks (fixed canaries + creative agent-varied checks), test isolation verification

### 🔧 Changed

- [`.agents/recipes/_runner.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/_runner.md) - Added environment docs (`.venv/bin` on PATH), runner memory JSON schema with TTL and size rules, updated PR creation instructions to use `/create-pr` skill
- [`.github/CODEOWNERS`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.github/CODEOWNERS) - Added `.agents/recipes/` ownership entry
- [`plans/472/agentic-ci-plan.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/plans/472/agentic-ci-plan.md) - Marked Phase 2, 3, and 4 deliverables as complete

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`agentic-ci-daily.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.github/workflows/agentic-ci-daily.yml) - New workflow with `contents: write` and `pull-requests: write` permissions. Write access is intentional to support future recipe-driven PRs, but all current recipes are read-only audits.
- Executable smoke checks in [`test-health/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/test-health/recipe.md#L114-L237) and [`code-quality/recipe.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/code-quality/recipe.md#L109-L166) - These run real Python against the installed packages. Fixed canaries are deterministic; creative checks are agent-designed each run.
- Runner memory schema in [`_runner.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/b54da234/.agents/recipes/_runner.md#L19-L55) - Defines the JSON contract for cross-run state persistence including TTL rules for known_issues.

## 🧪 Testing

- [x] `make check-all` passes (ruff lint + format)
- [ ] Unit tests added/updated — N/A, no testable Python logic (recipes are markdown instructions, workflow is YAML)
- [ ] E2E tests — N/A, requires self-hosted runner with Claude CLI. Can be validated via `workflow_dispatch` after merge.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A, this is CI infrastructure