### PR TITLE
fix: Add --org option to NGC download command

### DIFF
--- a/packages/data-designer/src/data_designer/cli/services/download_service.py
+++ b/packages/data-designer/src/data_designer/cli/services/download_service.py
@@ -53,6 +53,8 @@ class DownloadService:
                 "resource",
                 "download-version",
                 f"nvidia/nemotron-personas/{locale_obj.dataset_name}",
+                "--org",
+                "nvidia",
                 "--dest",
                 temp_dir,
             ]

--- a/packages/data-designer/tests/cli/services/test_download_service.py
+++ b/packages/data-designer/tests/cli/services/test_download_service.py
@@ -137,6 +137,8 @@ def test_download_persona_dataset_success(
         "resource",
         "download-version",
         "nvidia/nemotron-personas/nemotron-personas-dataset-en_us",
+        "--org",
+        "nvidia",
         "--dest",
         temp_dir_path,
     ]


### PR DESCRIPTION
## 📋 Summary
Adds `--org nvidia` to the NGC CLI download command for Nemotron personas datasets. Without this, the existing command only works if you have a `~/.ngc/config` file with a default org set. Some users might not "configure" their NGC CLI like this.

## 🔗 Related Issue
N/A, too small to bother

## 🔄 Changes
- Adds the arg to the download service

## 🧪 Testing
<!-- What testing was done? -->
- [x] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable) (N/A)

Also manually tested `data-designer download personas --locale ja_JP` both with and without a `~/.ngc/config` file present; works in both scenarios.

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable) (N/A)
