### PR TITLE
fix: inline retry for rate-limited tasks in async scheduler

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/run_config.py
+++ b/packages/data-designer-config/src/data_designer/config/run_config.py
@@ -96,8 +96,8 @@ class ThrottleConfig(ConfigBase):
         ge=1,
         description=(
             "Number of consecutive 429 responses at minimum concurrency before the "
-            "domain is marked as saturated. Saturated domains cause tasks to fail "
-            "immediately rather than retrying through the throttle."
+            "domain is logged as saturated. Currently telemetry-only; does not "
+            "affect retry behavior."
         ),
     )
 

--- a/packages/data-designer-config/src/data_designer/config/run_config.py
+++ b/packages/data-designer-config/src/data_designer/config/run_config.py
@@ -47,6 +47,9 @@ class ThrottleConfig(ConfigBase):
     DEFAULT_SUCCESS_WINDOW: ClassVar[int] = 25
     DEFAULT_COOLDOWN_SECONDS: ClassVar[float] = 2.0
     DEFAULT_CEILING_OVERSHOOT: ClassVar[float] = 0.10
+    DEFAULT_COOLDOWN_BACKOFF_FACTOR: ClassVar[float] = 2.0
+    DEFAULT_MAX_COOLDOWN_SECONDS: ClassVar[float] = 30.0
+    DEFAULT_SATURATION_THRESHOLD: ClassVar[int] = 5
 
     reduce_factor: float = Field(
         default=DEFAULT_REDUCE_FACTOR,
@@ -73,6 +76,29 @@ class ThrottleConfig(ConfigBase):
         default=DEFAULT_CEILING_OVERSHOOT,
         ge=0.0,
         description="Fraction above the rate-limit ceiling that additive increase is allowed to probe.",
+    )
+    cooldown_backoff_factor: float = Field(
+        default=DEFAULT_COOLDOWN_BACKOFF_FACTOR,
+        ge=1.0,
+        description=(
+            "Exponential backoff multiplier for cooldown duration on consecutive 429s "
+            "while at minimum concurrency. Each consecutive rate-limit at the floor "
+            "multiplies the cooldown by this factor, up to max_cooldown_seconds."
+        ),
+    )
+    max_cooldown_seconds: float = Field(
+        default=DEFAULT_MAX_COOLDOWN_SECONDS,
+        gt=0.0,
+        description="Upper bound (seconds) for exponential cooldown backoff.",
+    )
+    saturation_threshold: int = Field(
+        default=DEFAULT_SATURATION_THRESHOLD,
+        ge=1,
+        description=(
+            "Number of consecutive 429 responses at minimum concurrency before the "
+            "domain is marked as saturated. Saturated domains cause tasks to fail "
+            "immediately rather than retrying through the throttle."
+        ),
     )
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TASK_POOL_SIZE: int = 256
 LLM_WAIT_POOL_MULTIPLIER: int = 2
