### PR TITLE
chore: remove obsolete Cerebro ignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,11 +102,7 @@ packages/data-designer/README.md
 # Notebook build cache
 .notebook-cache/
 
-# Cerebro knowledge base
-.cerebro/
-.cursor/rules/cerebro.mdc
 .cursor/mcp.json
-.claude/rules/cerebro.md
 
 # Claude worktrees
 .claude/worktrees/


### PR DESCRIPTION
## 📋 Summary
Remove obsolete Cerebro-specific ignore patterns now that Cerebro is no longer used in this repository. This keeps the ignore list aligned with active tooling and avoids carrying stale project conventions.

## 🔗 Related Issue
N/A

## 🔄 Changes
- Removed the Cerebro block from [`.gitignore`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/chore/remove-cerebro-references/.gitignore).
- Deleted stale ignore entries for `.cerebro/`, `.cursor/rules/cerebro.mdc`, and `.claude/rules/cerebro.md`.
- Kept unrelated ignore rules, including `.cursor/mcp.json`, unchanged.

## 🧪 Testing
- [ ] `make test` passes (N/A — metadata-only `.gitignore` change)
- [ ] Unit tests added/updated (N/A — no testable runtime logic changed)
- [ ] E2E tests added/updated (if applicable) (N/A — no user-facing behavior changes)

## ✅ Checklist
- [x] Follows commit message conventions
- [ ] Commits are signed off (DCO) (not included in this commit)
- [x] Architecture docs updated (if applicable) (N/A)