### PR TITLE
fix: quote review-code skill argument hint

### DIFF
--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-code
 description: Perform a thorough code review of the current branch or a GitHub PR by number.
-argument-hint: [pr-number] [special instructions]
+argument-hint: "[pr-number] [special instructions]"
 disable-model-invocation: true
 metadata:
     internal: true


### PR DESCRIPTION
## 📋 Summary

This PR fixes the `review-code` skill frontmatter so Codex can load it successfully. Quoting the `argument-hint` preserves the Claude Code-style metadata while making the value valid YAML.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Quote the `argument-hint` value in `.agents/skills/review-code/SKILL.md` so `[pr-number] [special instructions]` is parsed as a string instead of invalid YAML flow syntax.

## 🧪 Testing

- [x] Skill frontmatter parses successfully with `python3`/PyYAML
- [x] `git diff --check origin/main..HEAD` passes
- [ ] `make test` passes (not run — metadata-only skill frontmatter change)
- [x] Unit tests added/updated (N/A — no runtime code change)
- [x] E2E tests added/updated (N/A — no E2E behavior change)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — skill metadata only)