### PR TITLE
fix(config): validate subcategory parent sampler type

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/data_designer_config.py
+++ b/packages/data-designer-config/src/data_designer/config/data_designer_config.py
@@ -54,10 +54,15 @@ class DataDesignerConfig(ExportableConfigBase):
             if col.column_type != "sampler" or col.sampler_type != SamplerType.SUBCATEGORY:
                 continue
             parent = by_name.get(col.params.category)
-            if parent is not None and parent.column_type != "sampler":
+            if parent is not None and (parent.column_type != "sampler" or parent.sampler_type != SamplerType.CATEGORY):
+                if parent.column_type == "sampler":
+                    parent_sampler_type = getattr(parent.sampler_type, "value", parent.sampler_type)
+                    parent_type = f"sampler column with sampler_type='{parent_sampler_type}'"
+                else:
+                    parent_type = f"'{parent.column_type}' column"
                 raise ValueError(
-                    f"Subcategory column '{col.name}' has parent '{parent.name}', which is a "
-                    f"'{parent.column_type}' column. Subcategory parents must be sampler columns "
+                    f"Subcategory column '{col.name}' has parent '{parent.name}', which is a {parent_type}. "
+                    f"Subcategory parents must be sampler columns "
                     f"with sampler_type='category'."
                 )
         return self

--- a/packages/data-designer-config/tests/config/test_data_designer_config.py
+++ b/packages/data-designer-config/tests/config/test_data_designer_config.py
@@ -183,6 +183,31 @@ def test_subcategory_parent_as_category_sampler_is_valid() -> None:
     assert len(config.columns) == 2
 
 
+def test_subcategory_parent_must_be_a_category_sampler() -> None:
+    with pytest.raises(ValueError, match=r"sampler_type='uniform'.*sampler_type='category'"):
+        DataDesignerConfig.model_validate(
+            {
+                "columns": [
+                    {
+                        "name": "package_type",
+                        "column_type": "sampler",
+                        "sampler_type": "uniform",
+                        "params": {"low": 0, "high": 1},
+                    },
+                    {
+                        "name": "ski_category",
+                        "column_type": "sampler",
+                        "sampler_type": "subcategory",
+                        "params": {
+                            "category": "package_type",
+                            "values": {"basic": ["a"], "premium": ["b"]},
+                        },
+                    },
+                ]
+            }
+        )
+
+
 def test_subcategory_parent_missing_defers_to_schema_validator() -> None:
     config = DataDesignerConfig.model_validate(
         {


### PR DESCRIPTION
## 📋 Summary

This PR tightens `DataDesignerConfig` validation so subcategory sampler parents must be category samplers, not just any sampler column. This matches the existing error message and prevents invalid configs from pairing subcategory sampling with non-category parent values.

## 🔗 Related Issue

N/A — split out from plugin catalog PR review cleanup.

## 🔄 Changes

- Update the subcategory parent validator to reject sampler parents whose `sampler_type` is not `category`.
- Preserve the existing rejection for non-sampler parent columns while making the error message describe the actual parent type.
- Add a regression test for a `subcategory` column whose parent is a `uniform` sampler.

## 🧪 Testing

- [x] `uv run --package data-designer-config pytest packages/data-designer-config/tests/config/test_data_designer_config.py -q`
- [x] `uv run ruff format --check packages/data-designer-config/src/data_designer/config/data_designer_config.py packages/data-designer-config/tests/config/test_data_designer_config.py`
- [x] `uv run ruff check --output-format=full packages/data-designer-config/src/data_designer/config/data_designer_config.py packages/data-designer-config/tests/config/test_data_designer_config.py`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — validation-only bug fix)