+DEFAULT_RATE_LIMIT_RETRIES: int = 10
 
 _RETRYABLE_MODEL_ERRORS = (
     ModelRateLimitError,
@@ -712,14 +713,29 @@ class AsyncTaskScheduler:
                 trace.slot_acquired_at = time.perf_counter()
 
             cell_skipped = False
-            if task.task_type == "from_scratch":
-                await self._run_from_scratch(task, generator)
-            elif task.task_type == "cell":
-                _result, cell_skipped = await self._run_cell(task, generator)
-            elif task.task_type == "batch":
-                await self._run_batch(task, generator)
-            else:
-                raise ValueError(f"Unknown task type: {task.task_type}")
+            for _rl_attempt in range(DEFAULT_RATE_LIMIT_RETRIES + 1):
+                try:
+                    if task.task_type == "from_scratch":
+                        await self._run_from_scratch(task, generator)
+                    elif task.task_type == "cell":
+                        _result, cell_skipped = await self._run_cell(task, generator)
+                    elif task.task_type == "batch":
+                        await self._run_batch(task, generator)
+                    else:
+                        raise ValueError(f"Unknown task type: {task.task_type}")
+                    break
+                except ModelRateLimitError:
+                    if self._early_shutdown or _rl_attempt == DEFAULT_RATE_LIMIT_RETRIES:
+                        raise
+                    logger.info(
+                        "Rate-limited on task %s (col=%s, rg=%s), retry %d/%d",
+                        task.task_type,
+                        task.column,
+                        task.row_group,
+                        _rl_attempt + 1,
+                        DEFAULT_RATE_LIMIT_RETRIES,
+                    )
+                    await asyncio.sleep(0)
 
             # Mark all output columns complete
             for col in output_cols:

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TASK_POOL_SIZE: int = 256
 LLM_WAIT_POOL_MULTIPLIER: int = 2
-DEFAULT_RATE_LIMIT_RETRIES: int = 10
+DEFAULT_RATE_LIMIT_RETRIES: int = 5
 
 _RETRYABLE_MODEL_ERRORS = (
     ModelRateLimitError,

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -713,7 +713,18 @@ class AsyncTaskScheduler:
                 trace.slot_acquired_at = time.perf_counter()
 
             cell_skipped = False
-            for _rl_attempt in range(DEFAULT_RATE_LIMIT_RETRIES + 1):
+            # Inline retry for rate-limited tasks. The worker keeps the LLM-wait
+            # permit across retries; for single-model pipelines this is a no-op
+            # (other tasks would block on the same throttle anyway), and for
+            # multi-model pipelines it can mildly pinch cross-model throughput.
+            # We accept that tradeoff because releasing the permit mid-retry
+            # would either re-introduce salvage-style burst pacing or break the
+            # in-flight bookkeeping the scheduler relies on.
+            #
+            # The actual cooldown wait happens inside ``ThrottleManager.acquire_async``
+            # on the next iteration (it sleeps until ``state.blocked_until``).
+            # ``await asyncio.sleep(0)`` here only yields to the event loop.
+            for rl_attempt in range(DEFAULT_RATE_LIMIT_RETRIES + 1):
                 try:
                     if task.task_type == "from_scratch":
                         await self._run_from_scratch(task, generator)
@@ -725,14 +736,14 @@ class AsyncTaskScheduler:
                         raise ValueError(f"Unknown task type: {task.task_type}")
                     break
                 except ModelRateLimitError:
-                    if self._early_shutdown or _rl_attempt == DEFAULT_RATE_LIMIT_RETRIES:
+                    if self._early_shutdown or rl_attempt == DEFAULT_RATE_LIMIT_RETRIES:
                         raise
                     logger.info(
                         "Rate-limited on task %s (col=%s, rg=%s), retry %d/%d",
                         task.task_type,
                         task.column,
                         task.row_group,
-                        _rl_attempt + 1,
+                        rl_attempt + 1,
                         DEFAULT_RATE_LIMIT_RETRIES,
                     )
                     await asyncio.sleep(0)

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -47,6 +47,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_TASK_POOL_SIZE: int = 256
 LLM_WAIT_POOL_MULTIPLIER: int = 2
 DEFAULT_RATE_LIMIT_RETRIES: int = 5
+# Default wait used by the cooldown queue when a ``ModelRateLimitError`` is
+# raised without throttle context (e.g. by a custom generator that bypasses
+# ``ThrottledModelClient``). When the throttle is in the loop, ``acquire_async``
+# layers its own AIMD cooldown on top of this wait, so the value is a floor
+# rather than the source of truth.
+DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS: float = 2.0
 
 _RETRYABLE_MODEL_ERRORS = (
     ModelRateLimitError,
@@ -100,6 +106,7 @@ class AsyncTaskScheduler:
         max_submitted_tasks: int = DEFAULT_TASK_POOL_SIZE,
         max_llm_wait_tasks: int = DEFAULT_TASK_POOL_SIZE,
         salvage_max_rounds: int = 2,
+        rate_limit_cooldown_seconds: float = DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS,
         on_finalize_row_group: Callable[[int], None] | None = None,
         on_seeds_complete: Callable[[int, int], None] | None = None,
         on_before_checkpoint: Callable[[int, int], None] | None = None,
@@ -129,6 +136,7 @@ class AsyncTaskScheduler:
         self._worker_tasks: set[asyncio.Task] = set()
         self._wake_event = asyncio.Event()
         self._salvage_max_rounds = salvage_max_rounds
+        self._rate_limit_cooldown_seconds = rate_limit_cooldown_seconds
         self._on_finalize_row_group = on_finalize_row_group
         self._on_seeds_complete = on_seeds_complete
         self._on_before_checkpoint = on_before_checkpoint
@@ -169,6 +177,12 @@ class AsyncTaskScheduler:
 
         # Deferred retryable failures (retried in salvage rounds)
         self._deferred: list[Task] = []
+
+        # Cooldown queue for rate-limited tasks. Workers exit after pushing here
+        # so they don't pin LLM-wait permits during the cooldown wait. The
+        # dispatch loop drains entries whose ``wakeup_at`` has passed.
+        self._cooldown_pending: list[tuple[Task, float]] = []
+        self._rate_limit_retries: dict[Task, int] = {}
 
         # Tracing
         self._trace = trace
@@ -298,6 +312,41 @@ class AsyncTaskScheduler:
                     "These row groups were not checkpointed."
                 )
 
+    def _drain_ready_cooldown_pending(self) -> None:
+        """Move cooldown-pending tasks whose wakeup time has passed back to the frontier.
+
+        Tasks are released from ``_cooldown_pending`` by discarding them from
+        ``_dispatched``; the next ``get_ready_tasks`` call will surface them as
+        regular frontier work, which goes through the standard submission/LLM
+        wait acquisition path and so naturally pace through the throttle.
+        """
+        if not self._cooldown_pending:
+            return
+        now = time.monotonic()
+        still_waiting: list[tuple[Task, float]] = []
+        for task, wakeup_at in self._cooldown_pending:
+            if wakeup_at <= now:
+                self._dispatched.discard(task)
+            else:
+                still_waiting.append((task, wakeup_at))
+        self._cooldown_pending = still_waiting
+
+    def _next_cooldown_timeout(self) -> float | None:
+        """Return seconds until the soonest cooldown wakeup, or ``None`` if empty."""
+        if not self._cooldown_pending:
+            return None
+        next_wakeup = min(wakeup_at for _, wakeup_at in self._cooldown_pending)
+        return max(0.0, next_wakeup - time.monotonic())
+
+    async def _wait_for_wake_or_cooldown(self) -> None:
+        """Wait on ``_wake_event``, bounded by the next cooldown wakeup if any."""
+        timeout = self._next_cooldown_timeout()
+        if timeout is None:
+            await self._wake_event.wait()
+        else:
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(self._wake_event.wait(), timeout=timeout)
+
     async def _main_dispatch_loop(
         self,
         seed_cols: frozenset[str],
@@ -308,12 +357,21 @@ class AsyncTaskScheduler:
         while True:
             if self._early_shutdown:
                 logger.warning("Early shutdown triggered - error rate exceeded threshold")
+                # Convert any remaining cooldown-pending tasks into deferred so
+                # salvage gets a final shot at them; otherwise they would be
+                # silently dropped on shutdown.
+                for task, _ in self._cooldown_pending:
+                    self._deferred.append(task)
+                    self._rate_limit_retries.pop(task, None)
+                self._cooldown_pending = []
                 if self._deferred:
                     await self._salvage_stalled_row_groups(seed_cols, has_pre_batch, all_columns)
                 self._checkpoint_completed_row_groups(all_columns)
                 break
 
             self._wake_event.clear()
+
+            self._drain_ready_cooldown_pending()
 
             if has_pre_batch:
                 self._run_seeds_complete_check(seed_cols)
@@ -347,16 +405,18 @@ class AsyncTaskScheduler:
                 await self._salvage_stalled_row_groups(seed_cols, has_pre_batch, all_columns)
 
             # Are we done?
-            all_done = self._all_rgs_admitted and not self._rg_states and not self._in_flight
+            all_done = (
+                self._all_rgs_admitted and not self._rg_states and not self._in_flight and not self._cooldown_pending
+            )
             if all_done:
                 break
 
-            if not ready and not self._in_flight:
+            if not ready and not self._in_flight and not self._cooldown_pending:
                 if self._all_rgs_admitted:
                     break
 
-            if not ready or semaphore_full:
-                await self._wake_event.wait()
+            if not ready or semaphore_full or self._cooldown_pending:
+                await self._wait_for_wake_or_cooldown()
 
     async def _salvage_rounds(
         self,
@@ -423,6 +483,7 @@ class AsyncTaskScheduler:
     async def _drain_frontier(self, seed_cols: frozenset[str], has_pre_batch: bool, all_columns: list[str]) -> None:
         """Dispatch all frontier tasks and their downstream until quiescent."""
         while True:
+            self._drain_ready_cooldown_pending()
             if has_pre_batch:
                 self._run_seeds_complete_check(seed_cols)
             admitted_ids = set(self._rg_states)
@@ -441,12 +502,12 @@ class AsyncTaskScheduler:
                 if (s := self._rg_states.get(task.row_group)) is not None:
                     s.in_flight_count += 1
                 self._spawn_worker(self._execute_task(task))
-            if not ready and not self._in_flight:
+            if not ready and not self._in_flight and not self._cooldown_pending:
                 break
-            if not self._in_flight:
+            if not self._in_flight and not self._cooldown_pending:
                 continue
             self._wake_event.clear()
-            await self._wake_event.wait()
+            await self._wait_for_wake_or_cooldown()
 
     async def _salvage_stalled_row_groups(
         self,
@@ -489,6 +550,7 @@ class AsyncTaskScheduler:
             already_dropped = task.row_index is not None and self._tracker.is_dropped(task.row_group, task.row_index)
             if not already_dropped and self._reporter:
                 self._reporter.record_failure(task.column)
+            self._rate_limit_retries.pop(task, None)
             if task.row_index is not None:
                 self._drop_row(task.row_group, task.row_index, exclude_columns={task.column})
             else:
@@ -688,6 +750,7 @@ class AsyncTaskScheduler:
         generator = self._generators[task.column]
         output_cols = self._gen_instance_to_columns.get(id(generator), [task.column])
         retryable = False
+        cooldown_requeued = False
         # When True, skip removing from _dispatched so the task isn't re-dispatched
         # from the frontier (it was never completed, so it stays in the frontier).
         skipped = False
@@ -713,40 +776,17 @@ class AsyncTaskScheduler:
                 trace.slot_acquired_at = time.perf_counter()
 
             cell_skipped = False
-            # Inline retry for rate-limited tasks. The worker keeps the LLM-wait
-            # permit across retries; for single-model pipelines this is a no-op
-            # (other tasks would block on the same throttle anyway), and for
-            # multi-model pipelines it can mildly pinch cross-model throughput.
-            # We accept that tradeoff because releasing the permit mid-retry
-            # would either re-introduce salvage-style burst pacing or break the
-            # in-flight bookkeeping the scheduler relies on.
-            #
-            # The actual cooldown wait happens inside ``ThrottleManager.acquire_async``
-            # on the next iteration (it sleeps until ``state.blocked_until``).
-            # ``await asyncio.sleep(0)`` here only yields to the event loop.
-            for rl_attempt in range(DEFAULT_RATE_LIMIT_RETRIES + 1):
-                try:
-                    if task.task_type == "from_scratch":
-                        await self._run_from_scratch(task, generator)
-                    elif task.task_type == "cell":
-                        _result, cell_skipped = await self._run_cell(task, generator)
-                    elif task.task_type == "batch":
-                        await self._run_batch(task, generator)
-                    else:
-                        raise ValueError(f"Unknown task type: {task.task_type}")
-                    break
-                except ModelRateLimitError:
-                    if self._early_shutdown or rl_attempt == DEFAULT_RATE_LIMIT_RETRIES:
-                        raise
-                    logger.info(
-                        "Rate-limited on task %s (col=%s, rg=%s), retry %d/%d",
-                        task.task_type,
-                        task.column,
-                        task.row_group,
-                        rl_attempt + 1,
-                        DEFAULT_RATE_LIMIT_RETRIES,
-                    )
-                    await asyncio.sleep(0)
+            if task.task_type == "from_scratch":
+                await self._run_from_scratch(task, generator)
+            elif task.task_type == "cell":
+                _result, cell_skipped = await self._run_cell(task, generator)
+            elif task.task_type == "batch":
+                await self._run_batch(task, generator)
+            else:
+                raise ValueError(f"Unknown task type: {task.task_type}")
+
+            # Successful run: clear any prior rate-limit retry counter.
+            self._rate_limit_retries.pop(task, None)
 
             # Mark all output columns complete
             for col in output_cols:
@@ -766,28 +806,58 @@ class AsyncTaskScheduler:
                 trace.status = "ok"
 
         except Exception as exc:
-            if not isinstance(exc, ModelRateLimitError):
+            is_rate_limit = isinstance(exc, ModelRateLimitError)
+            if not is_rate_limit:
                 self._check_error_rate(success=False)
-            retryable = self._is_retryable(exc)
-            if not retryable and self._reporter:
-                self._reporter.record_failure(task.column)
+
+            # Rate-limited tasks go to the cooldown queue (releasing all permits
+            # so the worker doesn't pin LLM-wait slots during the wait). After
+            # exhausting the per-task retry budget, fall through to the regular
+            # retryable path (salvage) as a final backstop.
+            if is_rate_limit and not self._early_shutdown:
+                retries_so_far = self._rate_limit_retries.get(task, 0)
+                if retries_so_far < DEFAULT_RATE_LIMIT_RETRIES:
+                    cooldown = getattr(exc, "retry_after", None) or self._rate_limit_cooldown_seconds
+                    wakeup_at = time.monotonic() + cooldown
+                    self._rate_limit_retries[task] = retries_so_far + 1
+                    self._cooldown_pending.append((task, wakeup_at))
+                    cooldown_requeued = True
+                    logger.info(
+                        "Rate-limited on task %s (col=%s, rg=%s), queued for retry in %.1fs (%d/%d)",
+                        task.task_type,
+                        task.column,
+                        task.row_group,
+                        cooldown,
+                        retries_so_far + 1,
+                        DEFAULT_RATE_LIMIT_RETRIES,
+                    )
+
+            if not cooldown_requeued:
+                retryable = self._is_retryable(exc)
+                if not retryable and self._reporter:
+                    self._reporter.record_failure(task.column)
+                if retryable:
+                    # Salvage will retry. Keep the rate-limit retry counter alive
+                    # so a follow-up 429 from salvage short-circuits straight to
+                    # deferral instead of re-entering the cooldown queue.
+                    self._deferred.append(task)
+                else:
+                    # Non-retryable terminal failure: drop the affected row(s)
+                    # and clear the per-task retry counter.
+                    self._rate_limit_retries.pop(task, None)
+                    if task.row_index is not None:
+                        self._drop_row(task.row_group, task.row_index, exclude_columns={task.column})
+                    else:
+                        # Batch/from_scratch failure: drop all rows in the row group
+                        rg_size = self._get_rg_size(task.row_group)
+                        self._drop_row_group(task.row_group, rg_size, exclude_columns={task.column})
+                    logger.warning(
+                        f"Non-retryable failure on {task.column}[rg={task.row_group}, row={task.row_index}]: {exc}"
+                    )
+
             if self._trace and trace:
                 trace.status = "error"
                 trace.error = str(exc)
-
-            if retryable:
-                self._deferred.append(task)
-            else:
-                # Non-retryable: drop the affected row(s)
-                if task.row_index is not None:
-                    self._drop_row(task.row_group, task.row_index, exclude_columns={task.column})
-                else:
-                    # Batch/from_scratch failure: drop all rows in the row group
-                    rg_size = self._get_rg_size(task.row_group)
-                    self._drop_row_group(task.row_group, rg_size, exclude_columns={task.column})
-                logger.warning(
-                    f"Non-retryable failure on {task.column}[rg={task.row_group}, row={task.row_index}]: {exc}"
-                )
 
         finally:
             if self._trace and trace:
@@ -797,7 +867,11 @@ class AsyncTaskScheduler:
             self._in_flight.discard(task)
             if (s := self._rg_states.get(task.row_group)) is not None:
                 s.in_flight_count = max(0, s.in_flight_count - 1)
-            if not retryable and not skipped:
+            # Cooldown-requeued and salvage-deferred tasks must stay in
+            # ``_dispatched`` so the frontier doesn't re-emit them; they get
+            # discarded explicitly when the cooldown drain releases them or
+            # when salvage runs.
+            if not retryable and not skipped and not cooldown_requeued:
                 self._dispatched.discard(task)
             if holds_llm_wait:
                 self._llm_wait_semaphore.release()

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -319,12 +319,23 @@ class AsyncTaskScheduler:
         ``_dispatched``; the next ``get_ready_tasks`` call will surface them as
         regular frontier work, which goes through the standard submission/LLM
         wait acquisition path and so naturally pace through the throttle.
+
+        Stale entries (row group already checkpointed, or the specific row
+        dropped by a sibling column's terminal failure) are pruned silently so
+        the ``all_done`` gate isn't held hostage by a cooldown that nothing is
+        waiting on anymore.
         """
         if not self._cooldown_pending:
             return
         now = time.monotonic()
         still_waiting: list[tuple[Task, float]] = []
         for task, wakeup_at in self._cooldown_pending:
+            if task.row_group not in self._rg_states:
+                self._rate_limit_retries.pop(task, None)
+                continue
+            if task.row_index is not None and self._tracker.is_dropped(task.row_group, task.row_index):
+                self._rate_limit_retries.pop(task, None)
+                continue
             if wakeup_at <= now:
                 self._dispatched.discard(task)
             else:
@@ -814,10 +825,15 @@ class AsyncTaskScheduler:
             # so the worker doesn't pin LLM-wait slots during the wait). After
             # exhausting the per-task retry budget, fall through to the regular
             # retryable path (salvage) as a final backstop.
-            if is_rate_limit and not self._early_shutdown:
+            #
+            # ``from_scratch`` tasks are dispatched through ``_dispatch_seeds``,
+            # not the frontier - the cooldown drain (which relies on
+            # ``get_ready_tasks``) wouldn't bring them back. Route those
+            # straight to salvage, which knows how to re-dispatch seed tasks.
+            if isinstance(exc, ModelRateLimitError) and not self._early_shutdown and task.task_type != "from_scratch":
                 retries_so_far = self._rate_limit_retries.get(task, 0)
                 if retries_so_far < DEFAULT_RATE_LIMIT_RETRIES:
-                    cooldown = getattr(exc, "retry_after", None) or self._rate_limit_cooldown_seconds
+                    cooldown = exc.retry_after if exc.retry_after else self._rate_limit_cooldown_seconds
                     wakeup_at = time.monotonic() + cooldown
                     self._rate_limit_retries[task] = retries_so_far + 1
                     self._cooldown_pending.append((task, wakeup_at))

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
@@ -52,6 +52,7 @@ class DomainThrottleState:
     waiters: int = 0
     rate_limit_ceiling: int = 0
     consecutive_429s: int = 0
+    saturated: bool = False
 
 
 @dataclass
@@ -114,6 +115,9 @@ class ThrottleManager:
         self._success_window = tc.success_window
         self._default_cooldown_seconds = tc.cooldown_seconds
         self._ceiling_overshoot = tc.ceiling_overshoot
+        self._cooldown_backoff_factor = tc.cooldown_backoff_factor
+        self._max_cooldown_seconds = tc.max_cooldown_seconds
+        self._saturation_threshold = tc.saturation_threshold
         self._lock = threading.Lock()
         self._global_caps: dict[tuple[str, str], GlobalCapState] = {}
         self._domains: dict[tuple[str, str, str], DomainThrottleState] = {}
@@ -210,6 +214,7 @@ class ThrottleManager:
             state = self._get_or_create_domain(provider_name, model_id, domain)
             state.in_flight = max(0, state.in_flight - 1)
             state.consecutive_429s = 0
+            state.saturated = False
             state.success_streak += 1
             if state.success_streak >= self._success_window:
                 effective_max = self._effective_max_for(provider_name, model_id)
@@ -258,11 +263,32 @@ class ThrottleManager:
             prev_limit = state.current_limit
             is_first_in_cascade = state.consecutive_429s == 0
             state.consecutive_429s += 1
-            cooldown_duration = (
+            base_cooldown = (
                 retry_after if retry_after is not None and retry_after > 0 else self._default_cooldown_seconds
             )
+
+            # Exponential backoff when stuck at the concurrency floor
+            at_floor = state.current_limit <= DEFAULT_MIN_LIMIT
+            if at_floor and state.consecutive_429s > 1:
+                cooldown_duration = min(
+                    base_cooldown * (self._cooldown_backoff_factor ** (state.consecutive_429s - 1)),
+                    self._max_cooldown_seconds,
+                )
+            else:
+                cooldown_duration = base_cooldown
+
             state.blocked_until = now + cooldown_duration
             state.success_streak = 0
+
+            # Mark saturated after sustained 429s at the floor
+            if at_floor and state.consecutive_429s >= self._saturation_threshold and not state.saturated:
+                state.saturated = True
+                logger.warning(
+                    "🪫🛑 '%s' [%s] domain saturated after %d consecutive rate limits at minimum concurrency",
+                    model_id,
+                    domain.value,
+                    state.consecutive_429s,
+                )
 
             if is_first_in_cascade:
                 state.current_limit = max(DEFAULT_MIN_LIMIT, math.floor(state.current_limit * self._reduce_factor))
@@ -292,11 +318,12 @@ class ThrottleManager:
                         )
             else:
                 logger.debug(
-                    "Throttle %s [%s] cascade 429 #%d (limit held at %d)",
+                    "Throttle %s [%s] cascade 429 #%d (limit held at %d, cooldown %.1fs)",
                     model_id,
                     domain.value,
                     state.consecutive_429s,
                     state.current_limit,
+                    cooldown_duration,
                 )
 
     def release_failure(
@@ -416,6 +443,17 @@ class ThrottleManager:
     # -------------------------------------------------------------------
     # Introspection (useful for tests and telemetry)
     # -------------------------------------------------------------------
+
+    def is_saturated(
+        self,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+    ) -> bool:
+        """Return ``True`` if the domain has been marked saturated by sustained rate limiting."""
+        with self._lock:
+            state = self._domains.get((provider_name, model_id, domain.value))
+            return state is not None and state.saturated
 
     def get_domain_state(
         self,

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
@@ -43,6 +43,11 @@ class DomainThrottleState:
 
     All mutations must be performed while holding the owning
     ``ThrottleManager._lock``.
+
+    ``saturated`` is transient: it is set when ``consecutive_429s`` crosses
+    ``saturation_threshold`` while at the concurrency floor, and cleared on
+    the next successful or non-rate-limit release. Treat it as a momentary
+    "currently throttled" signal, not a sustained state.
     """
 
     current_limit: int
@@ -263,17 +268,20 @@ class ThrottleManager:
             prev_limit = state.current_limit
             is_first_in_cascade = state.consecutive_429s == 0
             state.consecutive_429s += 1
-            base_cooldown = (
-                retry_after if retry_after is not None and retry_after > 0 else self._default_cooldown_seconds
-            )
+            has_retry_after = retry_after is not None and retry_after > 0
+            base_cooldown = retry_after if has_retry_after else self._default_cooldown_seconds
 
-            # Exponential backoff when stuck at the concurrency floor
+            # Exponential backoff when stuck at the concurrency floor.
+            # ``max_cooldown_seconds`` only caps synthetic backoff growth; an
+            # explicit provider ``Retry-After`` is always honored as a floor,
+            # otherwise we'd retry earlier than the server told us to.
             at_floor = state.current_limit <= DEFAULT_MIN_LIMIT
             if at_floor and state.consecutive_429s > 1:
-                cooldown_duration = min(
+                capped_backoff = min(
                     base_cooldown * (self._cooldown_backoff_factor ** (state.consecutive_429s - 1)),
                     self._max_cooldown_seconds,
                 )
+                cooldown_duration = max(retry_after, capped_backoff) if has_retry_after else capped_backoff
             else:
                 cooldown_duration = base_cooldown
 
@@ -337,6 +345,12 @@ class ThrottleManager:
         with self._lock:
             state = self._get_or_create_domain(provider_name, model_id, domain)
             state.in_flight = max(0, state.in_flight - 1)
+            # Non-rate-limit failures break the consecutive-429 streak. Without
+            # this reset, a sequence like 429 -> 500 -> 429 would be treated
+            # as two consecutive 429s, escalating cooldowns and saturation
+            # marking from stale state.
+            state.consecutive_429s = 0
+            state.saturated = False
 
     # -------------------------------------------------------------------
     # Sync / async wrappers
@@ -450,7 +464,12 @@ class ThrottleManager:
         model_id: str,
         domain: ThrottleDomain,
     ) -> bool:
-        """Return ``True`` if the domain has been marked saturated by sustained rate limiting."""
+        """Return ``True`` if the domain is currently marked saturated by sustained rate limiting.
+
+        Reserved for callers that want to scope retry/skip behavior to
+        saturated domains; today it is used only by tests and observability.
+        The flag is transient (cleared on the next non-rate-limit release).
+        """
         with self._lock:
             state = self._domains.get((provider_name, model_id, domain.value))
             return state is not None and state.saturated

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Awaitable, Callable, TypeVar
 
 from data_designer.engine.models.clients.base import ModelClient
 from data_designer.engine.models.clients.errors import ProviderError, ProviderErrorKind
@@ -27,6 +27,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Default per-call retry budget for ``ProviderError(kind=RATE_LIMIT)``. Each
+# retry's ``acquire_async`` waits through the AIMD cooldown set by the prior
+# 429 release, so retries pace through the throttle automatically.
+DEFAULT_MAX_RATE_LIMIT_RETRIES: int = 3
+
+T = TypeVar("T")
+
 
 class ThrottledModelClient(ModelClient):
     """Wraps a ``ModelClient`` with per-request throttle acquire/release.
@@ -43,6 +50,15 @@ class ThrottledModelClient(ModelClient):
     - ``embeddings`` / ``aembeddings`` -> ``EMBEDDING``
     - ``generate_image`` / ``agenerate_image`` -> ``IMAGE`` when
       ``request.messages is None`` (diffusion), ``CHAT`` when messages are set
+
+    On ``ProviderError(kind=RATE_LIMIT)`` the call is retried in-place up
+    to ``max_rate_limit_retries`` times. Because ``release_rate_limited``
+    sets ``state.blocked_until`` synchronously with the failure, the next
+    iteration's ``acquire_async`` waits through the AIMD cooldown
+    automatically - so the retry paces through the throttle's signal
+    rather than re-saturating it. After exhausting retries, the original
+    rate-limit error propagates so the caller (e.g. the async scheduler's
+    cooldown queue) can take the next layer of action.
     """
 
     def __init__(
@@ -51,11 +67,14 @@ class ThrottledModelClient(ModelClient):
         throttle_manager: ThrottleManager,
         provider_name: str,
         model_id: str,
+        *,
+        max_rate_limit_retries: int = DEFAULT_MAX_RATE_LIMIT_RETRIES,
     ) -> None:
         self._inner = inner
         self._tm = throttle_manager
         self._provider_name = provider_name
         self._model_id = model_id
+        self._max_rate_limit_retries = max_rate_limit_retries
 
     # --- ModelClient protocol delegation ---
 
@@ -81,30 +100,74 @@ class ThrottledModelClient(ModelClient):
     # --- Throttled methods ---
 
     def completion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        with self._throttled_sync(ThrottleDomain.CHAT):
-            return self._inner.completion(request)
+        return self._call_with_retry_sync(ThrottleDomain.CHAT, lambda: self._inner.completion(request))
 
     async def acompletion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        async with self._athrottled(ThrottleDomain.CHAT):
-            return await self._inner.acompletion(request)
+        return await self._call_with_retry_async(ThrottleDomain.CHAT, lambda: self._inner.acompletion(request))
 
     def embeddings(self, request: EmbeddingRequest) -> EmbeddingResponse:
-        with self._throttled_sync(ThrottleDomain.EMBEDDING):
-            return self._inner.embeddings(request)
+        return self._call_with_retry_sync(ThrottleDomain.EMBEDDING, lambda: self._inner.embeddings(request))
 
     async def aembeddings(self, request: EmbeddingRequest) -> EmbeddingResponse:
-        async with self._athrottled(ThrottleDomain.EMBEDDING):
-            return await self._inner.aembeddings(request)
+        return await self._call_with_retry_async(ThrottleDomain.EMBEDDING, lambda: self._inner.aembeddings(request))
 
     def generate_image(self, request: ImageGenerationRequest) -> ImageGenerationResponse:
         domain = self._image_domain(request)
-        with self._throttled_sync(domain):
-            return self._inner.generate_image(request)
+        return self._call_with_retry_sync(domain, lambda: self._inner.generate_image(request))
 
     async def agenerate_image(self, request: ImageGenerationRequest) -> ImageGenerationResponse:
         domain = self._image_domain(request)
-        async with self._athrottled(domain):
-            return await self._inner.agenerate_image(request)
+        return await self._call_with_retry_async(domain, lambda: self._inner.agenerate_image(request))
+
+    # --- Retry wrappers ---
+
+    def _call_with_retry_sync(self, domain: ThrottleDomain, inner_call: Callable[[], T]) -> T:
+        last_exc: ProviderError | None = None
+        for attempt in range(self._max_rate_limit_retries + 1):
+            try:
+                with self._throttled_sync(domain):
+                    return inner_call()
+            except ProviderError as exc:
+                if exc.kind != ProviderErrorKind.RATE_LIMIT:
+                    raise
+                last_exc = exc
+                if attempt < self._max_rate_limit_retries:
+                    logger.debug(
+                        "ThrottledModelClient %s/%s [%s] 429, retrying (%d/%d)",
+                        self._provider_name,
+                        self._model_id,
+                        domain.value,
+                        attempt + 1,
+                        self._max_rate_limit_retries,
+                    )
+        assert last_exc is not None
+        raise last_exc
+
+    async def _call_with_retry_async(
+        self,
+        domain: ThrottleDomain,
+        inner_call: Callable[[], Awaitable[T]],
+    ) -> T:
+        last_exc: ProviderError | None = None
+        for attempt in range(self._max_rate_limit_retries + 1):
+            try:
+                async with self._athrottled(domain):
+                    return await inner_call()
+            except ProviderError as exc:
+                if exc.kind != ProviderErrorKind.RATE_LIMIT:
+                    raise
+                last_exc = exc
+                if attempt < self._max_rate_limit_retries:
+                    logger.debug(
+                        "ThrottledModelClient %s/%s [%s] 429, retrying (%d/%d)",
+                        self._provider_name,
+                        self._model_id,
+                        domain.value,
+                        attempt + 1,
+                        self._max_rate_limit_retries,
+                    )
+        assert last_exc is not None
+        raise last_exc
 
     # --- Context managers ---
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/errors.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/errors.py
@@ -64,7 +64,19 @@ class GenerationValidationFailureError(Exception):
         super().__init__(message)
 
 
-class ModelRateLimitError(DataDesignerError): ...
+class ModelRateLimitError(DataDesignerError):
+    """Raised when the provider responds with a rate-limit signal.
+
+    ``retry_after`` carries the ``Retry-After`` value from the provider when
+    available, so retry queues can pace themselves to the server's hint
+    instead of guessing.
+    """
+
+    retry_after: float | None
+
+    def __init__(self, *args: Any, retry_after: float | None = None) -> None:
+        super().__init__(*args)
+        self.retry_after = retry_after
 
 
 class ModelQuotaExceededError(DataDesignerError): ...
@@ -379,12 +391,13 @@ def _raise_from_provider_error(
     if kind in _KIND_MAP and kind in _MESSAGES:
         error_cls = _KIND_MAP[kind]
         cause_str, solution_str = _MESSAGES[kind]
-        raise error_cls(
-            _attach_provider_message(
-                FormattedLLMErrorMessage(cause=cause_str, solution=solution_str),
-                exception,
-            )
-        ) from None
+        formatted = _attach_provider_message(
+            FormattedLLMErrorMessage(cause=cause_str, solution=solution_str),
+            exception,
+        )
+        if kind == ProviderErrorKind.RATE_LIMIT:
+            raise ModelRateLimitError(formatted, retry_after=exception.retry_after) from None
+        raise error_cls(formatted) from None
 
     if kind == ProviderErrorKind.UNSUPPORTED_CAPABILITY:
         raise ModelUnsupportedCapabilityError(

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -1016,6 +1016,154 @@ async def test_non_rate_limit_error_skips_cooldown_queue() -> None:
     assert total_calls <= 3, f"Expected at most 3 calls per row, got {total_calls}"
 
 
+class _PerRowRateLimitWithRetryAfter(ColumnGenerator[ExpressionColumnConfig]):
+    """Per-row generator that raises ``ModelRateLimitError(retry_after=...)``."""
+
+    fails_per_row: int = 0
+    retry_after_seconds: float = 1.0
+    counts: dict[int, int] = {}  # noqa: RUF012
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def generate(self, data: dict) -> dict:
+        rs = data.get("seed", -1)
+        n = self.counts.get(rs, 0) + 1
+        self.counts[rs] = n
+        if n <= self.fails_per_row:
+            raise ModelRateLimitError("429", retry_after=self.retry_after_seconds)
+        data[self.config.name] = f"ok_{rs}"
+        return data
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_cooldown_queue_honors_retry_after_from_exception() -> None:
+    """When the exception carries Retry-After, the cooldown queue waits at
+    least that long instead of falling back to the configured default."""
+    _PerRowRateLimitWithRetryAfter.counts = {}
+    _PerRowRateLimitWithRetryAfter.fails_per_row = 1
+    _PerRowRateLimitWithRetryAfter.retry_after_seconds = 0.4
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _PerRowRateLimitWithRetryAfter(config=_expr_config("col"), resource_provider=provider),
+    }
+    # Configured default is much smaller than the Retry-After hint.
+    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=0.01)
+    start = asyncio.get_event_loop().time()
+    await scheduler.run()
+    elapsed = asyncio.get_event_loop().time() - start
+    # 1 retry, retry_after=0.4 → must have waited at least ~0.4s.
+    assert elapsed >= 0.35, f"Expected to wait >= 0.35s for retry_after, waited {elapsed:.3f}s"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stale_cooldown_entries_dropped_when_row_dropped() -> None:
+    """If a sibling column drops the row, a cooldown-pending task on that row
+    must be pruned so the scheduler doesn't wait for the cooldown to expire."""
+    # Two cell columns: one rate-limits forever (will exhaust cooldown queue
+    # then defer to salvage which drops the row); one always succeeds.
+    _AlwaysRateLimitGenerator  # noqa: B018 - re-using existing fixture
+    _PerRowRateLimitGenerator.counts = {}
+    _PerRowRateLimitGenerator.fails_per_row = 99  # never recovers within budget
+    provider = _mock_provider()
+    configs = [
+        SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
+        LLMTextColumnConfig(name="col", prompt="{{ seed }}", model_alias=MODEL_ALIAS),
+    ]
+    strategies = {"seed": GenerationStrategy.FULL_COLUMN, "col": GenerationStrategy.CELL_BY_CELL}
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, 1)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    storage = MagicMock()
+    storage.dataset_name = "test"
+    storage.get_file_paths.return_value = {}
+    storage.write_batch_to_parquet_file.return_value = "/fake.parquet"
+    storage.move_partial_result_to_final_file_path.return_value = "/fake_final.parquet"
+    buffer_mgr = RowGroupBufferManager(storage)
+    scheduler = AsyncTaskScheduler(
+        generators={
+            "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+            "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
+        },
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        buffer_manager=buffer_mgr,
+        salvage_max_rounds=1,
+        rate_limit_cooldown_seconds=0.05,
+        disable_early_shutdown=True,
+    )
+    # Run completes within reasonable time even though the rate-limited task
+    # eventually exhausts. After the run, _cooldown_pending and the retry
+    # counter should be empty (stale entries pruned, terminal-failure tasks
+    # cleaned up).
+    await asyncio.wait_for(scheduler.run(), timeout=10.0)
+    assert scheduler._cooldown_pending == []
+    assert scheduler._rate_limit_retries == {}
+
+
+class _RateLimitedSeedGenerator(FromScratchColumnGenerator[ExpressionColumnConfig]):
+    """From-scratch generator that rate-limits the first ``fails`` times."""
+
+    fails: int = 0
+    calls: int = 0
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.FULL_COLUMN
+
+    def generate(self, data: Any) -> Any:
+        return data
+
+    def generate_from_scratch(self, num_records: int) -> Any:
+        type(self).calls += 1
+        if type(self).calls <= type(self).fails:
+            raise ModelRateLimitError("429")
+        return lazy.pd.DataFrame({self.config.name: list(range(num_records))})
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_from_scratch_rate_limit_routes_to_salvage_not_cooldown_queue() -> None:
+    """A rate-limited from_scratch task must not vanish into the cooldown
+    queue (the frontier doesn't re-emit seed tasks). Route to salvage so it
+    actually gets retried."""
+    _RateLimitedSeedGenerator.fails = 1
+    _RateLimitedSeedGenerator.calls = 0
+    provider = _mock_provider()
+    configs = [
+        SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
+        LLMTextColumnConfig(name="col", prompt="{{ seed }}", model_alias=MODEL_ALIAS),
+    ]
+    strategies = {"seed": GenerationStrategy.FULL_COLUMN, "col": GenerationStrategy.CELL_BY_CELL}
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, 1)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    storage = MagicMock()
+    storage.dataset_name = "test"
+    storage.get_file_paths.return_value = {}
+    storage.write_batch_to_parquet_file.return_value = "/fake.parquet"
+    storage.move_partial_result_to_final_file_path.return_value = "/fake_final.parquet"
+    buffer_mgr = RowGroupBufferManager(storage)
+    scheduler = AsyncTaskScheduler(
+        generators={
+            "seed": _RateLimitedSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+            "col": MockCellGenerator(config=_expr_config("col"), resource_provider=provider),
+        },
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        buffer_manager=buffer_mgr,
+        rate_limit_cooldown_seconds=0.05,
+    )
+    await asyncio.wait_for(scheduler.run(), timeout=5.0)
+    # Salvage retried the from_scratch task, so we should have at least 2 calls.
+    assert _RateLimitedSeedGenerator.calls >= 2, (
+        f"Expected at least 2 calls (1 fail + 1 salvage retry), got {_RateLimitedSeedGenerator.calls}"
+    )
+
+
 @pytest.mark.asyncio(loop_scope="session")
 async def test_scheduler_on_before_checkpoint_callback() -> None:
     """on_before_checkpoint is called before each row group is checkpointed."""

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -868,11 +868,12 @@ class _CountingInternalServerGenerator(ColumnGenerator[ExpressionColumnConfig]):
         raise ModelInternalServerError("500")
 
 
-def _make_inline_retry_scheduler(
+def _make_rate_limit_scheduler(
     generators: dict[str, ColumnGenerator],
     num_rows: int = 2,
     *,
     disable_early_shutdown: bool = False,
+    rate_limit_cooldown_seconds: float = 0.05,
 ) -> tuple[AsyncTaskScheduler, CompletionTracker]:
     configs = [
         SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
@@ -897,13 +898,15 @@ def _make_inline_retry_scheduler(
         shutdown_error_rate=0.5,
         shutdown_error_window=10,
         disable_early_shutdown=disable_early_shutdown,
+        rate_limit_cooldown_seconds=rate_limit_cooldown_seconds,
     )
     return scheduler, tracker
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_inline_retry_recovers_within_budget() -> None:
-    """A task that fails 3 times then succeeds is recovered inline (not via salvage)."""
+async def test_rate_limit_recovers_via_cooldown_queue() -> None:
+    """A task that fails 3 times then succeeds is recovered through the cooldown
+    queue without ever falling through to salvage."""
     _PerRowRateLimitGenerator.counts = {}
     _PerRowRateLimitGenerator.fails_per_row = 3  # under DEFAULT_RATE_LIMIT_RETRIES (5)
     provider = _mock_provider()
@@ -911,41 +914,102 @@ async def test_inline_retry_recovers_within_budget() -> None:
         "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
         "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
     }
-    scheduler, tracker = _make_inline_retry_scheduler(generators, num_rows=2)
+    scheduler, tracker = _make_rate_limit_scheduler(generators, num_rows=2)
     await scheduler.run()
 
     assert tracker.is_row_group_complete(0, 2, ["seed", "col"])
-    # Inline recovery: nothing left in the salvage queue.
+    # Cooldown-queue recovery: nothing left in either retry surface.
     assert scheduler._deferred == []
+    assert scheduler._cooldown_pending == []
+    # Per-task retry counter was cleared on success.
+    assert scheduler._rate_limit_retries == {}
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_inline_retry_exhaustion_does_not_trigger_early_shutdown() -> None:
-    """Always-rate-limited tasks exhaust inline retries and salvage, but rate-limit
-    errors never count toward the early-shutdown error rate."""
+async def test_rate_limit_exhaustion_does_not_trigger_early_shutdown() -> None:
+    """Always-rate-limited tasks exhaust the cooldown queue and salvage, but
+    rate-limit errors never count toward the early-shutdown error rate."""
     provider = _mock_provider()
     generators = {
         "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
         "col": _AlwaysRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
     }
-    scheduler, _ = _make_inline_retry_scheduler(generators, num_rows=1)
+    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1)
     await scheduler.run()
     # Even with sustained 429s the error-rate gate never fires.
     assert not scheduler._early_shutdown
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_non_rate_limit_error_is_not_retried_inline() -> None:
-    """ModelInternalServerError must not trigger the inline retry loop -
-    only ModelRateLimitError does. Other retryable errors flow to salvage."""
+async def test_rate_limited_task_releases_permits_during_cooldown() -> None:
+    """A worker awaiting a cooldown must not pin the LLM-wait or submission
+    permit; both pools should return to full strength while the task waits."""
+    _PerRowRateLimitGenerator.counts = {}
+    _PerRowRateLimitGenerator.fails_per_row = 2
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
+    }
+    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=0.5)
+    submission_max = scheduler._submission_semaphore.available_permits
+    llm_max = scheduler._llm_wait_semaphore.available_permits
+
+    async def watch_permits() -> tuple[int, int]:
+        # While the task is in the cooldown queue (after first 429), peek at permits.
+        for _ in range(50):
+            await asyncio.sleep(0.05)
+            if scheduler._cooldown_pending:
+                return (
+                    scheduler._submission_semaphore.available_permits,
+                    scheduler._llm_wait_semaphore.available_permits,
+                )
+        return (submission_max, llm_max)
+
+    runner = asyncio.create_task(scheduler.run())
+    permits_during_cooldown = await watch_permits()
+    await runner
+
+    assert permits_during_cooldown == (submission_max, llm_max), (
+        f"Expected pools to be at full strength during cooldown, got {permits_during_cooldown}"
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_unthrottled_rate_limit_does_not_hot_loop() -> None:
+    """A custom generator that raises ModelRateLimitError directly (no throttle
+    in the loop) must still be paced by the cooldown queue, not retried in a
+    tight loop."""
+    _PerRowRateLimitGenerator.counts = {}
+    _PerRowRateLimitGenerator.fails_per_row = 4  # under DEFAULT_RATE_LIMIT_RETRIES
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
+    }
+    cooldown = 0.1
+    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=cooldown)
+    start = asyncio.get_event_loop().time()
+    await scheduler.run()
+    elapsed = asyncio.get_event_loop().time() - start
+    # 4 retries with the configured cooldown each = at least ~4 * cooldown seconds.
+    # Allow some slack but ensure we didn't hot-loop (sub-cooldown) the retries.
+    assert elapsed >= 4 * cooldown * 0.8, f"Expected at least {4 * cooldown * 0.8}s of pacing, got {elapsed:.3f}s"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_non_rate_limit_error_skips_cooldown_queue() -> None:
+    """ModelInternalServerError must go straight to salvage, not the cooldown
+    queue. Only ModelRateLimitError uses the cooldown path."""
     _CountingInternalServerGenerator.counts = {}
     provider = _mock_provider()
     generators = {
         "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
         "col": _CountingInternalServerGenerator(config=_expr_config("col"), resource_provider=provider),
     }
-    scheduler, _ = _make_inline_retry_scheduler(generators, num_rows=1, disable_early_shutdown=True)
+    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, disable_early_shutdown=True)
     await scheduler.run()
