### PR TITLE
feat: update default nvidia-vision model to nemotron-3-nano-omni

### DIFF
--- a/docs/concepts/models/default-model-settings.md
+++ b/docs/concepts/models/default-model-settings.md
@@ -45,7 +45,7 @@ The following model configurations are automatically available when `NVIDIA_API_
 |-------|-------|----------|---------------------|
 | `nvidia-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `nvidia-reasoning` | `nvidia/nemotron-3-super-120b-a12b` | Reasoning and analysis tasks | `temperature=1.0, top_p=0.95, extra_body={"reasoning_effort": "medium"}` |
-| `nvidia-vision` | `nvidia/nemotron-nano-12b-v2-vl` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `nvidia-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Vision and image understanding | `temperature=0.60, top_p=0.95` |
 | `nvidia-embedding` | `nvidia/llama-3.2-nv-embedqa-1b-v2` | Text embeddings | `encoding_format="float", extra_body={"input_type": "query"}` |
 
 

--- a/docs/concepts/models/model-configs.md
+++ b/docs/concepts/models/model-configs.md
@@ -81,7 +81,7 @@ model_configs = [
     # Vision tasks
     dd.ModelConfig(
         alias="vision-model",
-        model="nvidia/nemotron-nano-12b-v2-vl",
+        model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         provider="nvidia",
         inference_parameters=dd.ChatCompletionInferenceParams(
             temperature=0.7,

--- a/docs/concepts/models/model-configs.md
+++ b/docs/concepts/models/model-configs.md
@@ -84,7 +84,7 @@ model_configs = [
         model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         provider="nvidia",
         inference_parameters=dd.ChatCompletionInferenceParams(
-            temperature=0.7,
+            temperature=0.60,
             top_p=0.95,
             max_tokens=2048,
         ),

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -341,6 +341,7 @@ NEMOTRON_3_SUPER_120B_A12B_INFERENCE_PARAMS = {
     "top_p": 0.95,
     "extra_body": {"reasoning_effort": "medium"},
 }
+NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS = {"temperature": 0.60, "top_p": 0.95}
 GPT5_INFERENCE_PARAMS = {"extra_body": {"reasoning_effort": "medium"}}
 
 PREDEFINED_PROVIDERS_MODEL_MAP = {
@@ -353,7 +354,10 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
             "model": "nvidia/nemotron-3-super-120b-a12b",
             "inference_parameters": NEMOTRON_3_SUPER_120B_A12B_INFERENCE_PARAMS,
         },
-        "vision": {"model": "nvidia/nemotron-nano-12b-v2-vl", "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS},
+        "vision": {
+            "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+            "inference_parameters": NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS,
+        },
         "embedding": {
             "model": "nvidia/llama-3.2-nv-embedqa-1b-v2",
             "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS | {"extra_body": {"input_type": "query"}},

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -63,7 +63,7 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[1].model == "nvidia/nemotron-3-super-120b-a12b"
     assert builtin_model_configs[1].provider == "nvidia"
     assert builtin_model_configs[2].alias == "nvidia-vision"
-    assert builtin_model_configs[2].model == "nvidia/nemotron-nano-12b-v2-vl"
+    assert builtin_model_configs[2].model == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
     assert builtin_model_configs[2].provider == "nvidia"
     assert builtin_model_configs[3].alias == "nvidia-embedding"
     assert builtin_model_configs[3].model == "nvidia/llama-3.2-nv-embedqa-1b-v2"


### PR DESCRIPTION
## 📋 Summary

Updates the default `nvidia-vision` model alias from `nvidia/nemotron-nano-12b-v2-vl` to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`, which provides improved multimodal capabilities with reasoning support.

We're keeping the `openrouter-vision` model config unchanged until `nvidia/nemotron-nano-12b-v2-vl` becomes available there.

## 🔗 Related Issue

Closes #582

## 🔄 Changes

- Updated `PREDEFINED_PROVIDERS_MODEL_MAP[nvidia][vision]` to use `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` with new inference params (`temperature=0.60, top_p=0.95`)
- Added `NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS` constant in [`constants.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat/update-nvidia-vision-model/packages/data-designer-config/src/data_designer/config/utils/constants.py#L344)
- Updated docs to reflect new model and parameters in [`default-model-settings.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat/update-nvidia-vision-model/docs/concepts/models/default-model-settings.md) and [`model-configs.md`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat/update-nvidia-vision-model/docs/concepts/models/model-configs.md)
- Updated test assertions to match new model name

## 🧪 Testing

- [x] `make test` passes
- [x] Unit tests updated in `test_default_model_settings.py`
- [ ] E2E tests added/updated — N/A, config-only change

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated

Made with [Cursor](https://cursor.com)