### PR TITLE
fix: normalize image_url blocks to OpenAI-compliant dict format

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/models.py
+++ b/packages/data-designer-config/src/data_designer/config/models.py
@@ -134,7 +134,7 @@ class ImageContext(ModalityContext):
 
         return contexts
 
-    def _auto_resolve_context_value(self, context_value: str, base_path: str | None) -> str | dict[str, str]:
+    def _auto_resolve_context_value(self, context_value: str, base_path: str | None) -> dict[str, str]:
         """Auto-detect the format of a context value and resolve it.
 
         Resolution rules:

--- a/packages/data-designer-config/src/data_designer/config/models.py
+++ b/packages/data-designer-config/src/data_designer/config/models.py
@@ -121,13 +121,11 @@ class ImageContext(ModalityContext):
         for context_value in context_values:
             context = dict(type="image_url")
             if self.data_type is not None:
-                # Explicit data_type: use existing behavior
                 if self.data_type == ModalityDataType.URL:
-                    context["image_url"] = context_value
+                    context["image_url"] = {"url": context_value}
                 else:
                     context["image_url"] = {
                         "url": f"data:image/{self.image_format.value};base64,{context_value}",
-                        "format": self.image_format.value,
                     }
             else:
                 # Auto-detect: resolve file paths, pass through URLs, assume base64 otherwise
@@ -150,7 +148,7 @@ class ImageContext(ModalityContext):
                 return self._format_base64_context(base64_data)
 
         if is_image_url(context_value):
-            return context_value
+            return {"url": context_value}
 
         return self._format_base64_context(context_value)
 
@@ -165,7 +163,6 @@ class ImageContext(ModalityContext):
             image_format = detect_image_format(image_bytes)
         return {
             "url": f"data:image/{image_format.value};base64,{base64_data}",
-            "format": image_format.value,
         }
 
     @model_validator(mode="after")

--- a/packages/data-designer-config/tests/config/test_models.py
+++ b/packages/data-designer-config/tests/config/test_models.py
@@ -38,7 +38,7 @@ def test_image_context_get_contexts_single_string():
     assert image_context.get_contexts({"image_base64": "somebase64encodedimagestring"}) == [
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,somebase64encodedimagestring", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,somebase64encodedimagestring"},
         }
     ]
 
@@ -46,7 +46,7 @@ def test_image_context_get_contexts_single_string():
     assert image_context.get_contexts({"image_url": "https://example.com/examle_image.png"}) == [
         {
             "type": "image_url",
-            "image_url": "https://example.com/examle_image.png",
+            "image_url": {"url": "https://example.com/examle_image.png"},
         }
     ]
 
@@ -59,15 +59,15 @@ def test_image_context_get_contexts_list_of_strings():
     assert image_context.get_contexts({"image_base64": ["image1base64", "image2base64", "image3base64"]}) == [
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image1base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image1base64"},
         },
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image2base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image2base64"},
         },
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image3base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image3base64"},
         },
     ]
 
@@ -77,11 +77,11 @@ def test_image_context_get_contexts_list_of_strings():
     ) == [
         {
             "type": "image_url",
-            "image_url": "https://example.com/image1.png",
+            "image_url": {"url": "https://example.com/image1.png"},
         },
         {
             "type": "image_url",
-            "image_url": "https://example.com/image2.png",
+            "image_url": {"url": "https://example.com/image2.png"},
         },
     ]
 
@@ -95,11 +95,11 @@ def test_image_context_get_contexts_numpy_array():
     assert image_context.get_contexts({"image_base64": numpy_array}) == [
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image1base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image1base64"},
         },
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image2base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image2base64"},
         },
     ]
 
@@ -108,11 +108,11 @@ def test_image_context_get_contexts_numpy_array():
     assert image_context.get_contexts({"image_url": numpy_array}) == [
         {
             "type": "image_url",
-            "image_url": "https://example.com/image1.png",
+            "image_url": {"url": "https://example.com/image1.png"},
         },
         {
             "type": "image_url",
-            "image_url": "https://example.com/image2.png",
+            "image_url": {"url": "https://example.com/image2.png"},
         },
     ]
 
@@ -126,11 +126,11 @@ def test_image_context_get_contexts_json_serialized_list():
     assert image_context.get_contexts({"image_base64": json_str}) == [
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image1base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image1base64"},
         },
         {
             "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,image2base64", "format": "png"},
+            "image_url": {"url": "data:image/png;base64,image2base64"},
         },
     ]
 
@@ -139,11 +139,11 @@ def test_image_context_get_contexts_json_serialized_list():
     assert image_context.get_contexts({"image_url": json_str}) == [
         {
             "type": "image_url",
-            "image_url": "https://example.com/image1.png",
+            "image_url": {"url": "https://example.com/image1.png"},
         },
         {
             "type": "image_url",
-            "image_url": "https://example.com/image2.png",
+            "image_url": {"url": "https://example.com/image2.png"},
         },
     ]
 
@@ -152,11 +152,10 @@ def test_image_context_get_contexts_json_string_not_list():
     """Test get_contexts with a JSON string that isn't a list (should treat as single string)."""
     image_context = ImageContext(column_name="image_url", data_type=ModalityDataType.URL)
     json_str = json.dumps({"nested": "object"})