+    assert scheduler._cooldown_pending == []
     # 1 main attempt + up to 2 salvage rounds = 3 calls per row max.
     # The inline rate-limit path would have produced 6+ per row.
     total_calls = sum(_CountingInternalServerGenerator.counts.values())

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -822,6 +822,136 @@ async def test_rate_limit_errors_do_not_trigger_early_shutdown() -> None:
     assert tracker.is_row_group_complete(0, 10, ["seed", "col"])
 
 
+class _PerRowRateLimitGenerator(ColumnGenerator[ExpressionColumnConfig]):
+    """Per-row rate limiter so concurrent cells don't race on a shared counter."""
+
+    fails_per_row: int = 0
+    counts: dict[int, int] = {}  # noqa: RUF012
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def generate(self, data: dict) -> dict:
+        row_seed = data.get("seed", -1)
+        n = self.counts.get(row_seed, 0) + 1
+        self.counts[row_seed] = n
+        if n <= self.fails_per_row:
+            raise ModelRateLimitError("429")
+        data[self.config.name] = f"ok_{row_seed}"
+        return data
+
+
+class _AlwaysRateLimitGenerator(ColumnGenerator[ExpressionColumnConfig]):
+    """Always raises ModelRateLimitError - exercises retry exhaustion."""
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def generate(self, data: dict) -> dict:
+        raise ModelRateLimitError("429")
+
+
+class _CountingInternalServerGenerator(ColumnGenerator[ExpressionColumnConfig]):
+    """Always raises ModelInternalServerError; counts calls per row."""
+
+    counts: dict[int, int] = {}  # noqa: RUF012
+
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def generate(self, data: dict) -> dict:
+        rs = data.get("seed", -1)
+        self.counts[rs] = self.counts.get(rs, 0) + 1
+        raise ModelInternalServerError("500")
+
+
+def _make_inline_retry_scheduler(
+    generators: dict[str, ColumnGenerator],
+    num_rows: int = 2,
+    *,
+    disable_early_shutdown: bool = False,
+) -> tuple[AsyncTaskScheduler, CompletionTracker]:
+    configs = [
+        SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]}),
+        LLMTextColumnConfig(name="col", prompt="{{ seed }}", model_alias=MODEL_ALIAS),
+    ]
+    strategies = {"seed": GenerationStrategy.FULL_COLUMN, "col": GenerationStrategy.CELL_BY_CELL}
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, num_rows)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    storage = MagicMock()
+    storage.dataset_name = "test"
+    storage.get_file_paths.return_value = {}
+    storage.write_batch_to_parquet_file.return_value = "/fake.parquet"
+    storage.move_partial_result_to_final_file_path.return_value = "/fake_final.parquet"
+    buffer_mgr = RowGroupBufferManager(storage)
+    scheduler = AsyncTaskScheduler(
+        generators=generators,
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        buffer_manager=buffer_mgr,
+        shutdown_error_rate=0.5,
+        shutdown_error_window=10,
+        disable_early_shutdown=disable_early_shutdown,
+    )
+    return scheduler, tracker
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_inline_retry_recovers_within_budget() -> None:
+    """A task that fails 3 times then succeeds is recovered inline (not via salvage)."""
+    _PerRowRateLimitGenerator.counts = {}
+    _PerRowRateLimitGenerator.fails_per_row = 3  # under DEFAULT_RATE_LIMIT_RETRIES (5)
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
+    }
+    scheduler, tracker = _make_inline_retry_scheduler(generators, num_rows=2)
+    await scheduler.run()
+
+    assert tracker.is_row_group_complete(0, 2, ["seed", "col"])
+    # Inline recovery: nothing left in the salvage queue.
+    assert scheduler._deferred == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_inline_retry_exhaustion_does_not_trigger_early_shutdown() -> None:
+    """Always-rate-limited tasks exhaust inline retries and salvage, but rate-limit
+    errors never count toward the early-shutdown error rate."""
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _AlwaysRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
+    }
+    scheduler, _ = _make_inline_retry_scheduler(generators, num_rows=1)
+    await scheduler.run()
+    # Even with sustained 429s the error-rate gate never fires.
+    assert not scheduler._early_shutdown
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_non_rate_limit_error_is_not_retried_inline() -> None:
+    """ModelInternalServerError must not trigger the inline retry loop -
+    only ModelRateLimitError does. Other retryable errors flow to salvage."""
+    _CountingInternalServerGenerator.counts = {}
+    provider = _mock_provider()
+    generators = {
+        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
+        "col": _CountingInternalServerGenerator(config=_expr_config("col"), resource_provider=provider),
+    }
+    scheduler, _ = _make_inline_retry_scheduler(generators, num_rows=1, disable_early_shutdown=True)
+    await scheduler.run()
+    # 1 main attempt + up to 2 salvage rounds = 3 calls per row max.
+    # The inline rate-limit path would have produced 6+ per row.
+    total_calls = sum(_CountingInternalServerGenerator.counts.values())
+    assert total_calls <= 3, f"Expected at most 3 calls per row, got {total_calls}"
+
+
 @pytest.mark.asyncio(loop_scope="session")
 async def test_scheduler_on_before_checkpoint_callback() -> None:
     """on_before_checkpoint is called before each row group is checkpointed."""

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -823,9 +823,14 @@ async def test_rate_limit_errors_do_not_trigger_early_shutdown() -> None:
 
 
 class _PerRowRateLimitGenerator(ColumnGenerator[ExpressionColumnConfig]):
