### PR TITLE
fix(config): update OpenRouter vision model id

### DIFF
--- a/docs/concepts/models/default-model-settings.md
+++ b/docs/concepts/models/default-model-settings.md
@@ -68,7 +68,7 @@ The following model configurations are automatically available when `OPENROUTER_
 |-------|-------|----------|---------------------|
 | `openrouter-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `openrouter-reasoning` | `openai/gpt-oss-20b` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
-| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.60, top_p=0.95` |
 | `openrouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
 
 

--- a/docs/concepts/models/default-model-settings.md
+++ b/docs/concepts/models/default-model-settings.md
@@ -68,7 +68,7 @@ The following model configurations are automatically available when `OPENROUTER_
 |-------|-------|----------|---------------------|
 | `openrouter-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `openrouter-reasoning` | `openai/gpt-oss-20b` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
-| `openrouter-vision` | `nvidia/nemotron-nano-12b-v2-vl` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
 | `openrouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
 
 
@@ -106,6 +106,9 @@ Both methods operate on the same files, ensuring consistency across your entire 
 
 !!! warning "API Key Requirements"
     While default model configurations are always available, you need to set the appropriate API key environment variable (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`) to actually use the corresponding models for data generation. Without a valid API key, any attempt to generate data using that provider's models will fail.
+
+!!! warning "Hosted Provider Data Handling"
+    The default model providers call hosted endpoints operated by NVIDIA, OpenAI, OpenRouter, or their upstream providers. Provider terms and privacy practices apply independently of Data Designer, and free or trial endpoints may log request data for security, operations, or product improvement. Do not submit confidential information or personal data, including faces, voices, screenshots, regulated data, or other sensitive content, unless the selected provider and endpoint are approved for your use case.
 
 !!! warning "Deprecated: implicit default provider routing"
     The `default:` key in `~/.data-designer/model_providers.yaml` and the registry-level

--- a/fern/versions/v0.5.8/pages/concepts/models/default-model-settings.mdx
+++ b/fern/versions/v0.5.8/pages/concepts/models/default-model-settings.mdx
@@ -71,7 +71,7 @@ The following model configurations are automatically available when `OPENROUTER_
 |-------|-------|----------|---------------------|
 | `openrouter-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `openrouter-reasoning` | `openai/gpt-oss-20b` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
-| `openrouter-vision` | `nvidia/nemotron-nano-12b-v2-vl` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
 | `openrouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
 
 
@@ -110,6 +110,10 @@ Both methods operate on the same files, ensuring consistency across your entire 
 
 <Warning title="API Key Requirements">
   While default model configurations are always available, you need to set the appropriate API key environment variable (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`) to actually use the corresponding models for data generation. Without a valid API key, any attempt to generate data using that provider's models will fail.
+</Warning>
+
+<Warning title="Hosted Provider Data Handling">
+  The default model providers call hosted endpoints operated by NVIDIA, OpenAI, OpenRouter, or their upstream providers. Provider terms and privacy practices apply independently of Data Designer, and free or trial endpoints may log request data for security, operations, or product improvement. Do not submit confidential information or personal data, including faces, voices, screenshots, regulated data, or other sensitive content, unless the selected provider and endpoint are approved for your use case.
 </Warning>
 
 <Warning title="Deprecated: implicit default provider routing">

--- a/fern/versions/v0.5.8/pages/concepts/models/default-model-settings.mdx
+++ b/fern/versions/v0.5.8/pages/concepts/models/default-model-settings.mdx
@@ -71,7 +71,7 @@ The following model configurations are automatically available when `OPENROUTER_
 |-------|-------|----------|---------------------|
 | `openrouter-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `openrouter-reasoning` | `openai/gpt-oss-20b` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
-| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Vision and image understanding | `temperature=0.60, top_p=0.95` |
 | `openrouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
 
 

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -378,7 +378,7 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
         "reasoning": {"model": "openai/gpt-oss-20b", "inference_parameters": DEFAULT_REASONING_INFERENCE_PARAMS},
         "vision": {
             "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
-            "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS,
+            "inference_parameters": NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS,
         },
         "embedding": {
             "model": "openai/text-embedding-3-large",

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -376,7 +376,10 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
             "inference_parameters": NEMOTRON_3_NANO_30B_A3B_INFERENCE_PARAMS,
         },
         "reasoning": {"model": "openai/gpt-oss-20b", "inference_parameters": DEFAULT_REASONING_INFERENCE_PARAMS},
-        "vision": {"model": "nvidia/nemotron-nano-12b-v2-vl", "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS},
+        "vision": {
+            "model": "nvidia/nemotron-nano-12b-v2-vl:free",
+            "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS,
+        },
         "embedding": {
             "model": "openai/text-embedding-3-large",
             "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS,

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -377,7 +377,7 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
         },
         "reasoning": {"model": "openai/gpt-oss-20b", "inference_parameters": DEFAULT_REASONING_INFERENCE_PARAMS},
         "vision": {
-            "model": "nvidia/nemotron-nano-12b-v2-vl:free",
+            "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
             "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS,
         },
         "embedding": {

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -90,6 +90,10 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[10].alias == "openrouter-vision"
     assert builtin_model_configs[10].model == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
     assert builtin_model_configs[10].provider == "openrouter"
+    assert builtin_model_configs[10].inference_parameters == ChatCompletionInferenceParams(
+        temperature=0.60,
+        top_p=0.95,
+    )
     assert builtin_model_configs[11].alias == "openrouter-embedding"
     assert builtin_model_configs[11].model == "openai/text-embedding-3-large"
     assert builtin_model_configs[11].provider == "openrouter"

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -88,7 +88,7 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[9].model == "openai/gpt-oss-20b"
     assert builtin_model_configs[9].provider == "openrouter"
     assert builtin_model_configs[10].alias == "openrouter-vision"
-    assert builtin_model_configs[10].model == "nvidia/nemotron-nano-12b-v2-vl"
+    assert builtin_model_configs[10].model == "nvidia/nemotron-nano-12b-v2-vl:free"
     assert builtin_model_configs[10].provider == "openrouter"
     assert builtin_model_configs[11].alias == "openrouter-embedding"
     assert builtin_model_configs[11].model == "openai/text-embedding-3-large"

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -88,7 +88,7 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[9].model == "openai/gpt-oss-20b"
     assert builtin_model_configs[9].provider == "openrouter"
     assert builtin_model_configs[10].alias == "openrouter-vision"
-    assert builtin_model_configs[10].model == "nvidia/nemotron-nano-12b-v2-vl:free"
+    assert builtin_model_configs[10].model == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
     assert builtin_model_configs[10].provider == "openrouter"
     assert builtin_model_configs[11].alias == "openrouter-embedding"
     assert builtin_model_configs[11].model == "openai/text-embedding-3-large"

--- a/scripts/health_checks.py
+++ b/scripts/health_checks.py
@@ -41,6 +41,8 @@ PROVIDER_API_KEY_ENV_VARS = {
     OPENROUTER_PROVIDER_NAME: OPENROUTER_API_KEY_ENV_VAR_NAME,
 }
 
+CHAT_COMPLETION_ATTEMPTS = 2
+
 
 def _get_provider_registry(provider_name: str) -> ModelProviderRegistry:
     provider_data = next(p for p in PREDEFINED_PROVIDERS if p["name"] == provider_name)
@@ -76,8 +78,15 @@ def _check_model(provider_name: str, model_type: str) -> None:
             input_texts=["Hello!"],
             skip_usage_tracking=True,
         )
-        assert len(result) == 1 and len(result[0]) > 0
-    else:
+        if len(result) != 1 or len(result[0]) == 0:
+            raise AssertionError(
+                f"Expected one non-empty embedding from {provider_name}/{model_type} "
+                f"({model_name}); got {len(result)} embeddings"
+            )
+        return
+
+    result = None
+    for attempt in range(1, CHAT_COMPLETION_ATTEMPTS + 1):
         result, _ = facade.generate(
             prompt="Say 'OK' and nothing else.",
             parser=lambda x: x,
@@ -86,7 +95,15 @@ def _check_model(provider_name: str, model_type: str) -> None:
             max_conversation_restarts=0,
             skip_usage_tracking=True,
         )
-        assert isinstance(result, str) and len(result) > 0
+        if isinstance(result, str) and len(result) > 0:
+            return
+        if attempt < CHAT_COMPLETION_ATTEMPTS:
+            print(f"RETRY {provider_name}/{model_type} ({model_name}) returned {result!r}")
+
+    raise AssertionError(
+        f"Expected non-empty chat response from {provider_name}/{model_type} "
+        f"({model_name}) after {CHAT_COMPLETION_ATTEMPTS} attempts; got {result!r}"
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Fix the scheduled provider health checks by updating the OpenRouter vision default to the currently routable nano-3 omni free model, aligning its inference parameters with the nano-3 omni config, making empty chat responses easier to diagnose, and documenting hosted-provider data handling expectations. This is separate from #626, which updates startup alias collection but does not change provider defaults.

cc @nabinchha

## Changes

### Changed

- Updated [constants.py](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/openrouter-vision-model/packages/data-designer-config/src/data_designer/config/utils/constants.py) so `openrouter-vision` uses `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`.
- Aligned `openrouter-vision` with `NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS` (`temperature=0.60, top_p=0.95`), matching the nano-3 omni default.
- Updated [test_default_model_settings.py](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/openrouter-vision-model/packages/data-designer-config/tests/config/test_default_model_settings.py) to assert both the new built-in model ID and inference parameters.
- Updated the default model settings docs and Fern page to show the new `openrouter-vision` model ID and matching inference parameters.

### Fixed

- Hardened [health_checks.py](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/openrouter-vision-model/scripts/health_checks.py) to retry empty/non-string chat responses once before failing.
- Replaced bare provider health-check assertions with provider/model-specific failure messages.

### Docs

- Added a hosted-provider data handling warning to [default-model-settings.md](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatgretel/fix/openrouter-vision-model/docs/concepts/models/default-model-settings.md), covering hosted endpoints, provider terms/privacy practices, and confidential or personal data.

## Review Feedback

- Addressed Nabin's inline comments by using the nano-3 omni free OpenRouter model and its matching `NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS`.
- Addressed Greptile's stale-evidence concern by confirming the PR description and testing notes now refer to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`, the model currently committed.

## Testing

- `.venv/bin/pytest packages/data-designer-config/tests/config/test_default_model_settings.py`
- `.venv/bin/ruff check --fix packages/data-designer-config/src/data_designer/config/utils/constants.py packages/data-designer-config/tests/config/test_default_model_settings.py scripts/health_checks.py`
- `.venv/bin/ruff format packages/data-designer-config/src/data_designer/config/utils/constants.py packages/data-designer-config/tests/config/test_default_model_settings.py scripts/health_checks.py`
- `git diff --check`
- `env -u NVIDIA_API_KEY -u OPENAI_API_KEY .venv/bin/python scripts/health_checks.py`
- OpenRouter-only health check passes with `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`: `4 passed, 0 failed, 8 skipped`.

---
*Description updated with AI*