-    # Should treat the entire JSON string as a single image URL
     assert image_context.get_contexts({"image_url": json_str}) == [
         {
             "type": "image_url",
-            "image_url": json_str,
+            "image_url": {"url": json_str},
         }
     ]
 
@@ -168,7 +167,7 @@ def test_image_context_get_contexts_invalid_json():
     assert image_context.get_contexts({"image_url": invalid_json}) == [
         {
             "type": "image_url",
-            "image_url": invalid_json,
+            "image_url": {"url": invalid_json},
         }
     ]
 
@@ -195,7 +194,7 @@ def test_image_context_auto_detect_url() -> None:
     """Test auto-detection with URL value (no data_type)."""
     context = ImageContext(column_name="image_col")
     result = context.get_contexts({"image_col": "https://example.com/image.png"})
-    assert result == [{"type": "image_url", "image_url": "https://example.com/image.png"}]
+    assert result == [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}]
 
 
 def test_image_context_auto_detect_base64(minimal_png_base64: str) -> None:
@@ -205,7 +204,6 @@ def test_image_context_auto_detect_base64(minimal_png_base64: str) -> None:
     result = context.get_contexts({"image_col": png_base64})
     assert len(result) == 1
     assert result[0]["type"] == "image_url"
-    assert result[0]["image_url"]["format"] == "png"
     assert f"base64,{png_base64}" in result[0]["image_url"]["url"]
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
@@ -320,13 +320,10 @@ def translate_tool_result_content(content: Any) -> str | list[dict[str, Any]]:
 
 def translate_image_url_block(block: dict[str, Any]) -> dict[str, Any] | None:
     image_url = block.get("image_url")
-    if image_url is None:
+    if not isinstance(image_url, dict):
         return None
 
-    if isinstance(image_url, dict):
-        url = image_url.get("url", "")
-    else:
-        url = str(image_url)
+    url = image_url.get("url", "")
 
     match = _DATA_URI_RE.match(url)
     if match:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
@@ -193,9 +193,7 @@ def translate_content_blocks(content: Any) -> list[dict[str, Any]]:
     translated: list[dict[str, Any]] = []
     for block in raw_blocks:
         if isinstance(block, dict) and block.get("type") == "image_url":
-            anthropic_block = translate_image_url_block(block)
-            if anthropic_block is not None:
-                translated.append(anthropic_block)
+            translated.append(translate_image_url_block(block))
             continue
         # Anthropic rejects empty text blocks — drop them.
         if isinstance(block, dict) and block.get("type") == "text" and not block.get("text"):
@@ -318,10 +316,12 @@ def translate_tool_result_content(content: Any) -> str | list[dict[str, Any]]:
     return translated_blocks
 
 
-def translate_image_url_block(block: dict[str, Any]) -> dict[str, Any] | None:
+def translate_image_url_block(block: dict[str, Any]) -> dict[str, Any]:
     image_url = block.get("image_url")
     if not isinstance(image_url, dict):
-        return None
+        raise TypeError(
+            f"image_url block must contain a dict with a 'url' key, got {type(image_url).__name__}: {image_url!r}"
+        )
 
     url = image_url.get("url", "")
 

--- a/packages/data-designer-engine/tests/engine/column_generators/generators/test_image.py
+++ b/packages/data-designer-engine/tests/engine/column_generators/generators/test_image.py
@@ -172,7 +172,7 @@ def test_image_cell_generator_with_multi_modal_context(stub_resource_provider):
         assert call_args.kwargs["multi_modal_context"] is not None
         assert len(call_args.kwargs["multi_modal_context"]) == 1
         assert call_args.kwargs["multi_modal_context"][0]["type"] == "image_url"