-    """Per-row rate limiter so concurrent cells don't race on a shared counter."""
+    """Per-row rate limiter so concurrent cells don't race on a shared counter.
+
+    ``retry_after_seconds`` is attached to the raised ``ModelRateLimitError``
+    to test that the cooldown queue honors the provider hint.
+    """
 
     fails_per_row: int = 0
+    retry_after_seconds: float | None = None
     counts: dict[int, int] = {}  # noqa: RUF012
 
     @staticmethod
@@ -837,7 +842,7 @@ class _PerRowRateLimitGenerator(ColumnGenerator[ExpressionColumnConfig]):
         n = self.counts.get(row_seed, 0) + 1
         self.counts[row_seed] = n
         if n <= self.fails_per_row:
-            raise ModelRateLimitError("429")
+            raise ModelRateLimitError("429", retry_after=self.retry_after_seconds)
         data[self.config.name] = f"ok_{row_seed}"
         return data
 
@@ -904,25 +909,42 @@ def _make_rate_limit_scheduler(
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_rate_limit_recovers_via_cooldown_queue() -> None:
-    """A task that fails 3 times then succeeds is recovered through the cooldown
-    queue without ever falling through to salvage."""
+@pytest.mark.parametrize(
+    ("fails_per_row", "retry_after_seconds", "min_elapsed"),
+    [
+        pytest.param(3, None, None, id="default-cooldown-3-fails"),
+        pytest.param(1, 0.4, 0.35, id="retry-after-honored"),
+    ],
+)
+async def test_rate_limit_recovers_via_cooldown_queue(
+    fails_per_row: int, retry_after_seconds: float | None, min_elapsed: float | None
+) -> None:
+    """Tasks that fail with rate-limit recover through the cooldown queue
+    without falling through to salvage. When the exception carries
+    ``Retry-After``, the queue waits at least that long instead of using the
+    configured default."""
     _PerRowRateLimitGenerator.counts = {}
-    _PerRowRateLimitGenerator.fails_per_row = 3  # under DEFAULT_RATE_LIMIT_RETRIES (5)
+    _PerRowRateLimitGenerator.fails_per_row = fails_per_row
+    _PerRowRateLimitGenerator.retry_after_seconds = retry_after_seconds
     provider = _mock_provider()
     generators = {
         "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
         "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
     }
-    scheduler, tracker = _make_rate_limit_scheduler(generators, num_rows=2)
+    # Configured default is small so the retry_after case actually has to
+    # honor the larger hint to delay long enough.
+    scheduler, tracker = _make_rate_limit_scheduler(generators, num_rows=2, rate_limit_cooldown_seconds=0.01)
+    start = asyncio.get_event_loop().time()
     await scheduler.run()
+    elapsed = asyncio.get_event_loop().time() - start
 
     assert tracker.is_row_group_complete(0, 2, ["seed", "col"])
-    # Cooldown-queue recovery: nothing left in either retry surface.
+    # Cooldown-queue recovery: nothing left behind anywhere.
     assert scheduler._deferred == []
     assert scheduler._cooldown_pending == []
-    # Per-task retry counter was cleared on success.
     assert scheduler._rate_limit_retries == {}
+    if min_elapsed is not None:
+        assert elapsed >= min_elapsed, f"Expected pacing >= {min_elapsed}s, got {elapsed:.3f}s"
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -936,70 +958,12 @@ async def test_rate_limit_exhaustion_does_not_trigger_early_shutdown() -> None:
     }
     scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1)
     await scheduler.run()
