### PR TITLE
chore: update vulnerable dependencies

### DIFF
--- a/packages/data-designer-engine/pyproject.toml
+++ b/packages/data-designer-engine/pyproject.toml
@@ -34,6 +34,7 @@ bump = true
 dependencies = [
     "anyascii>=0.3.3,<1",
     "chardet>=3.0.2,<6",  # Pulled in by sqlfluff
+    "cryptography>=46.0.7,<47", # 46.0.7 fixes CVE-2026-39892 pulled in by mcp
     "data-designer-config=={{ version }}",
     "duckdb>=1.5.0,<2",
     "faker>=20.1.0,<21",
@@ -48,6 +49,7 @@ dependencies = [
     "marko>=2.1.2,<3",
     "mcp>=1.26.0,<2",
     "networkx>=3.0,<4",
+    "python-multipart>=0.0.27,<1", # 0.0.27 fixes security advisory pulled in by mcp
     "ruff>=0.14.10,<1",
     "scipy>=1.11.0,<2",
     "sqlfluff>=3.2.0,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,25 +31,6 @@ members = [
 # IMPORTANT: This root is NOT a package. It only defines workspace configuration.
 package = false
 required-version = ">=0.7.10"
-# Minimum versions for transitive dependencies with known security vulnerabilities.
-# aiohttp 3.13.3: CVE-2026-22815, CVE-2026-34513 through CVE-2026-34525 (multiple DoS, CRLF injection, credential theft)
-# cryptography 46.0.6: CVE-2026-39892 (buffer overflow on Python >3.11)
-# jupyter-server 2.17.0: security advisory (transitive via jupyter)
-# jupyterlab 4.5.6: security advisory (transitive via jupyter)
-# mistune 3.2.0: security advisory (transitive via nbconvert)
-# nbconvert 7.17.0: security advisory (transitive via jupyter)
-# notebook 7.5.5: security advisory (transitive via jupyter)
-# python-multipart 0.0.26: security advisory (transitive via mcp)
-constraint-dependencies = [
-    "aiohttp>=3.13.5",
-    "cryptography>=46.0.7",
-    "jupyter-server>=2.18.2",
-    "jupyterlab>=4.6.0a5",
-    "mistune>=3.2.1",
-    "nbconvert>=7.17.1",
-    "notebook>=7.6.0a5",
-    "python-multipart>=0.0.27",
-]
 
 [dependency-groups]
 dev = [
@@ -64,6 +45,7 @@ dev = [
 ]
 docs = [
     "jupytext>=1.16.0,<2",
+    "mistune>=3.2.1,<4", # 3.2.1 fixes security advisory pulled in by nbconvert
     "mike>=2.1.3,<3",
     "mkdocs-jupyter>=0.25.1,<1",
     "mkdocs-material>=9.6.22,<10",
@@ -71,12 +53,19 @@ docs = [
     "mkdocs>=1.6.1,<2",
     "mkdocstrings-python>=1.18.2,<2",
     "mkdocstrings>=0.30.1,<1",
+    "nbconvert>=7.17.1,<8", # 7.17.1 fixes security advisory pulled in by mkdocs-jupyter
     "pymdown-extensions>=10.21.2,<11",
 ]
 notebooks = [
+    "aiohttp>=3.13.5,<4", # 3.13.5 fixes CVE-2026-22815 and CVE-2026-34513 through CVE-2026-34525
     "datasets>=4.0.0,<5",
     "ipykernel>=6.29.0,<7",
     "jupyter>=1.0.0,<2",
+    "jupyter-server>=2.18.2,<3", # 2.18.2 fixes security advisory pulled in by jupyter
+    "jupyterlab>=4.6.0a5,<5", # 4.6.0a5 fixes security advisory pulled in by jupyter
+    "mistune>=3.2.1,<4", # 3.2.1 fixes security advisory pulled in by nbconvert
+    "nbconvert>=7.17.1,<8", # 7.17.1 fixes security advisory pulled in by jupyter
+    "notebook>=7.6.0a5,<8", # 7.6.0a5 fixes security advisory pulled in by jupyter
 ]
 recipes = [
     "bm25s>=0.2.0,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,21 @@ required-version = ">=0.7.10"
 # Minimum versions for transitive dependencies with known security vulnerabilities.
 # aiohttp 3.13.3: CVE-2026-22815, CVE-2026-34513 through CVE-2026-34525 (multiple DoS, CRLF injection, credential theft)
 # cryptography 46.0.6: CVE-2026-39892 (buffer overflow on Python >3.11)
+# jupyter-server 2.17.0: security advisory (transitive via jupyter)
+# jupyterlab 4.5.6: security advisory (transitive via jupyter)
+# mistune 3.2.0: security advisory (transitive via nbconvert)
 # nbconvert 7.17.0: security advisory (transitive via jupyter)
-# python-multipart 0.0.22: security advisory (transitive via mcp)
+# notebook 7.5.5: security advisory (transitive via jupyter)
+# python-multipart 0.0.26: security advisory (transitive via mcp)
 constraint-dependencies = [
     "aiohttp>=3.13.5",
     "cryptography>=46.0.7",
+    "jupyter-server>=2.18.2",
+    "jupyterlab>=4.6.0a5",
+    "mistune>=3.2.1",
     "nbconvert>=7.17.1",
-    "python-multipart>=0.0.26",
+    "notebook>=7.6.0a5",
+    "python-multipart>=0.0.27",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -15,16 +15,6 @@ members = [
     "data-designer-engine",
     "data-designer-workspace",
 ]
-constraints = [
-    { name = "aiohttp", specifier = ">=3.13.5" },
-    { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "jupyter-server", specifier = ">=2.18.2" },
-    { name = "jupyterlab", specifier = ">=4.6.0a5" },
-    { name = "mistune", specifier = ">=3.2.1" },
-    { name = "nbconvert", specifier = ">=7.17.1" },
-    { name = "notebook", specifier = ">=7.6.0a5" },
-    { name = "python-multipart", specifier = ">=0.0.27" },
-]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -858,6 +848,7 @@ source = { editable = "packages/data-designer-engine" }
 dependencies = [
     { name = "anyascii" },
     { name = "chardet" },
+    { name = "cryptography" },
     { name = "data-designer-config" },
     { name = "duckdb" },
     { name = "faker" },
@@ -873,6 +864,7 @@ dependencies = [
     { name = "mcp" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-multipart" },
     { name = "ruff" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -884,6 +876,7 @@ dependencies = [
 requires-dist = [
     { name = "anyascii", specifier = ">=0.3.3,<1" },
     { name = "chardet", specifier = ">=3.0.2,<6" },
+    { name = "cryptography", specifier = ">=46.0.7,<47" },
     { name = "data-designer-config", editable = "packages/data-designer-config" },
     { name = "duckdb", specifier = ">=1.5.0,<2" },
     { name = "faker", specifier = ">=20.1.0,<21" },
@@ -898,6 +891,7 @@ requires-dist = [
     { name = "marko", specifier = ">=2.1.2,<3" },
     { name = "mcp", specifier = ">=1.26.0,<2" },
     { name = "networkx", specifier = ">=3.0,<4" },
+    { name = "python-multipart", specifier = ">=0.0.27,<1" },
     { name = "ruff", specifier = ">=0.14.10,<1" },
     { name = "scipy", specifier = ">=1.11.0,<2" },
     { name = "sqlfluff", specifier = ">=3.2.0,<4" },
@@ -923,18 +917,26 @@ dev = [
 docs = [
     { name = "jupytext" },
     { name = "mike" },
+    { name = "mistune" },
     { name = "mkdocs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
+    { name = "nbconvert" },
     { name = "pymdown-extensions" },
 ]
 notebooks = [
+    { name = "aiohttp" },
     { name = "datasets" },
     { name = "ipykernel" },
     { name = "jupyter" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "mistune" },
+    { name = "nbconvert" },
+    { name = "notebook" },
 ]
 recipes = [
     { name = "bm25s" },
@@ -957,18 +959,26 @@ dev = [
 docs = [
     { name = "jupytext", specifier = ">=1.16.0,<2" },
     { name = "mike", specifier = ">=2.1.3,<3" },
+    { name = "mistune", specifier = ">=3.2.1,<4" },
     { name = "mkdocs", specifier = ">=1.6.1,<2" },
     { name = "mkdocs-jupyter", specifier = ">=0.25.1,<1" },
     { name = "mkdocs-material", specifier = ">=9.6.22,<10" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2,<2" },
     { name = "mkdocstrings", specifier = ">=0.30.1,<1" },
     { name = "mkdocstrings-python", specifier = ">=1.18.2,<2" },
+    { name = "nbconvert", specifier = ">=7.17.1,<8" },
     { name = "pymdown-extensions", specifier = ">=10.21.2,<11" },
 ]
 notebooks = [
+    { name = "aiohttp", specifier = ">=3.13.5,<4" },
     { name = "datasets", specifier = ">=4.0.0,<5" },
     { name = "ipykernel", specifier = ">=6.29.0,<7" },
     { name = "jupyter", specifier = ">=1.0.0,<2" },
+    { name = "jupyter-server", specifier = ">=2.18.2,<3" },
+    { name = "jupyterlab", specifier = ">=4.6.0a5,<5" },
+    { name = "mistune", specifier = ">=3.2.1,<4" },
+    { name = "nbconvert", specifier = ">=7.17.1,<8" },
+    { name = "notebook", specifier = ">=7.6.0a5,<8" },
 ]
 recipes = [
     { name = "bm25s", specifier = ">=0.2.0,<1" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,8 +18,12 @@ members = [
 constraints = [
     { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "jupyter-server", specifier = ">=2.18.2" },
+    { name = "jupyterlab", specifier = ">=4.6.0a5" },
+    { name = "mistune", specifier = ">=3.2.1" },
     { name = "nbconvert", specifier = ">=7.17.1" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "notebook", specifier = ">=7.6.0a5" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
 ]
 
 [[package]]
@@ -1888,6 +1892,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "0.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "requests" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/fa/2b775ee2c20c5976b1c0bd53ddd2b064eb5d0552b9bd6196f2374bd681c5/jupyter_builder-0.0.9.tar.gz", hash = "sha256:d266930740c0453619491b21be31b30847f8daa6f5f6aad9db5c507241e60fcf", size = 962669, upload-time = "2026-05-06T18:25:44.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/32/79545479fcd2231021418352f3a04ccc29a9d5774b63e38f89dc72a47303/jupyter_builder-0.0.9-py3-none-any.whl", hash = "sha256:c5f55b434e9822ef416474e90200b70d6d77e75d51474f02ff2142a6301407de", size = 904634, upload-time = "2026-05-06T18:25:41.742Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1970,7 +1989,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.17.0"
+version = "2.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1993,9 +2012,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/ac/e040ec363d7b6b1f11304cc9f209dac4517ece5d5e01821366b924a64a50/jupyter_server-2.17.0.tar.gz", hash = "sha256:c38ea898566964c888b4772ae1ed58eca84592e88251d2cfc4d171f81f7e99d5", size = 731949, upload-time = "2025-08-21T14:42:54.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/80/a24767e6ca280f5a49525d987bf3e4d7552bf67c8be07e8ccf20271f8568/jupyter_server-2.17.0-py3-none-any.whl", hash = "sha256:e8cb9c7db4251f51ed307e329b81b72ccf2056ff82d50524debde1ee1870e13f", size = 388221, upload-time = "2025-08-21T14:42:52.034Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
 ]
 
 [[package]]
@@ -2013,13 +2032,14 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.6"
+version = "4.6.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
@@ -2031,9 +2051,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/d5/730628e03fff2e8a8e8ccdaedde1489ab1309f9a4fa2536248884e30b7c7/jupyterlab-4.5.6.tar.gz", hash = "sha256:642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42", size = 23970670, upload-time = "2026-03-11T14:17:04.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/c9/52165b226e875737bd8fe72db2b6ccf6b13633a0a446a039993f5b6039b8/jupyterlab-4.6.0a5.tar.gz", hash = "sha256:83c7475b753de7d0741d925a1903e683d213fefe825dfd2f6c0a930079f95606", size = 28519367, upload-time = "2026-04-29T15:47:03.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/1b/dad6fdcc658ed7af26fdf3841e7394072c9549a8b896c381ab49dd11e2d9/jupyterlab-4.5.6-py3-none-any.whl", hash = "sha256:d6b3dac883aa4d9993348e0f8e95b24624f75099aed64eab6a4351a9cdd1e580", size = 12447124, upload-time = "2026-03-11T14:17:00.229Z" },
+    { url = "https://files.pythonhosted.org/packages/97/7d/6644de104649c71a1e978d8660fef97ed229e44df557f7d10d88fa081c6f/jupyterlab-4.6.0a5-py3-none-any.whl", hash = "sha256:8e9fff389b7ab9a5e674ffe034f73a4cfcf87db5e669da5e04d3cb1dd9b3978e", size = 16936075, upload-time = "2026-04-29T15:46:58.584Z" },
 ]
 
 [[package]]
@@ -2417,14 +2437,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.0"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]
@@ -2828,18 +2848,19 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.5"
+version = "7.6.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/6d/41052c48d6f6349ca0a7c4d1f6a78464de135e6d18f5829ba2510e62184c/notebook-7.5.5.tar.gz", hash = "sha256:dc0bfab0f2372c8278c457423d3256c34154ac2cc76bf20e9925260c461013c3", size = 14169167, upload-time = "2026-03-11T16:32:51.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/86/7e77bb828775227d11895ca47d1ba19971a238d3bf89654147e355b062f9/notebook-7.6.0a5.tar.gz", hash = "sha256:2fa1a2d4f120af70797b77158f946f77f95a605ec8017c60ed76f0979b446c46", size = 5408300, upload-time = "2026-04-30T11:26:04.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/cbd1deb9f07446241e88f8d5fecccd95b249bca0b4e5482214a4d1714c49/notebook-7.5.5-py3-none-any.whl", hash = "sha256:a7c14dbeefa6592e87f72290ca982e0c10f5bbf3786be2a600fda9da2764a2b8", size = 14578929, upload-time = "2026-03-11T16:32:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/256458b13c3344ebe1767161fd2410805256d4e6e3aa8a793beb604a410e/notebook-7.6.0a5-py3-none-any.whl", hash = "sha256:3487fac4babc708d613aab90df0da8aef1db15dd7d9cce10c39960975d7a57e3", size = 5449002, upload-time = "2026-04-30T11:26:01.758Z" },
 ]
 
 [[package]]
@@ -3826,11 +3847,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📋 Summary

Updates workspace dependency constraints and the uv lockfile to address the May 2026 scanner findings for python-multipart, Jupyter Server, JupyterLab, Mistune, and Notebook. This keeps the vulnerable MCP and Jupyter dependency paths resolving to patched versions.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Adds root uv security floors for `jupyter-server>=2.18.2`, `jupyterlab>=4.6.0a5`, `mistune>=3.2.1`, `notebook>=7.6.0a5`, and `python-multipart>=0.0.27`.
- Regenerates `uv.lock` so the workspace resolves `jupyter-server` 2.18.2, `jupyterlab` 4.6.0a5, `mistune` 3.2.1, `notebook` 7.6.0a5, and `python-multipart` 0.0.28.
- Adds the new transitive `jupyter-builder` lock entry required by the updated JupyterLab/Notebook prereleases.

## 🔍 Attention Areas

- `uv.lock` now resolves prerelease versions for JupyterLab and Notebook because the scanner guidance specifically calls for `4.6.0a5` and `7.6.0a5`.

## 🧪 Testing

- [x] `uv lock --check`
- [x] `uv tree --all-groups --locked | rg "(jupyter-server|jupyterlab|mistune|notebook|python-multipart|jupyter-builder) v"`
- [x] `git diff --check`
- [ ] `make test` passes (not run; dependency lockfile-only change)
- [x] Unit tests added/updated (N/A — no code path changed)
- [x] E2E tests added/updated (N/A — no code path changed)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — dependency lockfile-only change)