-        assert call_args.kwargs["multi_modal_context"][0]["image_url"] == "https://example.com/image.png"
+        assert call_args.kwargs["multi_modal_context"][0]["image_url"] == {"url": "https://example.com/image.png"}
 
 
 def test_image_cell_generator_with_base64_multi_modal_context(stub_resource_provider):
@@ -302,4 +302,4 @@ def test_image_cell_generator_auto_detect_passes_through_urls(stub_resource_prov
         mock_generate.assert_called_once()
         context = mock_generate.call_args.kwargs["multi_modal_context"]
         assert context is not None
-        assert context[0]["image_url"] == "https://example.com/image.png"
+        assert context[0]["image_url"] == {"url": "https://example.com/image.png"}

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
@@ -446,7 +446,7 @@ def test_completion_translates_data_uri_image_blocks() -> None:
                 "content": [
                     {
                         "type": "image_url",
-                        "image_url": {"url": "data:image/png;base64,iVBOR...", "format": "png"},
+                        "image_url": {"url": "data:image/png;base64,iVBOR..."},
                     },
                     {"type": "text", "text": "What is this?"},
                 ],
@@ -464,7 +464,33 @@ def test_completion_translates_data_uri_image_blocks() -> None:
     assert content[1] == {"type": "text", "text": "What is this?"}
 
 
-def test_completion_translates_url_string_image_blocks() -> None:
+def test_completion_translates_url_dict_image_blocks() -> None:
+    sync_mock = make_mock_sync_client(_text_response())
+    client = _make_client(sync_client=sync_mock)
+
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                    {"type": "text", "text": "Describe this."},
+                ],
+            },
+        ],
+    )
+    client.completion(request)
+
+    payload = sync_mock.post.call_args.kwargs["json"]
+    content = payload["messages"][0]["content"]
+    assert content[0] == {
+        "type": "image",
+        "source": {"type": "url", "url": "https://example.com/cat.png"},
+    }
+
+
+def test_completion_drops_bare_string_image_blocks() -> None:
     sync_mock = make_mock_sync_client(_text_response())
     client = _make_client(sync_client=sync_mock)
 
@@ -484,36 +510,7 @@ def test_completion_translates_url_string_image_blocks() -> None:
 
     payload = sync_mock.post.call_args.kwargs["json"]
     content = payload["messages"][0]["content"]
-    assert content[0] == {
-        "type": "image",
-        "source": {"type": "url", "url": "https://example.com/cat.png"},
-    }
-
-
-def test_completion_translates_data_uri_string_image_blocks() -> None:
-    sync_mock = make_mock_sync_client(_text_response())
-    client = _make_client(sync_client=sync_mock)
-
-    request = ChatCompletionRequest(
-        model=MODEL,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image_url", "image_url": "data:image/jpeg;base64,/9j/4AAQ..."},
-                    {"type": "text", "text": "What is this?"},
-                ],
-            },
-        ],
-    )
-    client.completion(request)
-
-    payload = sync_mock.post.call_args.kwargs["json"]
-    content = payload["messages"][0]["content"]
-    assert content[0] == {
-        "type": "image",
-        "source": {"type": "base64", "media_type": "image/jpeg", "data": "/9j/4AAQ..."},
-    }
+    assert content == [{"type": "text", "text": "Describe this."}]
 
 
 def test_completion_preserves_non_image_content_blocks() -> None:

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
@@ -490,7 +490,7 @@ def test_completion_translates_url_dict_image_blocks() -> None:
     }
 
 
-def test_completion_drops_bare_string_image_blocks() -> None:
+def test_completion_rejects_bare_string_image_blocks() -> None:
     sync_mock = make_mock_sync_client(_text_response())
     client = _make_client(sync_client=sync_mock)
 
@@ -506,11 +506,8 @@ def test_completion_drops_bare_string_image_blocks() -> None:
             },
         ],
     )
-    client.completion(request)
-
-    payload = sync_mock.post.call_args.kwargs["json"]
-    content = payload["messages"][0]["content"]
-    assert content == [{"type": "text", "text": "Describe this."}]
+    with pytest.raises(TypeError, match="image_url block must contain a dict"):
+        client.completion(request)
 
 
 def test_completion_preserves_non_image_content_blocks() -> None:

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
@@ -510,6 +510,26 @@ def test_completion_rejects_bare_string_image_blocks() -> None:
         client.completion(request)
 
 