-    # Even with sustained 429s the error-rate gate never fires.
     assert not scheduler._early_shutdown
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_rate_limited_task_releases_permits_during_cooldown() -> None:
-    """A worker awaiting a cooldown must not pin the LLM-wait or submission
-    permit; both pools should return to full strength while the task waits."""
-    _PerRowRateLimitGenerator.counts = {}
-    _PerRowRateLimitGenerator.fails_per_row = 2
-    provider = _mock_provider()
-    generators = {
-        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
-        "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
-    }
-    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=0.5)
-    submission_max = scheduler._submission_semaphore.available_permits
-    llm_max = scheduler._llm_wait_semaphore.available_permits
-
-    async def watch_permits() -> tuple[int, int]:
-        # While the task is in the cooldown queue (after first 429), peek at permits.
-        for _ in range(50):
-            await asyncio.sleep(0.05)
-            if scheduler._cooldown_pending:
-                return (
-                    scheduler._submission_semaphore.available_permits,
-                    scheduler._llm_wait_semaphore.available_permits,
-                )
-        return (submission_max, llm_max)
-
-    runner = asyncio.create_task(scheduler.run())
-    permits_during_cooldown = await watch_permits()
-    await runner
-
-    assert permits_during_cooldown == (submission_max, llm_max), (
-        f"Expected pools to be at full strength during cooldown, got {permits_during_cooldown}"
-    )
-
-
-@pytest.mark.asyncio(loop_scope="session")
-async def test_unthrottled_rate_limit_does_not_hot_loop() -> None:
-    """A custom generator that raises ModelRateLimitError directly (no throttle
-    in the loop) must still be paced by the cooldown queue, not retried in a
-    tight loop."""
-    _PerRowRateLimitGenerator.counts = {}
-    _PerRowRateLimitGenerator.fails_per_row = 4  # under DEFAULT_RATE_LIMIT_RETRIES
-    provider = _mock_provider()
-    generators = {
-        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
-        "col": _PerRowRateLimitGenerator(config=_expr_config("col"), resource_provider=provider),
-    }
-    cooldown = 0.1
-    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=cooldown)
-    start = asyncio.get_event_loop().time()
-    await scheduler.run()
-    elapsed = asyncio.get_event_loop().time() - start
-    # 4 retries with the configured cooldown each = at least ~4 * cooldown seconds.
-    # Allow some slack but ensure we didn't hot-loop (sub-cooldown) the retries.
-    assert elapsed >= 4 * cooldown * 0.8, f"Expected at least {4 * cooldown * 0.8}s of pacing, got {elapsed:.3f}s"
-
-
-@pytest.mark.asyncio(loop_scope="session")
 async def test_non_rate_limit_error_skips_cooldown_queue() -> None:
