### PR TITLE
ci: fix Fern devnotes artifact lookup

### DIFF
--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -101,8 +101,8 @@ jobs:
             workflow="$1"
             shift
 
-            last_run_id=$(gh run list --workflow "$workflow" --status success "$@" --limit 1 --json databaseId -q '.[0].databaseId // empty' 2>/dev/null || true)
-            if [ -n "$last_run_id" ] && gh run download "$last_run_id" --name notebooks --dir website/docs/notebooks; then
+            last_run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" --status success "$@" --limit 1 --json databaseId -q '.[0].databaseId // empty' 2>/dev/null || true)
+            if [ -n "$last_run_id" ] && gh run download "$last_run_id" --repo "$GITHUB_REPOSITORY" --name notebooks --dir website/docs/notebooks; then
               echo "::notice::Downloaded notebooks from $workflow run $last_run_id"
               exit 0
             fi


### PR DESCRIPTION
## 📋 Summary

Fixes the post-merge `Publish Fern devnotes` failure by making the notebook artifact lookup explicit about which repository to query. After the Fern publishing change, this workflow runs `gh` from the Actions workspace root rather than a checkout, so repo inference no longer works.

## 🔗 Related Issue

N/A. Follow-up to failed workflow run https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/25939020504.

## 🔄 Changes

- Pass `--repo "$GITHUB_REPOSITORY"` to the `gh run list` notebook lookup.
- Pass `--repo "$GITHUB_REPOSITORY"` to the matching `gh run download` artifact fetch.
- Keep the existing fallback order unchanged.

## 🧪 Testing

- [x] Verified the patched `gh run list` command from `/tmp` with `GITHUB_REPOSITORY=NVIDIA-NeMo/DataDesigner`.
- [x] Verified the patched `gh run download` command downloads the `notebooks` artifact from the latest successful release docs run.
- [x] `/home/ubuntu/Code/repos/DataDesigner/checkouts/main/.venv/bin/ruff check --fix .`
- [x] `/home/ubuntu/Code/repos/DataDesigner/checkouts/main/.venv/bin/ruff format .`
- [x] `make test` not run - workflow-only fix.
- [x] Unit tests added/updated: N/A - workflow-only fix.
- [x] E2E tests added/updated: N/A - workflow-only fix.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated: N/A - workflow-only fix