+def test_completion_rejects_bare_data_uri_image_blocks() -> None:
+    sync_mock = make_mock_sync_client(_text_response())
+    client = _make_client(sync_client=sync_mock)
+
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": "data:image/png;base64,iVBOR..."},
+                    {"type": "text", "text": "What is this?"},
+                ],
+            },
+        ],
+    )
+    with pytest.raises(TypeError, match="image_url block must contain a dict"):
+        client.completion(request)
+
+
 def test_completion_preserves_non_image_content_blocks() -> None:
     sync_mock = make_mock_sync_client(_text_response())
     client = _make_client(sync_client=sync_mock)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -55,7 +55,7 @@ def test_build_anthropic_payload_preserves_multimodal_system_content() -> None:
                 "role": "system",
                 "content": [
                     {"type": "text", "text": "Describe this image."},
-                    {"type": "image_url", "image_url": "https://example.com/reference.png"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/reference.png"}},
                 ],
             },
             {"role": "user", "content": "Go."},
@@ -162,7 +162,7 @@ def test_translate_request_messages_merges_parallel_tool_results() -> None:
         pytest.param(
             [
                 {"type": "text", "text": "Rule 1"},
-                {"type": "image_url", "image_url": "https://example.com/reference.png"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/reference.png"}},
                 {"type": "text", "text": "Rule 2"},
             ],
             [
@@ -173,7 +173,7 @@ def test_translate_request_messages_merges_parallel_tool_results() -> None:
             id="mixed-text-and-image-returns-blocks",
         ),
         pytest.param(
-            [{"type": "image_url", "image_url": "https://example.com/reference.png"}],
+            [{"type": "image_url", "image_url": {"url": "https://example.com/reference.png"}}],
             [{"type": "image", "source": {"type": "url", "url": "https://example.com/reference.png"}}],
             id="image-only-returns-blocks",
         ),
@@ -319,7 +319,7 @@ def test_translate_tool_definition_normalizes_supported_shapes(
 def test_translate_content_blocks_converts_images_and_preserves_other_blocks() -> None:
     blocks = translate_content_blocks(
         [
-            {"type": "image_url", "image_url": "https://example.com/cat.png"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
             {"type": "text", "text": "Caption"},
             {"type": "custom_block", "value": "kept"},
         ]
@@ -347,14 +347,19 @@ def test_translate_content_blocks_drops_malformed_image_url_block() -> None:
     ("block", "expected"),
     [
         pytest.param(
-            {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBOR...", "format": "png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBOR..."}},
             {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR..."}},
-            id="data-uri",
+            id="data-uri-dict",
+        ),
+        pytest.param(
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}},
+            id="remote-url-dict",
         ),
         pytest.param(
             {"type": "image_url", "image_url": "https://example.com/cat.png"},
-            {"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}},
-            id="remote-url",
+            None,
+            id="bare-string-rejected",
         ),
     ],
 )
@@ -460,7 +465,7 @@ def test_translate_tool_result_message_requires_tool_call_id(message: dict[str, 
         ),
         pytest.param(
             [
-                {"type": "image_url", "image_url": "https://example.com/chart.png"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/chart.png"}},
                 {"type": "text", "text": "Caption"},
             ],
             [

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -332,15 +332,14 @@ def test_translate_content_blocks_converts_images_and_preserves_other_blocks() -
     ]
 
 
-def test_translate_content_blocks_drops_malformed_image_url_block() -> None:
-    blocks = translate_content_blocks(
-        [
-            {"type": "image_url"},
-            {"type": "text", "text": "Kept"},
-        ]
-    )
-
-    assert blocks == [{"type": "text", "text": "Kept"}]
+def test_translate_content_blocks_rejects_malformed_image_url_block() -> None:
+    with pytest.raises(TypeError, match="image_url block must contain a dict"):
+        translate_content_blocks(
+            [
+                {"type": "image_url"},
+                {"type": "text", "text": "Kept"},
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -355,11 +355,6 @@ def test_translate_content_blocks_rejects_malformed_image_url_block() -> None:
             {"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}},
             id="remote-url-dict",
         ),
-        pytest.param(
-            {"type": "image_url", "image_url": "https://example.com/cat.png"},
-            None,
-            id="bare-string-rejected",
-        ),
     ],
 )
 def test_translate_image_url_block_normalizes_supported_inputs(
@@ -367,6 +362,24 @@ def test_translate_image_url_block_normalizes_supported_inputs(
     expected: dict[str, object],
 ) -> None:
     assert translate_image_url_block(block) == expected
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        pytest.param(
+            {"type": "image_url", "image_url": "https://example.com/cat.png"},
+            id="bare-url-string",
+        ),
+        pytest.param(
+            {"type": "image_url", "image_url": "data:image/png;base64,iVBOR..."},
+            id="bare-data-uri-string",
+        ),
+    ],
+)
+def test_translate_image_url_block_rejects_bare_strings(block: dict[str, object]) -> None:
+    with pytest.raises(TypeError, match="image_url block must contain a dict"):
+        translate_image_url_block(block)
 
 
 @pytest.mark.parametrize(

--- a/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
@@ -249,6 +249,44 @@ async def test_agenerate_image_maps_images() -> None:
     assert len(result.images) == 1
 
 
+# --- Image URL passthrough ---
+
+
+def test_completion_forwards_image_url_dict_unchanged() -> None:
+    """OpenAI expects image_url blocks as {"url": ...} dicts — verify they pass through as-is."""
+    sync_mock = make_mock_sync_client(_chat_response())
+    client = _make_client(sync_client=sync_mock)
+
+    image_block = {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}
+    text_block = {"type": "text", "text": "Describe this."}
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[{"role": "user", "content": [image_block, text_block]}],
+    )
+    client.completion(request)
+
+    payload = sync_mock.post.call_args.kwargs["json"]
+    content = payload["messages"][0]["content"]
+    assert content == [image_block, text_block]
+
+
+def test_completion_forwards_base64_image_url_dict_unchanged() -> None:
+    """Base64 data-URI image blocks should also pass through unmodified."""
+    sync_mock = make_mock_sync_client(_chat_response())
+    client = _make_client(sync_client=sync_mock)
+
+    image_block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBOR..."}}
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[{"role": "user", "content": [image_block, {"type": "text", "text": "What is this?"}]}],
+    )
+    client.completion(request)
+
+    payload = sync_mock.post.call_args.kwargs["json"]
+    content = payload["messages"][0]["content"]
+    assert content[0] == image_block
+
+
 # --- Auth headers ---
 
 


### PR DESCRIPTION
## 📋 Summary

`ImageContext.get_contexts()` produced bare-string and non-standard dict shapes for `image_url` content blocks, which broke the native OpenAI adapter and only worked with Anthropic by accident. This is a regression from the litellm removal in [v0.5.4](https://github.com/NVIDIA-NeMo/DataDesigner/releases/tag/v0.5.4) — litellm was normalizing the shape internally before forwarding to provider APIs.

## 🔗 Related Issue

Fixes #576

## 🔄 Changes

### 🐛 Fixed
- [`models.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nabinchha/fix/576-image-context-openai-anthropic-compliance/packages/data-designer-config/src/data_designer/config/models.py#L123-L128) — `data_type=URL` path now wraps value in `{"url": ...}` instead of passing a bare string
- [`models.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nabinchha/fix/576-image-context-openai-anthropic-compliance/packages/data-designer-config/src/data_designer/config/models.py#L150-L151) — Auto-detect URL path returns `{"url": ...}` dict instead of bare string
- [`models.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nabinchha/fix/576-image-context-openai-anthropic-compliance/packages/data-designer-config/src/data_designer/config/models.py#L163-L165) — Removed non-standard `"format"` key from base64 dicts (media type is already encoded in the data URI)

### 🔧 Changed
- [`anthropic_translation.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nabinchha/fix/576-image-context-openai-anthropic-compliance/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py#L321-L325) — `translate_image_url_block` now raises `TypeError` when `image_url` is not a dict (e.g. a bare string). Since all `image_url` blocks are constructed internally by DataDesigner, we control the shape — a malformed block indicates an internal bug and should fail loudly rather than be silently dropped.

## 🧪 Testing

- [x] `uv run pytest` passes (136 tests across 5 test files)
- [x] Unit tests updated to match new canonical format
- [x] `test_completion_rejects_bare_string_image_blocks` — verifies Anthropic client raises `TypeError` on bare-string `image_url`
- [x] `test_translate_content_blocks_rejects_malformed_image_url_block` — verifies translation layer raises `TypeError` on malformed blocks
- [ ] E2E tests — N/A, no live API calls in this change

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A, no architectural change

Made with [Cursor](https://cursor.com)