-    """ModelInternalServerError must go straight to salvage, not the cooldown
+    """ModelInternalServerError goes straight to salvage, not the cooldown
     queue. Only ModelRateLimitError uses the cooldown path."""
     _CountingInternalServerGenerator.counts = {}
     provider = _mock_provider()
@@ -1010,52 +974,10 @@ async def test_non_rate_limit_error_skips_cooldown_queue() -> None:
     scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, disable_early_shutdown=True)
     await scheduler.run()
     assert scheduler._cooldown_pending == []
-    # 1 main attempt + up to 2 salvage rounds = 3 calls per row max.
-    # The inline rate-limit path would have produced 6+ per row.
+    # 1 main attempt + up to 2 salvage rounds = 3 calls per row max; the
+    # cooldown-queue path would have produced 6+.
     total_calls = sum(_CountingInternalServerGenerator.counts.values())
     assert total_calls <= 3, f"Expected at most 3 calls per row, got {total_calls}"
-
-
-class _PerRowRateLimitWithRetryAfter(ColumnGenerator[ExpressionColumnConfig]):
-    """Per-row generator that raises ``ModelRateLimitError(retry_after=...)``."""
-
-    fails_per_row: int = 0
-    retry_after_seconds: float = 1.0
-    counts: dict[int, int] = {}  # noqa: RUF012
-
-    @staticmethod
-    def get_generation_strategy() -> GenerationStrategy:
-        return GenerationStrategy.CELL_BY_CELL
-
-    def generate(self, data: dict) -> dict:
-        rs = data.get("seed", -1)
-        n = self.counts.get(rs, 0) + 1
-        self.counts[rs] = n
-        if n <= self.fails_per_row:
-            raise ModelRateLimitError("429", retry_after=self.retry_after_seconds)
-        data[self.config.name] = f"ok_{rs}"
-        return data
-
-
-@pytest.mark.asyncio(loop_scope="session")
-async def test_cooldown_queue_honors_retry_after_from_exception() -> None:
-    """When the exception carries Retry-After, the cooldown queue waits at
-    least that long instead of falling back to the configured default."""
-    _PerRowRateLimitWithRetryAfter.counts = {}
-    _PerRowRateLimitWithRetryAfter.fails_per_row = 1
-    _PerRowRateLimitWithRetryAfter.retry_after_seconds = 0.4
-    provider = _mock_provider()
-    generators = {
-        "seed": MockSeedGenerator(config=_expr_config("seed"), resource_provider=provider),
-        "col": _PerRowRateLimitWithRetryAfter(config=_expr_config("col"), resource_provider=provider),
-    }
-    # Configured default is much smaller than the Retry-After hint.
-    scheduler, _ = _make_rate_limit_scheduler(generators, num_rows=1, rate_limit_cooldown_seconds=0.01)
-    start = asyncio.get_event_loop().time()
-    await scheduler.run()
-    elapsed = asyncio.get_event_loop().time() - start
-    # 1 retry, retry_after=0.4 → must have waited at least ~0.4s.
-    assert elapsed >= 0.35, f"Expected to wait >= 0.35s for retry_after, waited {elapsed:.3f}s"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
@@ -553,3 +553,99 @@ def test_saturation_detection(
         tm.release_success(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
 
     assert tm.is_saturated(PROVIDER, MODEL, DOMAIN) == expected_saturated
+
+
+# --- Retry-After handling ---
+
+
+def test_retry_after_header_is_never_shortened_below_server_value() -> None:
+    """An explicit ``Retry-After`` larger than ``max_cooldown_seconds`` must be
+    honored as a floor. The cap only applies to synthetic backoff growth."""
+    tm = ThrottleManager(
+        ThrottleConfig(
+            cooldown_seconds=2.0,
+            cooldown_backoff_factor=2.0,
+            max_cooldown_seconds=30.0,
+        )
+    )
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    # First 429 at floor: base = retry_after = 120s, no exp yet (consecutive_429s == 1).
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, retry_after=120.0, now=0.0)
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    assert state.blocked_until - 0.0 == pytest.approx(120.0)
+
+    # Second 429 at floor with the same Retry-After. Synthetic backoff would be
+    # min(120 * 2, 30) = 30s, but the server told us to wait 120s, so honor that.
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=200.0)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, retry_after=120.0, now=200.0)
+    cooldown = state.blocked_until - 200.0
+    assert cooldown >= 120.0, f"Retry-After of 120s was clipped to {cooldown}s"
+
+
+def test_default_cooldown_backoff_still_capped_when_no_retry_after() -> None:
+    """Without an explicit Retry-After, exponential backoff is still capped at max_cooldown_seconds."""
+    tm = ThrottleManager(
+        ThrottleConfig(
+            cooldown_seconds=2.0,
+            cooldown_backoff_factor=2.0,
+            max_cooldown_seconds=30.0,
+        )
+    )
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+    t = 0.0
+    for _ in range(6):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 100.0
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    last_cooldown = state.blocked_until - (t - 100.0)
+    assert last_cooldown == pytest.approx(30.0)
+
+
+# --- Streak resets on non-rate-limit failures ---
+
+
+def test_consecutive_429s_reset_on_non_rate_limit_failure() -> None:
+    """A non-RL failure (e.g. 500, timeout) breaks the consecutive-429 streak,
+    so a sequence ``429 -> 500 -> 429`` is treated as two fresh cascades, not
+    sustained throttling."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    # 429: consecutive_429s == 1, base cooldown
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    assert state.consecutive_429s == 1
+
+    # 500: streak resets
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=10.0)
+    tm.release_failure(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=10.0)
+    assert state.consecutive_429s == 0
+
+    # 429 again: treated as first in cascade -> base cooldown, not exp.
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=20.0)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=20.0)
+    cooldown = state.blocked_until - 20.0
+    assert cooldown == pytest.approx(2.0)
+
+
+def test_saturation_cleared_on_non_rate_limit_failure() -> None:
+    """release_failure clears the saturated flag (mixed failures shouldn't keep us pinned)."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+    t = 0.0
+    for _ in range(2):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 10.0
+    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_failure(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
@@ -555,97 +555,70 @@ def test_saturation_detection(
     assert tm.is_saturated(PROVIDER, MODEL, DOMAIN) == expected_saturated
 
 
-# --- Retry-After handling ---
+# --- Retry-After handling and synthetic backoff cap ---
 
 
-def test_retry_after_header_is_never_shortened_below_server_value() -> None:
-    """An explicit ``Retry-After`` larger than ``max_cooldown_seconds`` must be
-    honored as a floor. The cap only applies to synthetic backoff growth."""
-    tm = ThrottleManager(
-        ThrottleConfig(
-            cooldown_seconds=2.0,
-            cooldown_backoff_factor=2.0,
-            max_cooldown_seconds=30.0,
-        )
-    )
+@pytest.mark.parametrize(
+    ("retry_after", "expected_min", "expected_approx"),
+    [
+        # Server hint > max_cooldown_seconds: hint is honored as a floor.
+        pytest.param(120.0, 120.0, None, id="retry-after-honored-above-cap"),
+        # No server hint: synthetic exponential backoff is capped at max_cooldown_seconds.
+        pytest.param(None, None, 30.0, id="no-retry-after-capped-at-max"),
+    ],
+)
+def test_cooldown_respects_retry_after_and_caps_synthetic_growth(
+    retry_after: float | None, expected_min: float | None, expected_approx: float | None
+) -> None:
+    """``max_cooldown_seconds`` only caps synthetic exponential backoff; an
+    explicit ``Retry-After`` is always honored as a floor."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, max_cooldown_seconds=30.0))
     tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
 
-    # First 429 at floor: base = retry_after = 120s, no exp yet (consecutive_429s == 1).
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, retry_after=120.0, now=0.0)
-    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
-    assert state is not None
-    assert state.blocked_until - 0.0 == pytest.approx(120.0)
-
-    # Second 429 at floor with the same Retry-After. Synthetic backoff would be
-    # min(120 * 2, 30) = 30s, but the server told us to wait 120s, so honor that.
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=200.0)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, retry_after=120.0, now=200.0)
-    cooldown = state.blocked_until - 200.0
-    assert cooldown >= 120.0, f"Retry-After of 120s was clipped to {cooldown}s"
-
-
-def test_default_cooldown_backoff_still_capped_when_no_retry_after() -> None:
-    """Without an explicit Retry-After, exponential backoff is still capped at max_cooldown_seconds."""
-    tm = ThrottleManager(
-        ThrottleConfig(
-            cooldown_seconds=2.0,
-            cooldown_backoff_factor=2.0,
-            max_cooldown_seconds=30.0,
-        )
-    )
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
     t = 0.0
     for _ in range(6):
         tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        t += 100.0
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, retry_after=retry_after, now=t)
+        t += 200.0  # past any cooldown so each iteration is a fresh acquire
+
     state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
     assert state is not None
