### PR TITLE
feat(cli): add data-designer --version

### DIFF
--- a/packages/data-designer/src/data_designer/cli/main.py
+++ b/packages/data-designer/src/data_designer/cli/main.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import sys
+
 import typer
 
 from data_designer.cli.agent_command_defs import AGENT_COMMANDS
@@ -10,6 +13,23 @@ from data_designer.cli.lazy_group import create_lazy_typer_group
 from data_designer.cli.runtime import ensure_cli_default_model_settings
 
 _CMD = "data_designer.cli.commands"
+_PACKAGE_NAME = "data-designer"
+
+
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    try:
+        typer.echo(importlib.metadata.version(_PACKAGE_NAME))
+    except importlib.metadata.PackageNotFoundError:
+        typer.echo(f"Unable to resolve installed {_PACKAGE_NAME} package version.", err=True)
+        raise typer.Exit(1) from None
+    raise typer.Exit()
+
+
+def _is_version_request(args: list[str]) -> bool:
+    return bool(args) and args[0] == "--version"
+
 
 # Initialize Typer app with custom configuration
 app = typer.Typer(
@@ -133,9 +153,23 @@ app.add_typer(download_app, name="download", rich_help_panel="Setup")
 app.add_typer(agent_app, name="agent", rich_help_panel="Agent")
 
 
+@app.callback()
+def app_callback(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the installed data-designer package version and exit.",
+    ),
+) -> None:
+    _ = version
+
+
 def main() -> None:
     """Main entry point for the CLI."""
-    ensure_cli_default_model_settings()
+    if not _is_version_request(sys.argv[1:]):
+        ensure_cli_default_model_settings()
     app()
 
 

--- a/packages/data-designer/src/data_designer/cli/main.py
+++ b/packages/data-designer/src/data_designer/cli/main.py
@@ -28,7 +28,7 @@ def _version_callback(value: bool) -> None:
 
 
 def _is_version_request(args: list[str]) -> bool:
-    return bool(args) and args[0] == "--version"
+    return "--version" in args
 
 
 # Initialize Typer app with custom configuration

--- a/packages/data-designer/tests/cli/test_main.py
+++ b/packages/data-designer/tests/cli/test_main.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 from unittest.mock import Mock, call, patch
 
 from typer.testing import CliRunner
@@ -24,6 +25,37 @@ def test_main_bootstraps_before_running_app(mock_bootstrap: Mock, mock_app: Mock
     main()
 
     assert call_order.mock_calls == [call.bootstrap(), call.app()]
+
+
+@patch("data_designer.cli.main.app")
+@patch("data_designer.cli.main.ensure_cli_default_model_settings")
+def test_main_skips_bootstrap_for_version(mock_bootstrap: Mock, mock_app: Mock) -> None:
+    """The CLI entrypoint avoids default setup for the fast version path."""
+    with patch("sys.argv", ["data-designer", "--version"]):
+        main()
+
+    mock_bootstrap.assert_not_called()
+    mock_app.assert_called_once_with()
+
+
+def test_app_version_prints_installed_data_designer_version() -> None:
+    with patch("data_designer.cli.main.importlib.metadata.version", return_value="0.6.0") as mock_version:
+        result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output == "0.6.0\n"
+    mock_version.assert_called_once_with("data-designer")
+
+
+def test_app_version_errors_when_package_version_is_missing() -> None:
+    with patch(
+        "data_designer.cli.main.importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError("data-designer"),
+    ):
+        result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 1
+    assert "Unable to resolve installed data-designer package version." in result.output
 
 
 @patch("data_designer.cli.commands.create.GenerationController")

--- a/packages/data-designer/tests/cli/test_main.py
+++ b/packages/data-designer/tests/cli/test_main.py
@@ -22,7 +22,8 @@ def test_main_bootstraps_before_running_app(mock_bootstrap: Mock, mock_app: Mock
     call_order.attach_mock(mock_bootstrap, "bootstrap")
     call_order.attach_mock(mock_app, "app")
 
-    main()
+    with patch("sys.argv", ["data-designer"]):
+        main()
 
     assert call_order.mock_calls == [call.bootstrap(), call.app()]
 
@@ -32,6 +33,17 @@ def test_main_bootstraps_before_running_app(mock_bootstrap: Mock, mock_app: Mock
 def test_main_skips_bootstrap_for_version(mock_bootstrap: Mock, mock_app: Mock) -> None:
     """The CLI entrypoint avoids default setup for the fast version path."""
     with patch("sys.argv", ["data-designer", "--version"]):
+        main()
+
+    mock_bootstrap.assert_not_called()
+    mock_app.assert_called_once_with()
+
+
+@patch("data_designer.cli.main.app")
+@patch("data_designer.cli.main.ensure_cli_default_model_settings")
+def test_main_skips_bootstrap_when_version_follows_another_flag(mock_bootstrap: Mock, mock_app: Mock) -> None:
+    """The CLI entrypoint detects eager version requests even after another root flag."""
+    with patch("sys.argv", ["data-designer", "--help", "--version"]):
         main()
 
     mock_bootstrap.assert_not_called()


### PR DESCRIPTION
## 📋 Summary

Adds a top-level `data-designer --version` flag so users and support workflows can quickly read the installed `data-designer` package version. The version path uses `importlib.metadata.version("data-designer")` and avoids default CLI model setup before exiting.

## 🔗 Related Issue

Fixes #597

## 🔄 Changes

- Added an eager Typer root `--version` option that prints only the resolved package version.
- Skipped `ensure_cli_default_model_settings()` for top-level version requests in the console entrypoint.
- Added CLI tests for the successful version output, missing package error, and bootstrap skip behavior.

## 🧪 Testing

- [ ] `make test` passes (not run; focused CLI checks below)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A - no E2E surface changed)
- [x] `uv run --package data-designer pytest packages/data-designer/tests/cli/test_main.py`
- [x] `uv run --package data-designer data-designer --version`
- [x] `uv run ruff check packages/data-designer/src/data_designer/cli/main.py packages/data-designer/tests/cli/test_main.py`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A - no architecture docs impacted)