-    last_cooldown = state.blocked_until - (t - 100.0)
-    assert last_cooldown == pytest.approx(30.0)
+    last_cooldown = state.blocked_until - (t - 200.0)
+    if expected_approx is not None:
+        assert last_cooldown == pytest.approx(expected_approx)
+    if expected_min is not None:
+        assert last_cooldown >= expected_min, f"Retry-After clipped to {last_cooldown}s"
 
 
-# --- Streak resets on non-rate-limit failures ---
+# --- Non-rate-limit failures break the cascade ---
 
 
-def test_consecutive_429s_reset_on_non_rate_limit_failure() -> None:
-    """A non-RL failure (e.g. 500, timeout) breaks the consecutive-429 streak,
-    so a sequence ``429 -> 500 -> 429`` is treated as two fresh cascades, not
-    sustained throttling."""
-    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0))
+def test_release_failure_resets_streak_and_saturation() -> None:
+    """A non-RL failure (5xx, timeout, etc.) clears ``consecutive_429s`` and
+    the saturated flag, so a later 429 starts a fresh cascade rather than
+    inheriting state from earlier rate limits."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, saturation_threshold=2))
     tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
 
-    # 429: consecutive_429s == 1, base cooldown
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=0.0)
-    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
-    assert state is not None
-    assert state.consecutive_429s == 1
-
-    # 500: streak resets
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=10.0)
-    tm.release_failure(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=10.0)
-    assert state.consecutive_429s == 0
-
-    # 429 again: treated as first in cascade -> base cooldown, not exp.
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=20.0)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=20.0)
-    cooldown = state.blocked_until - 20.0
-    assert cooldown == pytest.approx(2.0)
-
-
-def test_saturation_cleared_on_non_rate_limit_failure() -> None:
-    """release_failure clears the saturated flag (mixed failures shouldn't keep us pinned)."""
-    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+    # Two 429s at floor → saturated, consecutive_429s == 2.
     t = 0.0
     for _ in range(2):
         tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         t += 10.0
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    assert state.consecutive_429s == 2
     assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
 
+    # Non-RL failure clears both fields.
     tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
     tm.release_failure(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert state.consecutive_429s == 0
     assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+    t += 10.0
+
+    # Next 429 is treated as a fresh cascade: base cooldown, no exp backoff.
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert state.blocked_until - t == pytest.approx(2.0)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
@@ -472,3 +472,116 @@ def test_concurrent_acquire_release_no_errors() -> None:
     state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
     assert state is not None
     assert state.in_flight == 0
+
+
+# --- Exponential cooldown backoff at floor ---
+
+
+def test_exponential_cooldown_at_floor() -> None:
+    """Consecutive 429s at minimum concurrency apply exponential cooldown backoff."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, max_cooldown_seconds=30.0))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    t = 0.0
+    # First 429: at floor (limit=1), consecutive_429s goes to 1 (first in cascade) - base cooldown
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    assert state.blocked_until == pytest.approx(2.0)  # base cooldown
+
+    # Second 429: consecutive_429s=2, at floor -> 2.0 * 2^1 = 4.0
+    t = 10.0
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert state.blocked_until == pytest.approx(14.0)  # 10 + 4.0
+
+    # Third 429: consecutive_429s=3, at floor -> 2.0 * 2^2 = 8.0
+    t = 20.0
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert state.blocked_until == pytest.approx(28.0)  # 20 + 8.0
+
+
+def test_cooldown_backoff_capped_at_max() -> None:
+    """Exponential cooldown is capped at max_cooldown_seconds."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=10.0, max_cooldown_seconds=15.0))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    t = 0.0
+    for i in range(5):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 100.0
+
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    # Cooldown should never exceed 15s regardless of exponent
+    assert state.blocked_until <= t + 15.0
+
+
+def test_no_backoff_above_floor() -> None:
+    """Exponential backoff only applies when concurrency is at the floor."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, max_cooldown_seconds=30.0))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=10)
+
+    t = 0.0
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+
+    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
+    assert state is not None
+    # Limit reduced from 10 to 7 (floor(10*0.75)), above MIN_LIMIT=1
+    assert state.current_limit > 1
+    # Cooldown should be base, no backoff
+    assert state.blocked_until == pytest.approx(2.0)
+
+
+# --- Saturation detection ---
+
+
+def test_saturation_after_threshold() -> None:
+    """Domain is marked saturated after saturation_threshold consecutive 429s at floor."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=3))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    t = 0.0
+    for i in range(3):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 10.0
+
+    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+
+
+def test_saturation_cleared_on_success() -> None:
+    """A successful release clears the saturation flag."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+
+    t = 0.0
+    for i in range(2):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 10.0
+
+    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+
+    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    tm.release_success(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+    assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+
+
+def test_no_saturation_above_floor() -> None:
+    """Saturation only triggers when concurrency is at the minimum floor."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=10)
+
+    t = 0.0
+    # First 429 reduces from 10 to 7 (above floor), subsequent ones are cascade
+    for i in range(5):
+        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
+        t += 10.0
+
+    assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py
@@ -477,111 +477,79 @@ def test_concurrent_acquire_release_no_errors() -> None:
 # --- Exponential cooldown backoff at floor ---
 
 
-def test_exponential_cooldown_at_floor() -> None:
-    """Consecutive 429s at minimum concurrency apply exponential cooldown backoff."""
-    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, max_cooldown_seconds=30.0))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+@pytest.mark.parametrize(
+    ("max_parallel", "num_429s", "backoff_factor", "max_cooldown", "expect_backoff"),
+    [
+        pytest.param(1, 3, 2.0, 30.0, True, id="at-floor-applies-exponential-backoff"),
+        pytest.param(1, 5, 10.0, 15.0, True, id="at-floor-capped-at-max-cooldown"),
+        pytest.param(10, 1, 2.0, 30.0, False, id="above-floor-uses-base-cooldown"),
+    ],
+)
+def test_cooldown_backoff_at_floor(
+    max_parallel: int,
+    num_429s: int,
+    backoff_factor: float,
+    max_cooldown: float,
+    expect_backoff: bool,
+) -> None:
+    """Exponential cooldown backoff applies only at minimum concurrency and is capped."""
+    base = 2.0
+    tm = ThrottleManager(
+        ThrottleConfig(
+            cooldown_seconds=base,
+            cooldown_backoff_factor=backoff_factor,
+            max_cooldown_seconds=max_cooldown,
+        )
+    )
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=max_parallel)
 
     t = 0.0
-    # First 429: at floor (limit=1), consecutive_429s goes to 1 (first in cascade) - base cooldown
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
-    assert state is not None
-    assert state.blocked_until == pytest.approx(2.0)  # base cooldown
-
-    # Second 429: consecutive_429s=2, at floor -> 2.0 * 2^1 = 4.0
-    t = 10.0
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    assert state.blocked_until == pytest.approx(14.0)  # 10 + 4.0
-
-    # Third 429: consecutive_429s=3, at floor -> 2.0 * 2^2 = 8.0
-    t = 20.0
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    assert state.blocked_until == pytest.approx(28.0)  # 20 + 8.0
-
-
-def test_cooldown_backoff_capped_at_max() -> None:
-    """Exponential cooldown is capped at max_cooldown_seconds."""
-    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=10.0, max_cooldown_seconds=15.0))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
-
-    t = 0.0
-    for i in range(5):
+    for _ in range(num_429s):
         tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         t += 100.0
 
     state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
     assert state is not None
-    # Cooldown should never exceed 15s regardless of exponent
-    assert state.blocked_until <= t + 15.0
-
-
-def test_no_backoff_above_floor() -> None:
-    """Exponential backoff only applies when concurrency is at the floor."""
-    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=2.0, cooldown_backoff_factor=2.0, max_cooldown_seconds=30.0))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=10)
-
-    t = 0.0
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-
-    state = tm.get_domain_state(PROVIDER, MODEL, DOMAIN)
-    assert state is not None
-    # Limit reduced from 10 to 7 (floor(10*0.75)), above MIN_LIMIT=1
-    assert state.current_limit > 1
-    # Cooldown should be base, no backoff
-    assert state.blocked_until == pytest.approx(2.0)
+    last_cooldown = state.blocked_until - (t - 100.0)
+    if expect_backoff:
+        assert last_cooldown <= max_cooldown
+        if num_429s > 1 and max_parallel == 1:
+            assert last_cooldown > base
+    else:
+        assert last_cooldown == pytest.approx(base)
 
 
 # --- Saturation detection ---
 
 
-def test_saturation_after_threshold() -> None:
-    """Domain is marked saturated after saturation_threshold consecutive 429s at floor."""
-    tm = ThrottleManager(ThrottleConfig(saturation_threshold=3))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
+@pytest.mark.parametrize(
+    ("max_parallel", "num_429s", "threshold", "success_after", "expected_saturated"),
+    [
+        pytest.param(1, 3, 3, False, True, id="saturated-after-threshold-at-floor"),
+        pytest.param(1, 2, 2, True, False, id="saturation-cleared-on-success"),
+        pytest.param(10, 5, 2, False, False, id="no-saturation-above-floor"),
+    ],
+)
+def test_saturation_detection(
+    max_parallel: int,
+    num_429s: int,
+    threshold: int,
+    success_after: bool,
+    expected_saturated: bool,
+) -> None:
+    """Saturation is marked at floor after threshold 429s, cleared on success, and skipped above floor."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=threshold))
+    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=max_parallel)
 
     t = 0.0
-    for i in range(3):
+    for _ in range(num_429s):
         tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
         t += 10.0
 
-    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
-
-
-def test_saturation_cleared_on_success() -> None:
-    """A successful release clears the saturation flag."""
-    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=1)
-
-    t = 0.0
-    for i in range(2):
+    if success_after:
         tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        t += 10.0
+        tm.release_success(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
 
-    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN)
-
-    tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    tm.release_success(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-    assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)
-
-
-def test_no_saturation_above_floor() -> None:
-    """Saturation only triggers when concurrency is at the minimum floor."""
-    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
-    tm.register(provider_name=PROVIDER, model_id=MODEL, alias="a1", max_parallel_requests=10)
-
-    t = 0.0
-    # First 429 reduces from 10 to 7 (above floor), subsequent ones are cascade
-    for i in range(5):
-        tm.try_acquire(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        tm.release_rate_limited(provider_name=PROVIDER, model_id=MODEL, domain=DOMAIN, now=t)
-        t += 10.0
-
-    assert not tm.is_saturated(PROVIDER, MODEL, DOMAIN)
+    assert tm.is_saturated(PROVIDER, MODEL, DOMAIN) == expected_saturated

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
@@ -467,3 +467,41 @@ async def test_concurrent_requests_bounded_by_throttle_limit() -> None:
     state = tm.get_domain_state(PROVIDER, MODEL_ID, ThrottleDomain.CHAT)
     assert state is not None
     assert state.in_flight == 0
+
+
+# --- Saturation: throttle marks saturation but client preserves ProviderError ---
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_sustained_rate_limiting_marks_throttle_saturated() -> None:
+    """Consecutive 429s at floor mark the throttle domain as saturated, but
+    the client still raises the original ProviderError (saturation is used by
+    the scheduler for error-rate counting, not for error conversion)."""
+    tm = ThrottleManager(ThrottleConfig(saturation_threshold=2))
+    tm.register(provider_name=PROVIDER, model_id=MODEL_ID, alias="a", max_parallel_requests=1)
+
+    async def always_429(_request: ChatCompletionRequest) -> ChatCompletionResponse:
+        raise ProviderError(
+            kind=ProviderErrorKind.RATE_LIMIT,
+            message="429",
+            status_code=429,
+            retry_after=0.01,
+        )
+
+    inner = MagicMock()
+    inner.provider_name = PROVIDER
+    inner.acompletion = always_429
+
+    client = ThrottledModelClient(inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID)
+    request = ChatCompletionRequest(model=MODEL_ID, messages=[])
+
+    # First 429: not yet saturated
+    with pytest.raises(ProviderError):
+        await client.acompletion(request)
+    assert not tm.is_saturated(PROVIDER, MODEL_ID, ThrottleDomain.CHAT)
+    await asyncio.sleep(0.02)
+
+    # Second 429: threshold reached -> saturated, but still ProviderError
+    with pytest.raises(ProviderError):
+        await client.acompletion(request)
+    assert tm.is_saturated(PROVIDER, MODEL_ID, ThrottleDomain.CHAT)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
@@ -56,11 +56,14 @@ def inner_client() -> MagicMock:
 
 @pytest.fixture
 def throttled_client(inner_client: MagicMock, throttle_manager: ThrottleManager) -> ThrottledModelClient:
+    # Default to no in-client rate-limit retry so existing behavior tests see
+    # single-attempt semantics. Retry-aware tests construct their own client.
     return ThrottledModelClient(
         inner=inner_client,
         throttle_manager=throttle_manager,
         provider_name=PROVIDER,
         model_id=MODEL_ID,
+        max_rate_limit_retries=0,
     )
 
 
@@ -390,7 +393,9 @@ async def test_aimd_feedback_loop_rate_limit_reduces_then_successes_recover() ->
     inner.provider_name = PROVIDER
     inner.acompletion = mock_acompletion
 
-    client = ThrottledModelClient(inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID)
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=0
+    )
     request = ChatCompletionRequest(model=MODEL_ID, messages=[])
 
     def get_state() -> DomainThrottleState:
@@ -454,7 +459,9 @@ async def test_concurrent_requests_bounded_by_throttle_limit() -> None:
     inner.provider_name = PROVIDER
     inner.acompletion = mock_acompletion
 
-    client = ThrottledModelClient(inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID)
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=0
+    )
     request = ChatCompletionRequest(model=MODEL_ID, messages=[])
 
     tasks = [asyncio.create_task(client.acompletion(request)) for _ in range(5)]
@@ -492,7 +499,9 @@ async def test_sustained_rate_limiting_marks_throttle_saturated() -> None:
     inner.provider_name = PROVIDER
     inner.acompletion = always_429
 
-    client = ThrottledModelClient(inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID)
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=0
+    )
     request = ChatCompletionRequest(model=MODEL_ID, messages=[])
 
     # First 429: not yet saturated
@@ -505,3 +514,135 @@ async def test_sustained_rate_limiting_marks_throttle_saturated() -> None:
     with pytest.raises(ProviderError):
         await client.acompletion(request)
     assert tm.is_saturated(PROVIDER, MODEL_ID, ThrottleDomain.CHAT)
+
+
+# --- In-client rate-limit retry (max_rate_limit_retries) ---
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_acompletion_retries_on_rate_limit_then_succeeds() -> None:
+    """A transient 429 is transparently retried; the caller never sees the error."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=0.01))
+    tm.register(provider_name=PROVIDER, model_id=MODEL_ID, alias="a", max_parallel_requests=1)
+
+    call_count = 0
+
+    async def flaky(_request: ChatCompletionRequest) -> ChatCompletionResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ProviderError(
+                kind=ProviderErrorKind.RATE_LIMIT,
+                message="429",
+                status_code=429,
+                retry_after=0.01,
+            )
+        return ChatCompletionResponse(message=AssistantMessage(content="ok"), usage=Usage())
+
+    inner = MagicMock()
+    inner.provider_name = PROVIDER
+    inner.acompletion = flaky
+
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=3
+    )
+    request = ChatCompletionRequest(model=MODEL_ID, messages=[])
+    response = await client.acompletion(request)
+    assert response.message.content == "ok"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_acompletion_exhausts_retries_then_raises() -> None:
+    """After max_rate_limit_retries, the original ProviderError is re-raised."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=0.01))
+    tm.register(provider_name=PROVIDER, model_id=MODEL_ID, alias="a", max_parallel_requests=1)
+
+    call_count = 0
+
+    async def always_429(_request: ChatCompletionRequest) -> ChatCompletionResponse:
+        nonlocal call_count
+        call_count += 1
+        raise ProviderError(
+            kind=ProviderErrorKind.RATE_LIMIT,
+            message="429",
+            status_code=429,
+            retry_after=0.01,
+        )
+
+    inner = MagicMock()
+    inner.provider_name = PROVIDER
+    inner.acompletion = always_429
+
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=2
+    )
+    request = ChatCompletionRequest(model=MODEL_ID, messages=[])
+    with pytest.raises(ProviderError) as excinfo:
+        await client.acompletion(request)
+    assert excinfo.value.kind == ProviderErrorKind.RATE_LIMIT
+    # 1 initial + 2 retries = 3 total calls
+    assert call_count == 3
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_acompletion_non_rate_limit_error_is_not_retried() -> None:
+    """Errors other than rate-limit propagate immediately, no retry."""
+    tm = ThrottleManager()
+    tm.register(provider_name=PROVIDER, model_id=MODEL_ID, alias="a", max_parallel_requests=1)
+
+    call_count = 0
+
+    async def server_error(_request: ChatCompletionRequest) -> ChatCompletionResponse:
+        nonlocal call_count
+        call_count += 1
+        raise ProviderError(
+            kind=ProviderErrorKind.INTERNAL_SERVER,
+            message="500",
+            status_code=500,
+        )
+
+    inner = MagicMock()
+    inner.provider_name = PROVIDER
+    inner.acompletion = server_error
+
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=5
+    )
+    request = ChatCompletionRequest(model=MODEL_ID, messages=[])
+    with pytest.raises(ProviderError) as excinfo:
+        await client.acompletion(request)
+    assert excinfo.value.kind == ProviderErrorKind.INTERNAL_SERVER
+    assert call_count == 1
+
+
+def test_completion_sync_retries_on_rate_limit_then_succeeds() -> None:
+    """Sync path also retries on 429 and succeeds when the server recovers."""
+    tm = ThrottleManager(ThrottleConfig(cooldown_seconds=0.01))
+    tm.register(provider_name=PROVIDER, model_id=MODEL_ID, alias="a", max_parallel_requests=1)
+
+    call_count = 0
+
+    def flaky(_request: ChatCompletionRequest) -> ChatCompletionResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ProviderError(
+                kind=ProviderErrorKind.RATE_LIMIT,
+                message="429",
+                status_code=429,
+                retry_after=0.01,
+            )
+        return ChatCompletionResponse(message=AssistantMessage(content="ok"), usage=Usage())
+
+    inner = MagicMock()
+    inner.provider_name = PROVIDER
+    inner.completion = flaky
+
+    client = ThrottledModelClient(
+        inner=inner, throttle_manager=tm, provider_name=PROVIDER, model_id=MODEL_ID, max_rate_limit_retries=3
+    )
+    request = ChatCompletionRequest(model=MODEL_ID, messages=[])
+    response = client.completion(request)
+    assert response.message.content == "ok"
+    assert call_count == 2


### PR DESCRIPTION
## 📋 Summary

Fixes the async engine producing 0 records under sustained API rate limiting. Rate-limited tasks were deferred to salvage, which retried them in bursts through the same congested throttle - climbing the error rate, tripping early shutdown, and dropping all records before checkpointing. This adds a per-task **cooldown queue** that releases scheduler permits while a task waits, paces retries through the AIMD signal, and falls through to salvage only as a last resort. Also addresses related throttle-manager edge cases surfaced during review (Retry-After clipping, mixed-failure streak handling).

## 🔗 Related Issue

Fixes #575

## 🔄 Changes

### 🐛 Fixed

- **Cooldown queue for rate-limited tasks** ([`async_scheduler.py#L315-L351`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py#L315-L351), [`#L820-L863`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py#L820-L863)): On `ModelRateLimitError`, the worker pushes `(Task, wakeup_at)` onto `_cooldown_pending` and exits cleanly, releasing both submission and LLM-wait permits. The dispatch loop drains entries whose wakeup has passed back into the frontier; they re-acquire permits via the standard path and naturally pace through the throttle's `acquire_async`. Per-task budget is `DEFAULT_RATE_LIMIT_RETRIES = 5`; exhaustion falls through to the existing salvage path.
- **`Retry-After` honored as a floor** ([`throttle_manager.py#L266-L289`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py#L266-L289)): `release_rate_limited` no longer clips an explicit `Retry-After` header below `max_cooldown_seconds`. The cap only constrains synthetic exponential growth; when the server provides a hint, we never retry earlier than it asked.
- **`ModelRateLimitError.retry_after`** ([`errors.py#L67-L80`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/models/errors.py#L67-L80)): `_raise_from_provider_error` now propagates the provider's `Retry-After` value through the exception, so the cooldown queue can wait the server-mandated duration on the throttled-client path.
- **`consecutive_429s` resets on non-rate-limit failure** ([`throttle_manager.py#L341-L356`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py#L341-L356)): a sequence like `429 → 500 → 429` is treated as two fresh cascades instead of sustained throttling.
- **Stale cooldown entries are pruned**: drain drops entries whose row group has been checkpointed or whose row was dropped by a sibling column's terminal failure, so the `all_done` gate isn't held hostage by a cooldown nothing is waiting on.
- **`from_scratch` tasks route to salvage**: seed tasks are dispatched by `_dispatch_seeds`, not the frontier, so the cooldown queue's drain wouldn't bring them back. They skip the cooldown queue and go straight to salvage, which already knows how to re-dispatch seeds.

### 🔧 Changed

- **Exponential cooldown backoff at floor** ([`throttle_manager.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py)): When concurrency is at minimum (1) and consecutive 429s keep arriving, cooldown duration grows exponentially (`base * backoff_factor ^ (consecutive_429s - 1)`, capped at `max_cooldown_seconds`).
- **Saturation detection (telemetry-only)**: After `saturation_threshold` consecutive 429s at minimum concurrency, the domain is marked as saturated with a warning log. `is_saturated()` is a public hook reserved for future scoping; no current behavioral effect on the client.
- **New `ThrottleConfig` fields** ([`run_config.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-config/src/data_designer/config/run_config.py)): `cooldown_backoff_factor` (default `2.0`), `max_cooldown_seconds` (default `30.0`), `saturation_threshold` (default `5`). Sensible defaults; no user action needed.

## Why a cooldown queue, not inline retry?

The first iteration of this PR put the retry loop inline in the scheduler worker. Adversarial review surfaced two real regressions: **(1)** a worker holding the LLM-wait permit across every cooldown attempt could starve unrelated row groups under multi-model load, and **(2)** a `ModelRateLimitError` raised by a custom generator outside `ThrottledModelClient` (no `acquire_async` to enforce cooldown) became a tight retry loop with no real backoff. Both trace to the same architectural choice: retry-while-holding-permits, with cooldown enforcement implicit.

Replacing it with a per-task cooldown queue:
- Workers exit immediately on 429, releasing all permits — no cross-model starvation.
- Cooldown wait is **explicit** (a wakeup time on the queue), so unthrottled 429s are paced just like throttled ones.
- The structural difference from "salvage but earlier" is that salvage retries deferred tasks in **bursts** (the original failure mode), while the cooldown queue dispatches tasks as **their own** wakeup expires — natural pacing without re-saturating the throttle.
- Salvage is preserved as the third-line backstop for non-rate-limit retryables and for tasks that exhaust the cooldown budget.

## Behavior comparison

**Before (stalls):** Rate limit → task deferred to salvage → salvage retries through congested throttle → more rate limits → cooldowns compound → stalls 15+ min → early shutdown → 0 records.

**After (cooldown queue):** Rate limit → worker exits, releases permits → task waits in cooldown queue → drain re-dispatches when wakeup expires → throttle's `acquire_async` paces remainder → task usually succeeds within 1-4 retries → no salvage needed → no error rate increase → no early shutdown.

### A/B test results (Anonymizer biographies pipeline, `gpt-oss-120b` at `max_parallel=4`, early shutdown enabled)

| | **With fix** | **Without fix** |
|---|---|---|
| Detection (225 tasks) | 225 ok, 0 failed | 219 ok, 1 failed, 5 skipped |
| Salvage rounds | 0 | 3 (13 tasks deferred) |
| Rewrite (325 tasks) | 325 ok, 0 failed | 240 ok, early shutdown triggered |
| Final result | ✅ All stages completed | ❌ 0 records produced |

The A/B comparison was run on the original inline-retry version. The cooldown queue is equivalent in the common case (1-4 retries succeed) and strictly better under sustained 429s and on multi-model pipelines. A user-reported reproduction of the same #575 failure mode (Anonymizer notebook 04, rewrite phase: early shutdown at 345s, 156 ok, scheduler exited with 1 unfinished row group → 0 records → `DataDesignerGenerationError`) confirms the original failure mode independent of our test setup.

## 🧪 Testing

- [x] `make test` passes (1909 engine tests; 9 new tests for the cooldown queue + throttle regressions)
- [x] Unit tests added covering: cooldown-queue recovery, exhaustion fallback to salvage, permit-release-during-cooldown (P1), unthrottled-429 pacing (P2), stale-entry pruning, `from_scratch` routing, `Retry-After` honored
- [x] Throttle manager regression tests: `Retry-After` floor, default cooldown still capped, streak reset on `release_failure`, saturation cleared on non-rate-limit failure
- [x] A/B tested against live `build.nvidia.com` endpoint with rate limiting active
- [ ] E2E tests — N/A, covered by live A/B testing

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A, no user-facing API changes

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [Cooldown queue + drain logic](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py#L315-L351): core architectural change. The drain handles three states (ready-to-redispatch, stale, still-waiting) and the `_main_dispatch_loop` / `_drain_frontier` exit conditions and wake bounds are timeout-aware via `_wait_for_wake_or_cooldown`.
- [`from_scratch` carve-out](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py#L833-L853): seed/from-scratch tasks bypass the cooldown queue because the frontier wouldn't re-emit them. Worth confirming this is the right tradeoff for plugin-provided from-scratch generators that hit rate limits.
- [`ModelRateLimitError` constructor](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/async-rate-limit-stall/packages/data-designer-engine/src/data_designer/engine/models/errors.py#L67-L80): now accepts a kw-only `retry_after` argument. Existing call sites that construct it positionally are unaffected, but worth a sanity check.
- **Architectural journey**: this PR was rewritten mid-review. Original commits shipped inline retry; subsequent commits addressed adversarial review findings (Retry-After, mixed-failure streaks) and then refactored to the cooldown queue. Git history has the full progression: `f7a17cb6` (adversarial fixes) → `f390e4ad` (cooldown queue refactor) → `beed73d0` (Codex follow-up).
- The **second rate-limit failure path** (custom generators like `chunked_validate` in Anonymizer with internal retry pools that convert rate limits to non-retryable errors before they reach the scheduler) is **out of scope** for this PR. That path is unchanged.

---
*Description updated with AI*
