### PR TITLE
feat: track reasoning token usage

### DIFF
--- a/packages/data-designer-config/src/data_designer/lazy_heavy_imports.py
+++ b/packages/data-designer-config/src/data_designer/lazy_heavy_imports.py
@@ -40,6 +40,7 @@ _LAZY_IMPORTS = {
     "jsonschema": "jsonschema",
     "PIL": "PIL",
     "Image": "PIL.Image",
+    "tiktoken": "tiktoken",
 }
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/analysis/utils/column_statistics_calculations.py
+++ b/packages/data-designer-engine/src/data_designer/engine/analysis/utils/column_statistics_calculations.py
@@ -4,11 +4,8 @@
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
 from numbers import Number
 from typing import TYPE_CHECKING, Any
-
-import tiktoken
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.analysis.column_statistics import (
@@ -25,6 +22,7 @@ from data_designer.engine.column_generators.utils.prompt_renderer import (
     RecordBasedPromptRenderer,
     create_response_recipe,
 )
+from data_designer.engine.utils.token_counting import count_text_tokens
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -36,12 +34,6 @@ WARNING_PREFIX = "⚠️ Error during column profile calculation: "
 TEXT_FIELD_AVG_SPACE_COUNT_THRESHOLD = 0.1
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache(maxsize=1)
-def _get_tokenizer() -> tiktoken.Encoding:
-    """Lazily initialize tokenizer to avoid import-time side effects."""
-    return tiktoken.get_encoding("cl100k_base")
 
 
 def calculate_column_distribution(
@@ -106,7 +98,6 @@ def calculate_input_token_stats(
     column_config: LLMTextColumnConfig, df: pd.DataFrame
 ) -> dict[str, float | MissingValue]:
     try:
-        tokenizer = _get_tokenizer()
         num_tokens = []
         num_samples = min(MAX_PROMPT_SAMPLE_SIZE, len(df))
         renderer = RecordBasedPromptRenderer(response_recipe=create_response_recipe(column_config))
@@ -118,7 +109,7 @@ def calculate_input_token_stats(
                 prompt_template=column_config.prompt, record=record, prompt_type=PromptType.USER_PROMPT
             )
             concatenated_prompt = str(system_prompt + "\n\n" + prompt)
-            num_tokens.append(len(tokenizer.encode(concatenated_prompt, disallowed_special=())))
+            num_tokens.append(count_text_tokens(concatenated_prompt))
     except Exception as e:
         logger.warning(f"{WARNING_PREFIX} failed to calculate input token stats for column {column_config.name!r}: {e}")
         return {
@@ -137,10 +128,7 @@ def calculate_output_token_stats(
     column_config: LLMTextColumnConfig, df: pd.DataFrame
 ) -> dict[str, float | MissingValue]:
     try:
-        tokenizer = _get_tokenizer()
-        tokens_per_record = df[column_config.name].apply(
-            lambda value: len(tokenizer.encode(str(value), disallowed_special=()))
-        )
+        tokens_per_record = df[column_config.name].apply(lambda value: count_text_tokens(str(value)))
         return {
             "output_tokens_mean": tokens_per_record.mean(),
             "output_tokens_median": tokens_per_record.median(),

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
@@ -7,7 +7,7 @@ import json
 import re
 from typing import Any
 
-from data_designer.engine.models.clients.parsing import extract_usage
+from data_designer.engine.models.clients.parsing import extract_usage, fill_reasoning_tokens_from_content
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
     ChatCompletionRequest,
@@ -100,6 +100,7 @@ def parse_anthropic_response(response_json: dict[str, Any]) -> ChatCompletionRes
     usage: Usage | None = None
     if raw_usage:
         usage = extract_usage(raw_usage)
+        usage = fill_reasoning_tokens_from_content(usage, message.reasoning_content)
 
     return ChatCompletionResponse(message=message, usage=usage, raw=response_json)
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic_translation.py
@@ -7,7 +7,7 @@ import json
 import re
 from typing import Any
 
-from data_designer.engine.models.clients.parsing import extract_usage, fill_reasoning_tokens_from_content
+from data_designer.engine.models.clients.parsing import extract_usage, fill_reasoning_token_count_from_content
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
     ChatCompletionRequest,
@@ -100,7 +100,7 @@ def parse_anthropic_response(response_json: dict[str, Any]) -> ChatCompletionRes
     usage: Usage | None = None
     if raw_usage:
         usage = extract_usage(raw_usage)
-        usage = fill_reasoning_tokens_from_content(usage, message.reasoning_content)
+        usage = fill_reasoning_token_count_from_content(usage, message.reasoning_content)
 
     return ChatCompletionResponse(message=message, usage=usage, raw=response_json)
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -260,6 +260,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
     input_tokens = get_value_from(raw_usage, "prompt_tokens")
     output_tokens = get_value_from(raw_usage, "completion_tokens")
     total_tokens = get_value_from(raw_usage, "total_tokens")
+    reasoning_tokens = extract_reasoning_tokens(raw_usage)
 
     if input_tokens is None:
         input_tokens = get_value_from(raw_usage, "input_tokens")
@@ -269,6 +270,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
     input_tokens = coerce_to_int_or_none(input_tokens)
     output_tokens = coerce_to_int_or_none(output_tokens)
     total_tokens = coerce_to_int_or_none(total_tokens)
+    reasoning_tokens = coerce_to_int_or_none(reasoning_tokens)
 
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens
@@ -280,15 +282,39 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
 
     generated_images = coerce_to_int_or_none(generated_images)
 
-    if input_tokens is None and output_tokens is None and total_tokens is None and generated_images is None:
+    if (
+        input_tokens is None
+        and output_tokens is None
+        and total_tokens is None
+        and reasoning_tokens is None
+        and generated_images is None
+    ):
         return None
 
     return Usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
+        reasoning_tokens=reasoning_tokens,
         generated_images=generated_images,
     )
+
+
+def extract_reasoning_tokens(raw_usage: Any) -> Any:
+    if raw_usage is None:
+        return None
+
+    top_level = get_value_from(raw_usage, "reasoning_tokens")
+    if top_level is not None:
+        return top_level
+
+    for details_key in ("completion_tokens_details", "output_tokens_details"):
+        details = get_value_from(raw_usage, details_key)
+        reasoning_tokens = get_value_from(details, "reasoning_tokens")
+        if reasoning_tokens is not None:
+            return reasoning_tokens
+
+    return None
 
 
 def extract_embedding_vector(item: Any) -> list[float]:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from dataclasses import replace
 from typing import Any
 
 from data_designer.config.utils.image_helpers import (
@@ -323,16 +324,21 @@ def extract_reasoning_token_count(raw_usage: Any) -> int | None:
 
 
 def fill_reasoning_token_count_from_content(usage: Usage | None, reasoning_content: str | None) -> Usage | None:
-    if usage is None or usage.reasoning_tokens is not None or not reasoning_content:
+    if usage is None:
+        return None
+    if usage.reasoning_tokens is not None or not reasoning_content:
         return usage
 
     try:
-        usage.reasoning_tokens = count_text_tokens(reasoning_content)
+        reasoning_token_count = count_text_tokens(reasoning_content)
     except Exception:
         logger.debug("Failed to estimate reasoning token count", exc_info=True)
         return usage
-    usage.reasoning_token_count_source = TokenCountSource.ESTIMATED
-    return usage
+    return replace(
+        usage,
+        reasoning_tokens=reasoning_token_count,
+        reasoning_token_count_source=TokenCountSource.ESTIMATED,
+    )
 
 
 def extract_embedding_vector(item: Any) -> list[float]:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from functools import lru_cache
 from typing import Any
 
 from data_designer.config.utils.image_helpers import (
@@ -25,6 +24,7 @@ from data_designer.engine.models.clients.types import (
     Usage,
 )
 from data_designer.engine.models.usage import TokenCountSource
+from data_designer.engine.utils.token_counting import count_text_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -327,26 +327,13 @@ def fill_reasoning_tokens_from_content(usage: Usage | None, reasoning_content: s
     if usage is None or usage.reasoning_tokens is not None or not reasoning_content:
         return usage
 
-    reasoning_tokens = estimate_text_tokens(reasoning_content)
-    if reasoning_tokens is not None:
-        usage.reasoning_tokens = reasoning_tokens
-        usage.reasoning_token_count_source = TokenCountSource.ESTIMATED
-    return usage
-
-
-def estimate_text_tokens(text: str) -> int | None:
     try:
-        return len(_get_tokenizer().encode(text, disallowed_special=()))
+        usage.reasoning_tokens = count_text_tokens(reasoning_content)
     except Exception:
         logger.debug("Failed to estimate reasoning token count", exc_info=True)
-        return None
-
-
-@lru_cache(maxsize=1)
-def _get_tokenizer() -> Any:
-    import tiktoken
-
-    return tiktoken.get_encoding("cl100k_base")
+        return usage
+    usage.reasoning_token_count_source = TokenCountSource.ESTIMATED
+    return usage
 
 
 def extract_embedding_vector(item: Any) -> list[float]:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -46,7 +46,7 @@ def parse_chat_completion_response(response: Any) -> ChatCompletionResponse:
         images=images,
     )
     usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
-    usage = fill_reasoning_tokens_from_content(usage, assistant_message.reasoning_content)
+    usage = fill_reasoning_token_count_from_content(usage, assistant_message.reasoning_content)
     return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
 
 
@@ -62,7 +62,7 @@ async def aparse_chat_completion_response(response: Any) -> ChatCompletionRespon
         images=images,
     )
     usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
-    usage = fill_reasoning_tokens_from_content(usage, assistant_message.reasoning_content)
+    usage = fill_reasoning_token_count_from_content(usage, assistant_message.reasoning_content)
     return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
 
 
@@ -264,7 +264,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
     input_tokens = get_value_from(raw_usage, "prompt_tokens")
     output_tokens = get_value_from(raw_usage, "completion_tokens")
     total_tokens = get_value_from(raw_usage, "total_tokens")
-    reasoning_tokens = extract_reasoning_tokens(raw_usage)
+    reasoning_token_count = extract_reasoning_token_count(raw_usage)
 
     if input_tokens is None:
         input_tokens = get_value_from(raw_usage, "input_tokens")
@@ -274,8 +274,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
     input_tokens = coerce_to_int_or_none(input_tokens)
     output_tokens = coerce_to_int_or_none(output_tokens)
     total_tokens = coerce_to_int_or_none(total_tokens)
-    reasoning_tokens = coerce_to_int_or_none(reasoning_tokens)
-    reasoning_token_count_source = TokenCountSource.PROVIDER if reasoning_tokens is not None else None
+    reasoning_token_count_source = TokenCountSource.PROVIDER if reasoning_token_count is not None else None
 
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens
@@ -291,7 +290,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
         input_tokens is None
         and output_tokens is None
         and total_tokens is None
-        and reasoning_tokens is None
+        and reasoning_token_count is None
         and generated_images is None
     ):
         return None
@@ -300,30 +299,30 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        reasoning_tokens=reasoning_tokens,
+        reasoning_tokens=reasoning_token_count,
         reasoning_token_count_source=reasoning_token_count_source,
         generated_images=generated_images,
     )
 
 
-def extract_reasoning_tokens(raw_usage: Any) -> Any:
+def extract_reasoning_token_count(raw_usage: Any) -> int | None:
     if raw_usage is None:
         return None
 
     top_level = get_value_from(raw_usage, "reasoning_tokens")
     if top_level is not None:
-        return top_level
+        return coerce_to_int_or_none(top_level)
 
     for details_key in ("completion_tokens_details", "output_tokens_details"):
         details = get_value_from(raw_usage, details_key)
-        reasoning_tokens = get_value_from(details, "reasoning_tokens")
-        if reasoning_tokens is not None:
-            return reasoning_tokens
+        reasoning_token_count = get_value_from(details, "reasoning_tokens")
+        if reasoning_token_count is not None:
+            return coerce_to_int_or_none(reasoning_token_count)
 
     return None
 
 
-def fill_reasoning_tokens_from_content(usage: Usage | None, reasoning_content: str | None) -> Usage | None:
+def fill_reasoning_token_count_from_content(usage: Usage | None, reasoning_content: str | None) -> Usage | None:
     if usage is None or usage.reasoning_tokens is not None or not reasoning_content:
         return usage
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from functools import lru_cache
 from typing import Any
 
 from data_designer.config.utils.image_helpers import (
@@ -44,6 +45,7 @@ def parse_chat_completion_response(response: Any) -> ChatCompletionResponse:
         images=images,
     )
     usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
+    usage = fill_reasoning_tokens_from_content(usage, assistant_message.reasoning_content)
     return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
 
 
@@ -59,6 +61,7 @@ async def aparse_chat_completion_response(response: Any) -> ChatCompletionRespon
         images=images,
     )
     usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
+    usage = fill_reasoning_tokens_from_content(usage, assistant_message.reasoning_content)
     return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
 
 
@@ -315,6 +318,31 @@ def extract_reasoning_tokens(raw_usage: Any) -> Any:
             return reasoning_tokens
 
     return None
+
+
+def fill_reasoning_tokens_from_content(usage: Usage | None, reasoning_content: str | None) -> Usage | None:
+    if usage is None or usage.reasoning_tokens is not None or not reasoning_content:
+        return usage
+
+    reasoning_tokens = estimate_text_tokens(reasoning_content)
+    if reasoning_tokens is not None:
+        usage.reasoning_tokens = reasoning_tokens
+    return usage
+
+
+def estimate_text_tokens(text: str) -> int | None:
+    try:
+        return len(_get_tokenizer().encode(text, disallowed_special=()))
+    except Exception:
+        logger.debug("Failed to estimate reasoning token count", exc_info=True)
+        return None
+
+
+@lru_cache(maxsize=1)
+def _get_tokenizer() -> Any:
+    import tiktoken
+
+    return tiktoken.get_encoding("cl100k_base")
 
 
 def extract_embedding_vector(item: Any) -> list[float]:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -24,6 +24,7 @@ from data_designer.engine.models.clients.types import (
     ToolCall,
     Usage,
 )
+from data_designer.engine.models.usage import TokenCountSource
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +275,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
     output_tokens = coerce_to_int_or_none(output_tokens)
     total_tokens = coerce_to_int_or_none(total_tokens)
     reasoning_tokens = coerce_to_int_or_none(reasoning_tokens)
+    reasoning_token_count_source = TokenCountSource.PROVIDER if reasoning_tokens is not None else None
 
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens
@@ -299,6 +301,7 @@ def extract_usage(raw_usage: Any, generated_images: int | None = None) -> Usage 
         output_tokens=output_tokens,
         total_tokens=total_tokens,
         reasoning_tokens=reasoning_tokens,
+        reasoning_token_count_source=reasoning_token_count_source,
         generated_images=generated_images,
     )
 
@@ -327,6 +330,7 @@ def fill_reasoning_tokens_from_content(usage: Usage | None, reasoning_content: s
     reasoning_tokens = estimate_text_tokens(reasoning_content)
     if reasoning_tokens is not None:
         usage.reasoning_tokens = reasoning_tokens
+        usage.reasoning_token_count_source = TokenCountSource.ESTIMATED
     return usage
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields
 from typing import Any, ClassVar, Protocol
 
+from data_designer.engine.models.usage import TokenCountSource
+
 
 class HttpResponse(Protocol):
     """Structural type for HTTP response objects (httpx, requests, etc.)."""
@@ -22,6 +24,7 @@ class Usage:
     output_tokens: int | None = None
     total_tokens: int | None = None
     reasoning_tokens: int | None = None
+    reasoning_token_count_source: TokenCountSource | None = None
     generated_images: int | None = None
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
@@ -21,6 +21,7 @@ class Usage:
     input_tokens: int | None = None
     output_tokens: int | None = None
     total_tokens: int | None = None
+    reasoning_tokens: int | None = None
     generated_images: int | None = None
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
@@ -27,6 +27,12 @@ class Usage:
     reasoning_token_count_source: TokenCountSource | None = None
     generated_images: int | None = None
 
+    def __post_init__(self) -> None:
+        if self.reasoning_tokens is None and self.reasoning_token_count_source is not None:
+            raise ValueError("reasoning_token_count_source requires reasoning_tokens")
+        if self.reasoning_tokens is not None and self.reasoning_token_count_source is None:
+            raise ValueError("reasoning_tokens requires reasoning_token_count_source")
+
 
 @dataclass
 class ImagePayload:

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -36,7 +36,13 @@ from data_designer.engine.models.errors import (
 )
 from data_designer.engine.models.parsers.errors import ParserException
 from data_designer.engine.models.telemetry import TELEMETRY_ENABLED
-from data_designer.engine.models.usage import ImageUsageStats, ModelUsageStats, RequestUsageStats, TokenUsageStats
+from data_designer.engine.models.usage import (
+    ImageUsageStats,
+    ModelUsageStats,
+    RequestUsageStats,
+    TokenCountSource,
+    TokenUsageStats,
+)
 from data_designer.engine.models.utils import ChatMessage, prompt_to_messages
 
 if TYPE_CHECKING:
@@ -811,10 +817,14 @@ class ModelFacade:
 
         token_usage = None
         if usage is not None and usage.input_tokens is not None:
+            reasoning_token_count_source = usage.reasoning_token_count_source
+            if usage.reasoning_tokens is not None and reasoning_token_count_source is None:
+                reasoning_token_count_source = TokenCountSource.PROVIDER
             token_usage = TokenUsageStats(
                 input_tokens=usage.input_tokens,
                 output_tokens=usage.output_tokens or 0,
-                reasoning_tokens=usage.reasoning_tokens or 0,
+                reasoning_tokens=usage.reasoning_tokens,
+                reasoning_token_count_source=reasoning_token_count_source,
             )
 
         self._usage_stats.extend(

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -814,6 +814,7 @@ class ModelFacade:
             token_usage = TokenUsageStats(
                 input_tokens=usage.input_tokens,
                 output_tokens=usage.output_tokens or 0,
+                reasoning_tokens=usage.reasoning_tokens or 0,
             )
 
         self._usage_stats.extend(

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -40,7 +40,6 @@ from data_designer.engine.models.usage import (
     ImageUsageStats,
     ModelUsageStats,
     RequestUsageStats,
-    TokenCountSource,
     TokenUsageStats,
 )
 from data_designer.engine.models.utils import ChatMessage, prompt_to_messages
@@ -817,14 +816,11 @@ class ModelFacade:
 
         token_usage = None
         if usage is not None and usage.input_tokens is not None:
-            reasoning_token_count_source = usage.reasoning_token_count_source
-            if usage.reasoning_tokens is not None and reasoning_token_count_source is None:
-                reasoning_token_count_source = TokenCountSource.PROVIDER
             token_usage = TokenUsageStats(
                 input_tokens=usage.input_tokens,
                 output_tokens=usage.output_tokens or 0,
                 reasoning_tokens=usage.reasoning_tokens,
-                reasoning_token_count_source=reasoning_token_count_source,
+                reasoning_token_count_source=usage.reasoning_token_count_source,
             )
 
         self._usage_stats.extend(

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -32,8 +32,6 @@ def format_reasoning_tokens(reasoning_tokens: int | None, source: TokenCountSour
         return "unknown"
     if source == TokenCountSource.ESTIMATED or source == TokenCountSource.ESTIMATED.value:
         return f"{reasoning_tokens} (estimated)"
-    if source == TokenCountSource.MIXED or source == TokenCountSource.MIXED.value:
-        return f"{reasoning_tokens} (mixed)"
     return str(reasoning_tokens)
 
 
@@ -142,8 +140,6 @@ class ModelRegistry:
             )
             if token_usage.get("reasoning_token_count_source") == TokenCountSource.ESTIMATED.value:
                 logger.info(f"{LOG_INDENT}reasoning token count estimated with tiktoken")
-            elif token_usage.get("reasoning_token_count_source") == TokenCountSource.MIXED.value:
-                logger.info(f"{LOG_INDENT}reasoning token count combines provider-reported and estimated counts")
 
             request_usage = stats["request_usage"]
             successful_requests = request_usage["successful_requests"]

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from data_designer.config.models import GenerationType, ModelConfig
 from data_designer.engine.model_provider import ModelProvider, ModelProviderRegistry
-from data_designer.engine.models.usage import ModelUsageStats, RequestUsageStats, TokenUsageStats
+from data_designer.engine.models.usage import ModelUsageStats, RequestUsageStats, TokenCountSource, TokenUsageStats
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.logging import LOG_INDENT
 
@@ -25,6 +25,22 @@ if TYPE_CHECKING:
     ]
 
 logger = logging.getLogger(__name__)
+
+
+def format_reasoning_tokens(reasoning_tokens: int | None, source: TokenCountSource | str | None) -> str:
+    if reasoning_tokens is None:
+        return "unknown"
+    if source == TokenCountSource.ESTIMATED or source == TokenCountSource.ESTIMATED.value:
+        return f"{reasoning_tokens} (estimated)"
+    if source == TokenCountSource.MIXED or source == TokenCountSource.MIXED.value:
+        return f"{reasoning_tokens} (mixed)"
+    return str(reasoning_tokens)
+
+
+def get_token_delta(current: int | None, previous: int | None) -> int | None:
+    if current is None:
+        return None
+    return current - (previous or 0)
 
 
 class ModelRegistry:
@@ -113,7 +129,10 @@ class ModelRegistry:
             token_usage = stats["token_usage"]
             input_tokens = token_usage["input_tokens"]
             output_tokens = token_usage["output_tokens"]
-            reasoning_tokens = token_usage["reasoning_tokens"]
+            reasoning_tokens = format_reasoning_tokens(
+                token_usage.get("reasoning_tokens"),
+                token_usage.get("reasoning_token_count_source"),
+            )
             total_tokens = token_usage["total_tokens"]
             tokens_per_second = stats["tokens_per_second"]
             logger.info(
@@ -121,6 +140,10 @@ class ModelRegistry:
                 f"input={input_tokens}, output={output_tokens}, reasoning={reasoning_tokens}, "
                 f"total={total_tokens}, tps={tokens_per_second}"
             )
+            if token_usage.get("reasoning_token_count_source") == TokenCountSource.ESTIMATED.value:
+                logger.info(f"{LOG_INDENT}reasoning token count estimated with tiktoken")
+            elif token_usage.get("reasoning_token_count_source") == TokenCountSource.MIXED.value:
+                logger.info(f"{LOG_INDENT}reasoning token count combines provider-reported and estimated counts")
 
             request_usage = stats["request_usage"]
             successful_requests = request_usage["successful_requests"]
@@ -163,18 +186,30 @@ class ModelRegistry:
             prev = snapshot.get(model_name)
             delta_input = current.token_usage.input_tokens - (prev.token_usage.input_tokens if prev else 0)
             delta_output = current.token_usage.output_tokens - (prev.token_usage.output_tokens if prev else 0)
-            delta_reasoning = current.token_usage.reasoning_tokens - (prev.token_usage.reasoning_tokens if prev else 0)
+            delta_reasoning = get_token_delta(
+                current.token_usage.reasoning_tokens,
+                prev.token_usage.reasoning_tokens if prev else None,
+            )
             delta_successful = current.request_usage.successful_requests - (
                 prev.request_usage.successful_requests if prev else 0
             )
             delta_failed = current.request_usage.failed_requests - (prev.request_usage.failed_requests if prev else 0)
 
-            if delta_input > 0 or delta_output > 0 or delta_reasoning > 0 or delta_successful > 0 or delta_failed > 0:
+            if (
+                delta_input > 0
+                or delta_output > 0
+                or (delta_reasoning is not None and delta_reasoning > 0)
+                or delta_successful > 0
+                or delta_failed > 0
+            ):
                 deltas[model_name] = ModelUsageStats(
                     token_usage=TokenUsageStats(
                         input_tokens=delta_input,
                         output_tokens=delta_output,
                         reasoning_tokens=delta_reasoning,
+                        reasoning_token_count_source=current.token_usage.reasoning_token_count_source
+                        if delta_reasoning is not None
+                        else None,
                     ),
                     request_usage=RequestUsageStats(successful_requests=delta_successful, failed_requests=delta_failed),
                 )

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -27,9 +27,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def format_reasoning_tokens(reasoning_tokens: int | None, source: TokenCountSource | str | None) -> str:
-    if reasoning_tokens is None:
-        return "unknown"
+def format_reasoning_tokens(reasoning_tokens: int, source: TokenCountSource | str | None) -> str:
     if source == TokenCountSource.ESTIMATED or source == TokenCountSource.ESTIMATED.value:
         return f"{reasoning_tokens} (estimated)"
     return str(reasoning_tokens)
@@ -127,17 +125,15 @@ class ModelRegistry:
             token_usage = stats["token_usage"]
             input_tokens = token_usage["input_tokens"]
             output_tokens = token_usage["output_tokens"]
-            reasoning_tokens = format_reasoning_tokens(
-                token_usage.get("reasoning_tokens"),
-                token_usage.get("reasoning_token_count_source"),
-            )
             total_tokens = token_usage["total_tokens"]
             tokens_per_second = stats["tokens_per_second"]
-            logger.info(
-                f"{LOG_INDENT}tokens: "
-                f"input={input_tokens}, output={output_tokens}, reasoning={reasoning_tokens}, "
-                f"total={total_tokens}, tps={tokens_per_second}"
-            )
+            token_parts = [f"input={input_tokens}", f"output={output_tokens}"]
+            if (reasoning_tokens := token_usage.get("reasoning_tokens")) is not None:
+                token_parts.append(
+                    f"reasoning={format_reasoning_tokens(reasoning_tokens, token_usage.get('reasoning_token_count_source'))}"
+                )
+            token_parts.extend([f"total={total_tokens}", f"tps={tokens_per_second}"])
+            logger.info(f"{LOG_INDENT}tokens: {', '.join(token_parts)}")
             if token_usage.get("reasoning_token_count_source") == TokenCountSource.ESTIMATED.value:
                 logger.info(f"{LOG_INDENT}reasoning token count estimated with tiktoken")
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -160,14 +160,19 @@ class ModelRegistry:
             prev = snapshot.get(model_name)
             delta_input = current.token_usage.input_tokens - (prev.token_usage.input_tokens if prev else 0)
             delta_output = current.token_usage.output_tokens - (prev.token_usage.output_tokens if prev else 0)
+            delta_reasoning = current.token_usage.reasoning_tokens - (prev.token_usage.reasoning_tokens if prev else 0)
             delta_successful = current.request_usage.successful_requests - (
                 prev.request_usage.successful_requests if prev else 0
             )
             delta_failed = current.request_usage.failed_requests - (prev.request_usage.failed_requests if prev else 0)
 
-            if delta_input > 0 or delta_output > 0 or delta_successful > 0 or delta_failed > 0:
+            if delta_input > 0 or delta_output > 0 or delta_reasoning > 0 or delta_successful > 0 or delta_failed > 0:
                 deltas[model_name] = ModelUsageStats(
-                    token_usage=TokenUsageStats(input_tokens=delta_input, output_tokens=delta_output),
+                    token_usage=TokenUsageStats(
+                        input_tokens=delta_input,
+                        output_tokens=delta_output,
+                        reasoning_tokens=delta_reasoning,
+                    ),
                     request_usage=RequestUsageStats(successful_requests=delta_successful, failed_requests=delta_failed),
                 )
         return deltas

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -27,13 +27,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def format_reasoning_tokens(reasoning_tokens: int, source: TokenCountSource | str | None) -> str:
+def format_reasoning_token_count(reasoning_token_count: int, source: TokenCountSource | str | None) -> str:
     if source == TokenCountSource.ESTIMATED or source == TokenCountSource.ESTIMATED.value:
-        return f"{reasoning_tokens} (estimated)"
-    return str(reasoning_tokens)
+        return f"{reasoning_token_count} (estimated)"
+    return str(reasoning_token_count)
 
 
-def get_token_delta(current: int | None, previous: int | None) -> int | None:
+def get_token_count_delta(current: int | None, previous: int | None) -> int | None:
     if current is None:
         return None
     return current - (previous or 0)
@@ -128,10 +128,12 @@ class ModelRegistry:
             total_tokens = token_usage["total_tokens"]
             tokens_per_second = stats["tokens_per_second"]
             token_parts = [f"input={input_tokens}", f"output={output_tokens}"]
-            if (reasoning_tokens := token_usage.get("reasoning_tokens")) is not None:
-                token_parts.append(
-                    f"reasoning={format_reasoning_tokens(reasoning_tokens, token_usage.get('reasoning_token_count_source'))}"
+            if (reasoning_token_count := token_usage.get("reasoning_tokens")) is not None:
+                formatted_reasoning_token_count = format_reasoning_token_count(
+                    reasoning_token_count,
+                    token_usage.get("reasoning_token_count_source"),
                 )
+                token_parts.append(f"reasoning={formatted_reasoning_token_count}")
             token_parts.extend([f"total={total_tokens}", f"tps={tokens_per_second}"])
             logger.info(f"{LOG_INDENT}tokens: {', '.join(token_parts)}")
             if token_usage.get("reasoning_token_count_source") == TokenCountSource.ESTIMATED.value:
@@ -178,7 +180,7 @@ class ModelRegistry:
             prev = snapshot.get(model_name)
             delta_input = current.token_usage.input_tokens - (prev.token_usage.input_tokens if prev else 0)
             delta_output = current.token_usage.output_tokens - (prev.token_usage.output_tokens if prev else 0)
-            delta_reasoning = get_token_delta(
+            delta_reasoning_token_count = get_token_count_delta(
                 current.token_usage.reasoning_tokens,
                 prev.token_usage.reasoning_tokens if prev else None,
             )
@@ -190,7 +192,7 @@ class ModelRegistry:
             if (
                 delta_input > 0
                 or delta_output > 0
-                or (delta_reasoning is not None and delta_reasoning > 0)
+                or (delta_reasoning_token_count is not None and delta_reasoning_token_count > 0)
                 or delta_successful > 0
                 or delta_failed > 0
             ):
@@ -198,9 +200,9 @@ class ModelRegistry:
                     token_usage=TokenUsageStats(
                         input_tokens=delta_input,
                         output_tokens=delta_output,
-                        reasoning_tokens=delta_reasoning,
+                        reasoning_tokens=delta_reasoning_token_count,
                         reasoning_token_count_source=current.token_usage.reasoning_token_count_source
-                        if delta_reasoning is not None
+                        if delta_reasoning_token_count is not None
                         else None,
                     ),
                     request_usage=RequestUsageStats(successful_requests=delta_successful, failed_requests=delta_failed),

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -113,10 +113,13 @@ class ModelRegistry:
             token_usage = stats["token_usage"]
             input_tokens = token_usage["input_tokens"]
             output_tokens = token_usage["output_tokens"]
+            reasoning_tokens = token_usage["reasoning_tokens"]
             total_tokens = token_usage["total_tokens"]
             tokens_per_second = stats["tokens_per_second"]
             logger.info(
-                f"{LOG_INDENT}tokens: input={input_tokens}, output={output_tokens}, total={total_tokens}, tps={tokens_per_second}"
+                f"{LOG_INDENT}tokens: "
+                f"input={input_tokens}, output={output_tokens}, reasoning={reasoning_tokens}, "
+                f"total={total_tokens}, tps={tokens_per_second}"
             )
 
             request_usage = stats["request_usage"]

--- a/packages/data-designer-engine/src/data_designer/engine/models/usage.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/usage.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 class TokenCountSource(str, Enum):
     PROVIDER = "provider"
     ESTIMATED = "estimated"
-    MIXED = "mixed"
 
 
 class TokenUsageStats(BaseModel):
@@ -73,9 +72,9 @@ def merge_token_count_sources(
 
     current_source = TokenCountSource(current)
     incoming_source = TokenCountSource(incoming)
-    if current_source == incoming_source:
-        return current_source.value
-    return TokenCountSource.MIXED.value
+    if current_source == TokenCountSource.ESTIMATED or incoming_source == TokenCountSource.ESTIMATED:
+        return TokenCountSource.ESTIMATED.value
+    return TokenCountSource.PROVIDER.value
 
 
 class RequestUsageStats(BaseModel):

--- a/packages/data-designer-engine/src/data_designer/engine/models/usage.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/usage.py
@@ -4,16 +4,34 @@
 from __future__ import annotations
 
 import logging
+from enum import Enum
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field, model_validator
 
 logger = logging.getLogger(__name__)
 
 
+class TokenCountSource(str, Enum):
+    PROVIDER = "provider"
+    ESTIMATED = "estimated"
+    MIXED = "mixed"
+
+
 class TokenUsageStats(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     input_tokens: int = 0
     output_tokens: int = 0
-    reasoning_tokens: int = 0
+    reasoning_tokens: int | None = None
+    reasoning_token_count_source: TokenCountSource | None = None
+
+    @model_validator(mode="after")
+    def validate_reasoning_token_count_source(self) -> TokenUsageStats:
+        if self.reasoning_tokens is None and self.reasoning_token_count_source is not None:
+            raise ValueError("reasoning_token_count_source requires reasoning_tokens")
+        if self.reasoning_tokens is not None and self.reasoning_token_count_source is None:
+            raise ValueError("reasoning_tokens requires reasoning_token_count_source")
+        return self
 
     @computed_field
     def total_tokens(self) -> int:
@@ -23,10 +41,41 @@ class TokenUsageStats(BaseModel):
     def has_usage(self) -> bool:
         return self.total_tokens > 0
 
-    def extend(self, *, input_tokens: int, output_tokens: int, reasoning_tokens: int = 0) -> None:
+    def extend(
+        self,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        reasoning_tokens: int | None = None,
+        reasoning_token_count_source: TokenCountSource | None = None,
+    ) -> None:
+        if reasoning_tokens is not None and reasoning_token_count_source is None:
+            raise ValueError("reasoning_tokens requires reasoning_token_count_source")
+
         self.input_tokens += input_tokens
         self.output_tokens += output_tokens
-        self.reasoning_tokens += reasoning_tokens
+        if reasoning_tokens is not None:
+            self.reasoning_tokens = (self.reasoning_tokens or 0) + reasoning_tokens
+            self.reasoning_token_count_source = merge_token_count_sources(
+                self.reasoning_token_count_source,
+                reasoning_token_count_source,
+            )
+
+
+def merge_token_count_sources(
+    current: TokenCountSource | str | None,
+    incoming: TokenCountSource | str | None,
+) -> str | None:
+    if incoming is None:
+        return TokenCountSource(current).value if current is not None else None
+    if current is None:
+        return TokenCountSource(incoming).value
+
+    current_source = TokenCountSource(current)
+    incoming_source = TokenCountSource(incoming)
+    if current_source == incoming_source:
+        return current_source.value
+    return TokenCountSource.MIXED.value
 
 
 class RequestUsageStats(BaseModel):
@@ -108,6 +157,7 @@ class ModelUsageStats(BaseModel):
                 input_tokens=token_usage.input_tokens,
                 output_tokens=token_usage.output_tokens,
                 reasoning_tokens=token_usage.reasoning_tokens,
+                reasoning_token_count_source=token_usage.reasoning_token_count_source,
             )
         if request_usage is not None:
             self.request_usage.extend(

--- a/packages/data-designer-engine/src/data_designer/engine/models/usage.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/usage.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class TokenUsageStats(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+    reasoning_tokens: int = 0
 
     @computed_field
     def total_tokens(self) -> int:
@@ -22,9 +23,10 @@ class TokenUsageStats(BaseModel):
     def has_usage(self) -> bool:
         return self.total_tokens > 0
 
-    def extend(self, *, input_tokens: int, output_tokens: int) -> None:
+    def extend(self, *, input_tokens: int, output_tokens: int, reasoning_tokens: int = 0) -> None:
         self.input_tokens += input_tokens
         self.output_tokens += output_tokens
+        self.reasoning_tokens += reasoning_tokens
 
 
 class RequestUsageStats(BaseModel):
@@ -102,7 +104,11 @@ class ModelUsageStats(BaseModel):
         image_usage: ImageUsageStats | None = None,
     ) -> None:
         if token_usage is not None:
-            self.token_usage.extend(input_tokens=token_usage.input_tokens, output_tokens=token_usage.output_tokens)
+            self.token_usage.extend(
+                input_tokens=token_usage.input_tokens,
+                output_tokens=token_usage.output_tokens,
+                reasoning_tokens=token_usage.reasoning_tokens,
+            )
         if request_usage is not None:
             self.request_usage.extend(
                 successful_requests=request_usage.successful_requests, failed_requests=request_usage.failed_requests

--- a/packages/data-designer-engine/src/data_designer/engine/utils/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/utils/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py
+++ b/packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import tiktoken
+
+
+def count_text_tokens(text: str) -> int:
+    return len(get_cl100k_base_tokenizer().encode(text, disallowed_special=()))
+
+
+@lru_cache(maxsize=1)
+def get_cl100k_base_tokenizer() -> tiktoken.Encoding:
+    return tiktoken.get_encoding("cl100k_base")

--- a/packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py
+++ b/packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
-import tiktoken
+import data_designer.lazy_heavy_imports as lazy
+
+if TYPE_CHECKING:
+    import tiktoken
 
 
 def count_text_tokens(text: str) -> int:
@@ -14,4 +18,4 @@ def count_text_tokens(text: str) -> int:
 
 @lru_cache(maxsize=1)
 def get_cl100k_base_tokenizer() -> tiktoken.Encoding:
-    return tiktoken.get_encoding("cl100k_base")
+    return lazy.tiktoken.get_encoding("cl100k_base")

--- a/packages/data-designer-engine/tests/engine/analysis/utils/test_column_statistics_calculations.py
+++ b/packages/data-designer-engine/tests/engine/analysis/utils/test_column_statistics_calculations.py
@@ -27,7 +27,6 @@ from data_designer.engine.analysis.utils.column_statistics_calculations import (
     ensure_boolean,
     ensure_hashable,
 )
-from data_designer.engine.utils.token_counting import get_cl100k_base_tokenizer
 
 
 @pytest.fixture
@@ -350,11 +349,3 @@ def test_calculate_general_column_info_edge_cases():
     assert result["num_records"] == 0
     assert result["num_null"] == 0
     assert result["simple_dtype"] == MissingValue.CALCULATION_FAILED
-
-
-def test_get_cl100k_base_tokenizer_returns_cached_instance() -> None:
-    """get_cl100k_base_tokenizer returns the same cached tokenizer instance."""
-    get_cl100k_base_tokenizer.cache_clear()
-    tokenizer1 = get_cl100k_base_tokenizer()
-    tokenizer2 = get_cl100k_base_tokenizer()
-    assert tokenizer1 is tokenizer2

--- a/packages/data-designer-engine/tests/engine/analysis/utils/test_column_statistics_calculations.py
+++ b/packages/data-designer-engine/tests/engine/analysis/utils/test_column_statistics_calculations.py
@@ -18,7 +18,6 @@ from data_designer.config.analysis.column_statistics import (
 from data_designer.config.column_configs import LLMTextColumnConfig
 from data_designer.config.utils.numerical_helpers import prepare_number_for_reporting
 from data_designer.engine.analysis.utils.column_statistics_calculations import (
-    _get_tokenizer,
     calculate_column_distribution,
     calculate_general_column_info,
     calculate_input_token_stats,
@@ -28,6 +27,7 @@ from data_designer.engine.analysis.utils.column_statistics_calculations import (
     ensure_boolean,
     ensure_hashable,
 )
+from data_designer.engine.utils.token_counting import get_cl100k_base_tokenizer
 
 
 @pytest.fixture
@@ -352,9 +352,9 @@ def test_calculate_general_column_info_edge_cases():
     assert result["simple_dtype"] == MissingValue.CALCULATION_FAILED
 
 
-def test_get_tokenizer_returns_cached_instance() -> None:
-    """_get_tokenizer returns the same cached tokenizer instance."""
-    _get_tokenizer.cache_clear()
-    tokenizer1 = _get_tokenizer()
-    tokenizer2 = _get_tokenizer()
+def test_get_cl100k_base_tokenizer_returns_cached_instance() -> None:
+    """get_cl100k_base_tokenizer returns the same cached tokenizer instance."""
+    get_cl100k_base_tokenizer.cache_clear()
+    tokenizer1 = get_cl100k_base_tokenizer()
+    tokenizer2 = get_cl100k_base_tokenizer()
     assert tokenizer1 is tokenizer2

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -239,7 +239,7 @@ def test_merge_system_parts_normalizes_supported_inputs(
 
 
 def test_parse_anthropic_response_maps_tool_use_and_thinking(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 4)
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 4)
 
     response = parse_anthropic_response(
         {

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -239,7 +239,11 @@ def test_merge_system_parts_normalizes_supported_inputs(
 
 
 def test_parse_anthropic_response_maps_tool_use_and_thinking(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 4)
+    def count_reasoning_text(text: str) -> int:
+        assert text == "Let me reason."
+        return 4
+
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", count_reasoning_text)
 
     response = parse_anthropic_response(
         {

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -26,6 +26,7 @@ from data_designer.engine.models.clients.adapters.anthropic_translation import (
     translate_tool_result_message,
 )
 from data_designer.engine.models.clients.types import ChatCompletionRequest
+from data_designer.engine.models.usage import TokenCountSource
 from data_designer.engine.models.utils import ChatMessage
 
 MODEL = "claude-test"
@@ -257,6 +258,7 @@ def test_parse_anthropic_response_maps_tool_use_and_thinking(monkeypatch: pytest
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 5
     assert response.usage.reasoning_tokens == 4
+    assert response.usage.reasoning_token_count_source == TokenCountSource.ESTIMATED
     assert json.loads(response.message.tool_calls[0].arguments_json) == {"query": "weather"}
 
 

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -253,6 +253,8 @@ def test_parse_anthropic_response_maps_tool_use_and_thinking() -> None:
     assert response.message.reasoning_content == "Let me reason."
     assert response.usage is not None
     assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 5
+    assert response.usage.reasoning_tokens is None
     assert json.loads(response.message.tool_calls[0].arguments_json) == {"query": "weather"}
 
 

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py
@@ -237,7 +237,9 @@ def test_merge_system_parts_normalizes_supported_inputs(
     assert merge_system_parts(parts) == expected
 
 
-def test_parse_anthropic_response_maps_tool_use_and_thinking() -> None:
+def test_parse_anthropic_response_maps_tool_use_and_thinking(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 4)
+
     response = parse_anthropic_response(
         {
             "content": [
@@ -254,7 +256,7 @@ def test_parse_anthropic_response_maps_tool_use_and_thinking() -> None:
     assert response.usage is not None
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 5
-    assert response.usage.reasoning_tokens is None
+    assert response.usage.reasoning_tokens == 4
     assert json.loads(response.message.tool_calls[0].arguments_json) == {"query": "weather"}
 
 

--- a/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
@@ -16,6 +16,7 @@ from data_designer.engine.models.clients.types import (
     EmbeddingRequest,
     ImageGenerationRequest,
 )
+from data_designer.engine.models.usage import TokenCountSource
 from tests.engine.models.clients.conftest import make_mock_async_client, make_mock_sync_client
 
 PROVIDER = "test-provider"
@@ -92,6 +93,7 @@ def test_completion_maps_canonical_fields() -> None:
     assert result.usage.input_tokens == 10
     assert result.usage.output_tokens == 5
     assert result.usage.reasoning_tokens == 3
+    assert result.usage.reasoning_token_count_source == TokenCountSource.PROVIDER
 
 
 def test_completion_with_tool_calls() -> None:

--- a/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
@@ -46,6 +46,7 @@ def _make_client(
 def _chat_response(
     content: str = "Hello!",
     reasoning: str | None = None,
+    reasoning_tokens: int | None = None,
     tool_calls: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     message: dict[str, Any] = {"role": "assistant", "content": content}
@@ -55,7 +56,12 @@ def _chat_response(
         message["tool_calls"] = tool_calls
     return {
         "choices": [{"index": 0, "message": message, "finish_reason": "stop"}],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "completion_tokens_details": {"reasoning_tokens": reasoning_tokens} if reasoning_tokens is not None else {},
+            "total_tokens": 15,
+        },
     }
 
 
@@ -74,7 +80,7 @@ def _image_response() -> dict[str, Any]:
 
 
 def test_completion_maps_canonical_fields() -> None:
-    response_json = _chat_response(content="Hello!", reasoning="step-by-step")
+    response_json = _chat_response(content="Hello!", reasoning="step-by-step", reasoning_tokens=3)
     client = _make_client(sync_client=make_mock_sync_client(response_json))
 
     request = ChatCompletionRequest(model=MODEL, messages=[{"role": "user", "content": "Hi"}])
@@ -85,6 +91,7 @@ def test_completion_maps_canonical_fields() -> None:
     assert result.usage is not None
     assert result.usage.input_tokens == 10
     assert result.usage.output_tokens == 5
+    assert result.usage.reasoning_tokens == 3
 
 
 def test_completion_with_tool_calls() -> None:

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -17,6 +17,7 @@ from data_designer.engine.models.clients.types import (
     ImageGenerationRequest,
     TransportKwargs,
 )
+from data_designer.engine.models.usage import TokenCountSource
 
 # --- TransportKwargs.from_request: extra_body flattening (default) ---
 
@@ -291,6 +292,9 @@ def test_extract_usage_reasoning_tokens(raw_usage: dict[str, object], expected_r
 
     assert usage is not None
     assert usage.reasoning_tokens == expected_reasoning_tokens
+    assert usage.reasoning_token_count_source == (
+        TokenCountSource.PROVIDER if expected_reasoning_tokens is not None else None
+    )
 
 
 def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens() -> None:
@@ -302,6 +306,7 @@ def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens(
     assert usage.input_tokens == 10
     assert usage.output_tokens == 7
     assert usage.reasoning_tokens == 4
+    assert usage.reasoning_token_count_source == TokenCountSource.PROVIDER
     assert usage.total_tokens == 17
 
 
@@ -321,6 +326,7 @@ def test_parse_chat_completion_estimates_reasoning_tokens_from_reasoning_content
     assert result.usage.input_tokens == 10
     assert result.usage.output_tokens == 7
     assert result.usage.reasoning_tokens == 6
+    assert result.usage.reasoning_token_count_source == TokenCountSource.ESTIMATED
     assert result.usage.total_tokens == 17
 
 
@@ -343,3 +349,4 @@ def test_parse_chat_completion_prefers_provider_reasoning_token_count(
 
     assert result.usage is not None
     assert result.usage.reasoning_tokens == 4
+    assert result.usage.reasoning_token_count_source == TokenCountSource.PROVIDER

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-from data_designer.engine.models.clients.parsing import extract_reasoning_content, extract_tool_calls
+from data_designer.engine.models.clients.parsing import extract_reasoning_content, extract_tool_calls, extract_usage
 from data_designer.engine.models.clients.types import (
     ChatCompletionRequest,
     EmbeddingRequest,
@@ -251,3 +251,50 @@ def test_extract_reasoning_content_works_with_object_style_message() -> None:
         reasoning_content = "legacy object"
 
     assert extract_reasoning_content(Msg()) == "from object"
+
+
+# --- extract_usage ---
+
+
+@pytest.mark.parametrize(
+    ("raw_usage", "expected_reasoning_tokens"),
+    [
+        pytest.param(
+            {"prompt_tokens": 10, "completion_tokens": 7, "completion_tokens_details": {"reasoning_tokens": 4}},
+            4,
+            id="openai-chat-completions",
+        ),
+        pytest.param(
+            {"input_tokens": 10, "output_tokens": 7, "output_tokens_details": {"reasoning_tokens": "4"}},
+            4,
+            id="openai-responses",
+        ),
+        pytest.param(
+            {"input_tokens": 10, "output_tokens": 7, "reasoning_tokens": 4},
+            4,
+            id="top-level-provider-variant",
+        ),
+        pytest.param(
+            {"input_tokens": 10, "output_tokens": 7},
+            None,
+            id="not-reported",
+        ),
+    ],
+)
+def test_extract_usage_reasoning_tokens(raw_usage: dict[str, object], expected_reasoning_tokens: int | None) -> None:
+    usage = extract_usage(raw_usage)
+
+    assert usage is not None
+    assert usage.reasoning_tokens == expected_reasoning_tokens
+
+
+def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens() -> None:
+    usage = extract_usage(
+        {"prompt_tokens": 10, "completion_tokens": 7, "completion_tokens_details": {"reasoning_tokens": 4}}
+    )
+
+    assert usage is not None
+    assert usage.input_tokens == 10
+    assert usage.output_tokens == 7
+    assert usage.reasoning_tokens == 4
+    assert usage.total_tokens == 17

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -313,7 +313,7 @@ def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens(
 def test_parse_chat_completion_estimates_reasoning_tokens_from_reasoning_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 6)
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 6)
 
     response = {
         "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],
@@ -333,7 +333,7 @@ def test_parse_chat_completion_estimates_reasoning_tokens_from_reasoning_content
 def test_parse_chat_completion_prefers_provider_reasoning_token_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 999)
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 999)
 
     response = {
         "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -263,7 +263,7 @@ def test_extract_reasoning_content_works_with_object_style_message() -> None:
 
 
 @pytest.mark.parametrize(
-    ("raw_usage", "expected_reasoning_tokens"),
+    ("raw_usage", "expected_reasoning_token_count"),
     [
         pytest.param(
             {"prompt_tokens": 10, "completion_tokens": 7, "completion_tokens_details": {"reasoning_tokens": 4}},
@@ -287,17 +287,20 @@ def test_extract_reasoning_content_works_with_object_style_message() -> None:
         ),
     ],
 )
-def test_extract_usage_reasoning_tokens(raw_usage: dict[str, object], expected_reasoning_tokens: int | None) -> None:
+def test_extract_usage_reasoning_token_count(
+    raw_usage: dict[str, object],
+    expected_reasoning_token_count: int | None,
+) -> None:
     usage = extract_usage(raw_usage)
 
     assert usage is not None
-    assert usage.reasoning_tokens == expected_reasoning_tokens
+    assert usage.reasoning_tokens == expected_reasoning_token_count
     assert usage.reasoning_token_count_source == (
-        TokenCountSource.PROVIDER if expected_reasoning_tokens is not None else None
+        TokenCountSource.PROVIDER if expected_reasoning_token_count is not None else None
     )
 
 
-def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens() -> None:
+def test_extract_usage_reasoning_token_count_is_not_added_to_output_or_total_tokens() -> None:
     usage = extract_usage(
         {"prompt_tokens": 10, "completion_tokens": 7, "completion_tokens_details": {"reasoning_tokens": 4}}
     )
@@ -310,7 +313,7 @@ def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens(
     assert usage.total_tokens == 17
 
 
-def test_parse_chat_completion_estimates_reasoning_tokens_from_reasoning_content(
+def test_parse_chat_completion_estimates_reasoning_token_count_from_reasoning_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 6)

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -9,6 +9,7 @@ from data_designer.engine.models.clients.parsing import (
     extract_reasoning_content,
     extract_tool_calls,
     extract_usage,
+    fill_reasoning_token_count_from_content,
     parse_chat_completion_response,
 )
 from data_designer.engine.models.clients.types import (
@@ -16,6 +17,7 @@ from data_designer.engine.models.clients.types import (
     EmbeddingRequest,
     ImageGenerationRequest,
     TransportKwargs,
+    Usage,
 )
 from data_designer.engine.models.usage import TokenCountSource
 
@@ -316,7 +318,11 @@ def test_extract_usage_reasoning_token_count_is_not_added_to_output_or_total_tok
 def test_parse_chat_completion_estimates_reasoning_token_count_from_reasoning_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 6)
+    def count_reasoning_text(text: str) -> int:
+        assert text == "hidden thinking"
+        return 6
+
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", count_reasoning_text)
 
     response = {
         "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],
@@ -336,7 +342,10 @@ def test_parse_chat_completion_estimates_reasoning_token_count_from_reasoning_co
 def test_parse_chat_completion_prefers_provider_reasoning_token_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", lambda text: 999)
+    def fail_count_text_tokens(text: str) -> int:
+        raise AssertionError(f"Unexpected reasoning token estimate for {text!r}")
+
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", fail_count_text_tokens)
 
     response = {
         "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],
@@ -353,3 +362,35 @@ def test_parse_chat_completion_prefers_provider_reasoning_token_count(
     assert result.usage is not None
     assert result.usage.reasoning_tokens == 4
     assert result.usage.reasoning_token_count_source == TokenCountSource.PROVIDER
+
+
+def test_fill_reasoning_token_count_from_content_skips_when_usage_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_count_text_tokens(text: str) -> int:
+        raise AssertionError(f"Unexpected reasoning token estimate for {text!r}")
+
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", fail_count_text_tokens)
+
+    assert fill_reasoning_token_count_from_content(None, "hidden thinking") is None
+
+
+def test_fill_reasoning_token_count_from_content_preserves_provider_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_count_text_tokens(text: str) -> int:
+        raise AssertionError(f"Unexpected reasoning token estimate for {text!r}")
+
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.count_text_tokens", fail_count_text_tokens)
+    usage = Usage(
+        input_tokens=10,
+        output_tokens=7,
+        reasoning_tokens=0,
+        reasoning_token_count_source=TokenCountSource.PROVIDER,
+    )
+
+    result = fill_reasoning_token_count_from_content(usage, "hidden thinking")
+
+    assert result is usage
+    assert result.reasoning_tokens == 0
+    assert result.reasoning_token_count_source == TokenCountSource.PROVIDER

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 import pytest
 
-from data_designer.engine.models.clients.parsing import extract_reasoning_content, extract_tool_calls, extract_usage
+from data_designer.engine.models.clients.parsing import (
+    extract_reasoning_content,
+    extract_tool_calls,
+    extract_usage,
+    parse_chat_completion_response,
+)
 from data_designer.engine.models.clients.types import (
     ChatCompletionRequest,
     EmbeddingRequest,
@@ -298,3 +303,43 @@ def test_extract_usage_reasoning_tokens_are_not_added_to_output_or_total_tokens(
     assert usage.output_tokens == 7
     assert usage.reasoning_tokens == 4
     assert usage.total_tokens == 17
+
+
+def test_parse_chat_completion_estimates_reasoning_tokens_from_reasoning_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 6)
+
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17},
+    }
+
+    result = parse_chat_completion_response(response)
+
+    assert result.usage is not None
+    assert result.usage.input_tokens == 10
+    assert result.usage.output_tokens == 7
+    assert result.usage.reasoning_tokens == 6
+    assert result.usage.total_tokens == 17
+
+
+def test_parse_chat_completion_prefers_provider_reasoning_token_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("data_designer.engine.models.clients.parsing.estimate_text_tokens", lambda text: 999)
+
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "final answer", "reasoning": "hidden thinking"}}],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 7,
+            "completion_tokens_details": {"reasoning_tokens": 4},
+            "total_tokens": 17,
+        },
+    }
+
+    result = parse_chat_completion_response(response)
+
+    assert result.usage is not None
+    assert result.usage.reasoning_tokens == 4

--- a/packages/data-designer-engine/tests/engine/models/clients/test_types.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_types.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from data_designer.engine.models.clients.types import Usage
+from data_designer.engine.models.usage import TokenCountSource
+
+
+def test_usage_reasoning_token_count_source_is_required() -> None:
+    with pytest.raises(ValueError, match="reasoning_tokens requires reasoning_token_count_source"):
+        Usage(reasoning_tokens=1)
+
+    with pytest.raises(ValueError, match="reasoning_token_count_source requires reasoning_tokens"):
+        Usage(reasoning_token_count_source=TokenCountSource.ESTIMATED)

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -10,11 +10,13 @@ import pytest
 
 from data_designer.engine.mcp.errors import MCPConfigurationError, MCPToolError
 from data_designer.engine.models.clients.types import (
+    AssistantMessage,
     ChatCompletionResponse,
     EmbeddingResponse,
     ImageGenerationResponse,
     ImagePayload,
     ToolCall,
+    Usage,
 )
 from data_designer.engine.models.errors import ImageGenerationError, ModelGenerationValidationFailureError
 from data_designer.engine.models.facade import ModelFacade
@@ -199,6 +201,24 @@ def test_model_alias_property(stub_model_facade: ModelFacade, stub_model_configs
 def test_usage_stats_property(stub_model_facade: ModelFacade) -> None:
     assert stub_model_facade.usage_stats is not None
     assert hasattr(stub_model_facade.usage_stats, "model_dump")
+
+
+def test_completion_tracks_reasoning_tokens_without_changing_output_tokens(
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    stub_model_client.completion.return_value = ChatCompletionResponse(
+        message=AssistantMessage(content="ok"),
+        usage=Usage(input_tokens=10, output_tokens=8, reasoning_tokens=3),
+    )
+
+    stub_model_facade.completion([ChatMessage.as_user("hi")])
+
+    token_usage = stub_model_facade.usage_stats.token_usage
+    assert token_usage.input_tokens == 10
+    assert token_usage.output_tokens == 8
+    assert token_usage.reasoning_tokens == 3
+    assert token_usage.total_tokens == 18
 
 
 def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: ModelFacade) -> None:

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -228,19 +228,6 @@ def test_completion_tracks_reasoning_tokens_without_changing_output_tokens(
     assert token_usage.total_tokens == 18
 
 
-def test_completion_requires_reasoning_token_count_source(
-    stub_model_facade: ModelFacade,
-    stub_model_client: MagicMock,
-) -> None:
-    stub_model_client.completion.return_value = ChatCompletionResponse(
-        message=AssistantMessage(content="ok"),
-        usage=Usage(input_tokens=10, output_tokens=8, reasoning_tokens=3),
-    )
-
-    with pytest.raises(ValueError, match="reasoning_tokens requires reasoning_token_count_source"):
-        stub_model_facade.completion([ChatMessage.as_user("hi")])
-
-
 def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: ModelFacade) -> None:
     # Model config generate kwargs are used as base, and purpose is removed.
     # When telemetry is enabled (default), X-Title is injected.

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -21,6 +21,7 @@ from data_designer.engine.models.clients.types import (
 from data_designer.engine.models.errors import ImageGenerationError, ModelGenerationValidationFailureError
 from data_designer.engine.models.facade import ModelFacade
 from data_designer.engine.models.parsers.errors import ParserException
+from data_designer.engine.models.usage import TokenCountSource
 from data_designer.engine.models.utils import ChatMessage
 from data_designer.engine.testing import StubMCPFacade, StubMCPRegistry, make_stub_completion_response
 
@@ -209,7 +210,12 @@ def test_completion_tracks_reasoning_tokens_without_changing_output_tokens(
 ) -> None:
     stub_model_client.completion.return_value = ChatCompletionResponse(
         message=AssistantMessage(content="ok"),
-        usage=Usage(input_tokens=10, output_tokens=8, reasoning_tokens=3),
+        usage=Usage(
+            input_tokens=10,
+            output_tokens=8,
+            reasoning_tokens=3,
+            reasoning_token_count_source=TokenCountSource.PROVIDER,
+        ),
     )
 
     stub_model_facade.completion([ChatMessage.as_user("hi")])
@@ -218,6 +224,7 @@ def test_completion_tracks_reasoning_tokens_without_changing_output_tokens(
     assert token_usage.input_tokens == 10
     assert token_usage.output_tokens == 8
     assert token_usage.reasoning_tokens == 3
+    assert token_usage.reasoning_token_count_source == TokenCountSource.PROVIDER
     assert token_usage.total_tokens == 18
 
 

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -228,6 +228,19 @@ def test_completion_tracks_reasoning_tokens_without_changing_output_tokens(
     assert token_usage.total_tokens == 18
 
 
+def test_completion_requires_reasoning_token_count_source(
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    stub_model_client.completion.return_value = ChatCompletionResponse(
+        message=AssistantMessage(content="ok"),
+        usage=Usage(input_tokens=10, output_tokens=8, reasoning_tokens=3),
+    )
+
+    with pytest.raises(ValueError, match="reasoning_tokens requires reasoning_token_count_source"):
+        stub_model_facade.completion([ChatMessage.as_user("hi")])
+
+
 def test_consolidate_kwargs(stub_model_configs: list[Any], stub_model_facade: ModelFacade) -> None:
     # Model config generate kwargs are used as base, and purpose is removed.
     # When telemetry is enabled (default), X-Title is injected.

--- a/packages/data-designer-engine/tests/engine/models/test_model_registry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_model_registry.py
@@ -517,6 +517,29 @@ def test_log_model_usage_estimated_reasoning_tokens(stub_model_registry: ModelRe
         assert calls[4] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
 
 
+def test_log_model_usage_provider_zero_reasoning_tokens(stub_model_registry: ModelRegistry) -> None:
+    """Test log_model_usage shows provider-reported zero reasoning token counts."""
+    text_model = stub_model_registry.get_model(model_alias="stub-text")
+    text_model.usage_stats.extend(
+        token_usage=TokenUsageStats(
+            input_tokens=1000,
+            output_tokens=500,
+            reasoning_tokens=0,
+            reasoning_token_count_source=TokenCountSource.PROVIDER,
+        ),
+        request_usage=RequestUsageStats(successful_requests=10, failed_requests=0),
+    )
+
+    with patch("data_designer.engine.models.registry.logger") as mock_logger:
+        stub_model_registry.log_model_usage(total_time_elapsed=10.0)
+
+        calls = [call[0][0] for call in mock_logger.info.call_args_list]
+        assert calls[0] == "📊 Model usage summary:"
+        assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=0, total=1500, tps=150"
+        assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
+
+
 def test_log_model_usage_multiple_models(stub_model_registry: ModelRegistry) -> None:
     """Test log_model_usage with multiple models - verifies models are sorted by name."""
     text_model = stub_model_registry.get_model(model_alias="stub-text")
@@ -541,12 +564,12 @@ def test_log_model_usage_multiple_models(stub_model_registry: ModelRegistry) -> 
 
         # Models should be sorted alphabetically: stub-model-reasoning before stub-model-text
         assert calls[1] == f"{LOG_INDENT}model: stub-model-reasoning"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, reasoning=unknown, total=3000, tps=300"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, total=3000, tps=300"
         assert calls[3] == f"{LOG_INDENT}requests: success=20, failed=5, total=25, rpm=150"
         assert calls[4] == f"{LOG_INDENT.rstrip()}"
 
         assert calls[5] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=unknown, total=1500, tps=150"
+        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, total=1500, tps=150"
         assert calls[7] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
 
 
@@ -568,7 +591,7 @@ def test_log_model_usage_with_tool_usage(stub_model_registry: ModelRegistry) -> 
         calls = [call[0][0] for call in mock_logger.info.call_args_list]
         assert calls[0] == "📊 Model usage summary:"
         assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=unknown, total=1500, tps=150"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, total=1500, tps=150"
         assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
         assert calls[4] == f"{LOG_INDENT}tools: generations=2/3, calls=10, turns=5"
 

--- a/packages/data-designer-engine/tests/engine/models/test_model_registry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_model_registry.py
@@ -229,7 +229,7 @@ def test_get_usage_deltas(
         # Empty snapshot, then add usage
         pre_snapshot: dict[str, ModelUsageStats] = {}
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=50, output_tokens=100),
+            token_usage=TokenUsageStats(input_tokens=50, output_tokens=100, reasoning_tokens=20),
             request_usage=RequestUsageStats(successful_requests=5, failed_requests=1),
         )
 
@@ -238,19 +238,20 @@ def test_get_usage_deltas(
         assert set(deltas.keys()) == set(expected_keys)
         assert deltas["stub-model-text"].token_usage.input_tokens == 50
         assert deltas["stub-model-text"].token_usage.output_tokens == 100
+        assert deltas["stub-model-text"].token_usage.reasoning_tokens == 20
         assert deltas["stub-model-text"].request_usage.successful_requests == 5
         assert deltas["stub-model-text"].request_usage.failed_requests == 1
 
     elif test_case == "with_prior_usage":
         # Add initial usage, take snapshot, add more usage
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=100, output_tokens=200),
+            token_usage=TokenUsageStats(input_tokens=100, output_tokens=200, reasoning_tokens=40),
             request_usage=RequestUsageStats(successful_requests=10, failed_requests=2),
         )
         pre_snapshot = stub_model_registry.get_model_usage_snapshot()
 
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=50, output_tokens=75),
+            token_usage=TokenUsageStats(input_tokens=50, output_tokens=75, reasoning_tokens=15),
             request_usage=RequestUsageStats(successful_requests=3, failed_requests=1),
         )
 
@@ -259,6 +260,7 @@ def test_get_usage_deltas(
         assert set(deltas.keys()) == set(expected_keys)
         assert deltas["stub-model-text"].token_usage.input_tokens == 50
         assert deltas["stub-model-text"].token_usage.output_tokens == 75
+        assert deltas["stub-model-text"].token_usage.reasoning_tokens == 15
         assert deltas["stub-model-text"].request_usage.successful_requests == 3
         assert deltas["stub-model-text"].request_usage.failed_requests == 1
 

--- a/packages/data-designer-engine/tests/engine/models/test_model_registry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_model_registry.py
@@ -10,7 +10,7 @@ from data_designer.engine.models.errors import ModelAuthenticationError
 from data_designer.engine.models.facade import ModelFacade
 from data_designer.engine.models.factory import create_model_registry
 from data_designer.engine.models.registry import ModelRegistry
-from data_designer.engine.models.usage import ModelUsageStats, RequestUsageStats, TokenUsageStats
+from data_designer.engine.models.usage import ModelUsageStats, RequestUsageStats, TokenCountSource, TokenUsageStats
 from data_designer.logging import LOG_INDENT
 
 
@@ -229,7 +229,12 @@ def test_get_usage_deltas(
         # Empty snapshot, then add usage
         pre_snapshot: dict[str, ModelUsageStats] = {}
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=50, output_tokens=100, reasoning_tokens=20),
+            token_usage=TokenUsageStats(
+                input_tokens=50,
+                output_tokens=100,
+                reasoning_tokens=20,
+                reasoning_token_count_source=TokenCountSource.PROVIDER,
+            ),
             request_usage=RequestUsageStats(successful_requests=5, failed_requests=1),
         )
 
@@ -239,19 +244,30 @@ def test_get_usage_deltas(
         assert deltas["stub-model-text"].token_usage.input_tokens == 50
         assert deltas["stub-model-text"].token_usage.output_tokens == 100
         assert deltas["stub-model-text"].token_usage.reasoning_tokens == 20
+        assert deltas["stub-model-text"].token_usage.reasoning_token_count_source == TokenCountSource.PROVIDER
         assert deltas["stub-model-text"].request_usage.successful_requests == 5
         assert deltas["stub-model-text"].request_usage.failed_requests == 1
 
     elif test_case == "with_prior_usage":
         # Add initial usage, take snapshot, add more usage
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=100, output_tokens=200, reasoning_tokens=40),
+            token_usage=TokenUsageStats(
+                input_tokens=100,
+                output_tokens=200,
+                reasoning_tokens=40,
+                reasoning_token_count_source=TokenCountSource.PROVIDER,
+            ),
             request_usage=RequestUsageStats(successful_requests=10, failed_requests=2),
         )
         pre_snapshot = stub_model_registry.get_model_usage_snapshot()
 
         text_model.usage_stats.extend(
-            token_usage=TokenUsageStats(input_tokens=50, output_tokens=75, reasoning_tokens=15),
+            token_usage=TokenUsageStats(
+                input_tokens=50,
+                output_tokens=75,
+                reasoning_tokens=15,
+                reasoning_token_count_source=TokenCountSource.PROVIDER,
+            ),
             request_usage=RequestUsageStats(successful_requests=3, failed_requests=1),
         )
 
@@ -261,6 +277,7 @@ def test_get_usage_deltas(
         assert deltas["stub-model-text"].token_usage.input_tokens == 50
         assert deltas["stub-model-text"].token_usage.output_tokens == 75
         assert deltas["stub-model-text"].token_usage.reasoning_tokens == 15
+        assert deltas["stub-model-text"].token_usage.reasoning_token_count_source == TokenCountSource.PROVIDER
         assert deltas["stub-model-text"].request_usage.successful_requests == 3
         assert deltas["stub-model-text"].request_usage.failed_requests == 1
 
@@ -457,7 +474,12 @@ def test_log_model_usage_single_model(stub_model_registry: ModelRegistry) -> Non
     """Test log_model_usage with a single model that has usage."""
     text_model = stub_model_registry.get_model(model_alias="stub-text")
     text_model.usage_stats.extend(
-        token_usage=TokenUsageStats(input_tokens=1000, output_tokens=500, reasoning_tokens=125),
+        token_usage=TokenUsageStats(
+            input_tokens=1000,
+            output_tokens=500,
+            reasoning_tokens=125,
+            reasoning_token_count_source=TokenCountSource.PROVIDER,
+        ),
         request_usage=RequestUsageStats(successful_requests=10, failed_requests=2),
     )
 
@@ -469,6 +491,30 @@ def test_log_model_usage_single_model(stub_model_registry: ModelRegistry) -> Non
         assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
         assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=125, total=1500, tps=150"
         assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=2, total=12, rpm=72"
+
+
+def test_log_model_usage_estimated_reasoning_tokens(stub_model_registry: ModelRegistry) -> None:
+    """Test log_model_usage labels estimated reasoning token counts."""
+    text_model = stub_model_registry.get_model(model_alias="stub-text")
+    text_model.usage_stats.extend(
+        token_usage=TokenUsageStats(
+            input_tokens=1000,
+            output_tokens=500,
+            reasoning_tokens=125,
+            reasoning_token_count_source=TokenCountSource.ESTIMATED,
+        ),
+        request_usage=RequestUsageStats(successful_requests=10, failed_requests=0),
+    )
+
+    with patch("data_designer.engine.models.registry.logger") as mock_logger:
+        stub_model_registry.log_model_usage(total_time_elapsed=10.0)
+
+        calls = [call[0][0] for call in mock_logger.info.call_args_list]
+        assert calls[0] == "📊 Model usage summary:"
+        assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=125 (estimated), total=1500, tps=150"
+        assert calls[3] == f"{LOG_INDENT}reasoning token count estimated with tiktoken"
+        assert calls[4] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
 
 
 def test_log_model_usage_multiple_models(stub_model_registry: ModelRegistry) -> None:
@@ -495,12 +541,12 @@ def test_log_model_usage_multiple_models(stub_model_registry: ModelRegistry) -> 
 
         # Models should be sorted alphabetically: stub-model-reasoning before stub-model-text
         assert calls[1] == f"{LOG_INDENT}model: stub-model-reasoning"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, reasoning=0, total=3000, tps=300"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, reasoning=unknown, total=3000, tps=300"
         assert calls[3] == f"{LOG_INDENT}requests: success=20, failed=5, total=25, rpm=150"
         assert calls[4] == f"{LOG_INDENT.rstrip()}"
 
         assert calls[5] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=0, total=1500, tps=150"
+        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=unknown, total=1500, tps=150"
         assert calls[7] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
 
 
@@ -522,7 +568,7 @@ def test_log_model_usage_with_tool_usage(stub_model_registry: ModelRegistry) -> 
         calls = [call[0][0] for call in mock_logger.info.call_args_list]
         assert calls[0] == "📊 Model usage summary:"
         assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=0, total=1500, tps=150"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=unknown, total=1500, tps=150"
         assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
         assert calls[4] == f"{LOG_INDENT}tools: generations=2/3, calls=10, turns=5"
 

--- a/packages/data-designer-engine/tests/engine/models/test_model_registry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_model_registry.py
@@ -457,7 +457,7 @@ def test_log_model_usage_single_model(stub_model_registry: ModelRegistry) -> Non
     """Test log_model_usage with a single model that has usage."""
     text_model = stub_model_registry.get_model(model_alias="stub-text")
     text_model.usage_stats.extend(
-        token_usage=TokenUsageStats(input_tokens=1000, output_tokens=500),
+        token_usage=TokenUsageStats(input_tokens=1000, output_tokens=500, reasoning_tokens=125),
         request_usage=RequestUsageStats(successful_requests=10, failed_requests=2),
     )
 
@@ -467,7 +467,7 @@ def test_log_model_usage_single_model(stub_model_registry: ModelRegistry) -> Non
         calls = [call[0][0] for call in mock_logger.info.call_args_list]
         assert calls[0] == "📊 Model usage summary:"
         assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, total=1500, tps=150"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=125, total=1500, tps=150"
         assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=2, total=12, rpm=72"
 
 
@@ -495,12 +495,12 @@ def test_log_model_usage_multiple_models(stub_model_registry: ModelRegistry) -> 
 
         # Models should be sorted alphabetically: stub-model-reasoning before stub-model-text
         assert calls[1] == f"{LOG_INDENT}model: stub-model-reasoning"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, total=3000, tps=300"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=2000, output=1000, reasoning=0, total=3000, tps=300"
         assert calls[3] == f"{LOG_INDENT}requests: success=20, failed=5, total=25, rpm=150"
         assert calls[4] == f"{LOG_INDENT.rstrip()}"
 
         assert calls[5] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, total=1500, tps=150"
+        assert calls[6] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=0, total=1500, tps=150"
         assert calls[7] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
 
 
@@ -522,7 +522,7 @@ def test_log_model_usage_with_tool_usage(stub_model_registry: ModelRegistry) -> 
         calls = [call[0][0] for call in mock_logger.info.call_args_list]
         assert calls[0] == "📊 Model usage summary:"
         assert calls[1] == f"{LOG_INDENT}model: stub-model-text"
-        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, total=1500, tps=150"
+        assert calls[2] == f"{LOG_INDENT}tokens: input=1000, output=500, reasoning=0, total=1500, tps=150"
         assert calls[3] == f"{LOG_INDENT}requests: success=10, failed=0, total=10, rpm=60"
         assert calls[4] == f"{LOG_INDENT}tools: generations=2/3, calls=10, turns=5"
 

--- a/packages/data-designer-engine/tests/engine/models/test_usage.py
+++ b/packages/data-designer-engine/tests/engine/models/test_usage.py
@@ -44,7 +44,7 @@ def test_token_usage_stats_reasoning_source_is_required() -> None:
         TokenUsageStats(reasoning_token_count_source=TokenCountSource.ESTIMATED)
 
 
-def test_token_usage_stats_merges_reasoning_sources() -> None:
+def test_token_usage_stats_uses_estimated_source_when_any_count_is_estimated() -> None:
     token_usage_stats = TokenUsageStats()
 
     token_usage_stats.extend(
@@ -69,7 +69,7 @@ def test_token_usage_stats_merges_reasoning_sources() -> None:
         reasoning_token_count_source=TokenCountSource.ESTIMATED,
     )
     assert token_usage_stats.reasoning_tokens == 15
-    assert token_usage_stats.reasoning_token_count_source == TokenCountSource.MIXED
+    assert token_usage_stats.reasoning_token_count_source == TokenCountSource.ESTIMATED
 
 
 def test_request_usage_stats() -> None:

--- a/packages/data-designer-engine/tests/engine/models/test_usage.py
+++ b/packages/data-designer-engine/tests/engine/models/test_usage.py
@@ -14,12 +14,14 @@ def test_token_usage_stats() -> None:
     token_usage_stats = TokenUsageStats()
     assert token_usage_stats.input_tokens == 0
     assert token_usage_stats.output_tokens == 0
+    assert token_usage_stats.reasoning_tokens == 0
     assert token_usage_stats.total_tokens == 0
     assert token_usage_stats.has_usage is False
 
-    token_usage_stats.extend(input_tokens=10, output_tokens=20)
+    token_usage_stats.extend(input_tokens=10, output_tokens=20, reasoning_tokens=5)
     assert token_usage_stats.input_tokens == 10
     assert token_usage_stats.output_tokens == 20
+    assert token_usage_stats.reasoning_tokens == 5
     assert token_usage_stats.total_tokens == 30
     assert token_usage_stats.has_usage is True
 
@@ -157,25 +159,26 @@ def test_model_usage_stats() -> None:
 
     # tool_usage and image_usage are excluded when has_usage is False
     assert model_usage_stats.get_usage_stats(total_time_elapsed=10) == {
-        "token_usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        "token_usage": {"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0, "total_tokens": 0},
         "request_usage": {"successful_requests": 0, "failed_requests": 0, "total_requests": 0},
         "tokens_per_second": 0,
         "requests_per_minute": 0,
     }
 
     model_usage_stats.extend(
-        token_usage=TokenUsageStats(input_tokens=10, output_tokens=20),
+        token_usage=TokenUsageStats(input_tokens=10, output_tokens=20, reasoning_tokens=7),
         request_usage=RequestUsageStats(successful_requests=2, failed_requests=1),
     )
     assert model_usage_stats.token_usage.input_tokens == 10
     assert model_usage_stats.token_usage.output_tokens == 20
+    assert model_usage_stats.token_usage.reasoning_tokens == 7
     assert model_usage_stats.request_usage.successful_requests == 2
     assert model_usage_stats.request_usage.failed_requests == 1
     assert model_usage_stats.has_usage is True
 
     # tool_usage and image_usage are excluded when has_usage is False
     assert model_usage_stats.get_usage_stats(total_time_elapsed=2) == {
-        "token_usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+        "token_usage": {"input_tokens": 10, "output_tokens": 20, "reasoning_tokens": 7, "total_tokens": 30},
         "request_usage": {"successful_requests": 2, "failed_requests": 1, "total_requests": 3},
         "tokens_per_second": 15,
         "requests_per_minute": 90,

--- a/packages/data-designer-engine/tests/engine/models/test_usage.py
+++ b/packages/data-designer-engine/tests/engine/models/test_usage.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from data_designer.engine.models.usage import (
     ImageUsageStats,
     ModelUsageStats,
     RequestUsageStats,
+    TokenCountSource,
     TokenUsageStats,
     ToolUsageStats,
 )
@@ -14,16 +17,59 @@ def test_token_usage_stats() -> None:
     token_usage_stats = TokenUsageStats()
     assert token_usage_stats.input_tokens == 0
     assert token_usage_stats.output_tokens == 0
-    assert token_usage_stats.reasoning_tokens == 0
+    assert token_usage_stats.reasoning_tokens is None
+    assert token_usage_stats.reasoning_token_count_source is None
     assert token_usage_stats.total_tokens == 0
     assert token_usage_stats.has_usage is False
 
-    token_usage_stats.extend(input_tokens=10, output_tokens=20, reasoning_tokens=5)
+    token_usage_stats.extend(
+        input_tokens=10,
+        output_tokens=20,
+        reasoning_tokens=5,
+        reasoning_token_count_source=TokenCountSource.PROVIDER,
+    )
     assert token_usage_stats.input_tokens == 10
     assert token_usage_stats.output_tokens == 20
     assert token_usage_stats.reasoning_tokens == 5
+    assert token_usage_stats.reasoning_token_count_source == TokenCountSource.PROVIDER
     assert token_usage_stats.total_tokens == 30
     assert token_usage_stats.has_usage is True
+
+
+def test_token_usage_stats_reasoning_source_is_required() -> None:
+    with pytest.raises(ValueError, match="reasoning_tokens requires reasoning_token_count_source"):
+        TokenUsageStats(reasoning_tokens=1)
+
+    with pytest.raises(ValueError, match="reasoning_token_count_source requires reasoning_tokens"):
+        TokenUsageStats(reasoning_token_count_source=TokenCountSource.ESTIMATED)
+
+
+def test_token_usage_stats_merges_reasoning_sources() -> None:
+    token_usage_stats = TokenUsageStats()
+
+    token_usage_stats.extend(
+        input_tokens=10,
+        output_tokens=20,
+        reasoning_tokens=5,
+        reasoning_token_count_source=TokenCountSource.PROVIDER,
+    )
+    token_usage_stats.extend(
+        input_tokens=3,
+        output_tokens=4,
+        reasoning_tokens=2,
+        reasoning_token_count_source=TokenCountSource.PROVIDER,
+    )
+    assert token_usage_stats.reasoning_tokens == 7
+    assert token_usage_stats.reasoning_token_count_source == TokenCountSource.PROVIDER
+
+    token_usage_stats.extend(
+        input_tokens=1,
+        output_tokens=1,
+        reasoning_tokens=8,
+        reasoning_token_count_source=TokenCountSource.ESTIMATED,
+    )
+    assert token_usage_stats.reasoning_tokens == 15
+    assert token_usage_stats.reasoning_token_count_source == TokenCountSource.MIXED
 
 
 def test_request_usage_stats() -> None:
@@ -159,14 +205,25 @@ def test_model_usage_stats() -> None:
 
     # tool_usage and image_usage are excluded when has_usage is False
     assert model_usage_stats.get_usage_stats(total_time_elapsed=10) == {
-        "token_usage": {"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0, "total_tokens": 0},
+        "token_usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "reasoning_tokens": None,
+            "reasoning_token_count_source": None,
+            "total_tokens": 0,
+        },
         "request_usage": {"successful_requests": 0, "failed_requests": 0, "total_requests": 0},
         "tokens_per_second": 0,
         "requests_per_minute": 0,
     }
 
     model_usage_stats.extend(
-        token_usage=TokenUsageStats(input_tokens=10, output_tokens=20, reasoning_tokens=7),
+        token_usage=TokenUsageStats(
+            input_tokens=10,
+            output_tokens=20,
+            reasoning_tokens=7,
+            reasoning_token_count_source=TokenCountSource.PROVIDER,
+        ),
         request_usage=RequestUsageStats(successful_requests=2, failed_requests=1),
     )
     assert model_usage_stats.token_usage.input_tokens == 10
@@ -178,7 +235,13 @@ def test_model_usage_stats() -> None:
 
     # tool_usage and image_usage are excluded when has_usage is False
     assert model_usage_stats.get_usage_stats(total_time_elapsed=2) == {
-        "token_usage": {"input_tokens": 10, "output_tokens": 20, "reasoning_tokens": 7, "total_tokens": 30},
+        "token_usage": {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "reasoning_tokens": 7,
+            "reasoning_token_count_source": "provider",
+            "total_tokens": 30,
+        },
         "request_usage": {"successful_requests": 2, "failed_requests": 1, "total_requests": 3},
         "tokens_per_second": 15,
         "requests_per_minute": 90,

--- a/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
+++ b/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.engine.utils.token_counting import count_text_tokens, get_cl100k_base_tokenizer
+
+
+def test_count_text_tokens_counts_with_cl100k_base_tokenizer() -> None:
+    """count_text_tokens delegates to the shared cl100k_base tokenizer."""
+    text = "Hello, token counting."
+
+    assert count_text_tokens(text) == len(get_cl100k_base_tokenizer().encode(text, disallowed_special=()))
+
+
+def test_get_cl100k_base_tokenizer_returns_cached_instance() -> None:
+    """get_cl100k_base_tokenizer returns the same cached tokenizer instance."""
+    get_cl100k_base_tokenizer.cache_clear()
+    tokenizer1 = get_cl100k_base_tokenizer()
+    tokenizer2 = get_cl100k_base_tokenizer()
+
+    assert tokenizer1 is tokenizer2

--- a/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
+++ b/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import tiktoken
+
 from data_designer.engine.utils.token_counting import count_text_tokens, get_cl100k_base_tokenizer
 
 
@@ -10,7 +12,8 @@ def test_count_text_tokens_counts_with_cl100k_base_tokenizer() -> None:
     """count_text_tokens delegates to the shared cl100k_base tokenizer."""
     text = "Hello, token counting."
 
-    assert count_text_tokens(text) == len(get_cl100k_base_tokenizer().encode(text, disallowed_special=()))
+    tokenizer = tiktoken.get_encoding("cl100k_base")
+    assert count_text_tokens(text) == len(tokenizer.encode(text, disallowed_special=()))
 
 
 def test_get_cl100k_base_tokenizer_returns_cached_instance() -> None:

--- a/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
+++ b/packages/data-designer-engine/tests/engine/utils/test_token_counting.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import tiktoken
 
 from data_designer.engine.utils.token_counting import count_text_tokens, get_cl100k_base_tokenizer
@@ -23,3 +26,18 @@ def test_get_cl100k_base_tokenizer_returns_cached_instance() -> None:
     tokenizer2 = get_cl100k_base_tokenizer()
 
     assert tokenizer1 is tokenizer2
+
+
+def test_importing_token_counting_does_not_eagerly_import_tiktoken() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import data_designer.engine.utils.token_counting; print(int('tiktoken' in sys.modules))",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0"


### PR DESCRIPTION
## 📋 Summary

Adds reasoning token tracking to model usage stats while preserving provider output token semantics. Provider-reported reasoning counts are recorded exactly when available; when a provider returns reasoning/thinking content and normal usage but omits the reasoning-token breakdown, DD estimates the reasoning count using the shared tiktoken `cl100k_base` helper and labels it as estimated.

## 🔗 Related Issue

Fixes #665

## 🔄 Changes

- Add `reasoning_tokens` and `reasoning_token_count_source` to token usage stats.
- Parse provider-reported reasoning counts from OpenAI-compatible usage fields, including `completion_tokens_details.reasoning_tokens`, `output_tokens_details.reasoning_tokens`, and top-level variants.
- Estimate missing reasoning counts from returned reasoning/thinking content when provider usage exists but no reasoning count is reported.
- Do not synthesize usage stats when a provider omits `usage` entirely.
- Validate the reasoning count/source pair on both canonical `Usage` objects and aggregated `TokenUsageStats`.
- Lazy-load tiktoken through the shared lazy import facade so normal chat parsing does not eagerly import tokenizer code.
- Reuse the same tiktoken-based helper for reasoning estimates and column statistics.
- Update model usage summary logging to show reasoning counts only when known, with `(estimated)` labels when applicable.
- Clarify internal helper names and annotations so count-oriented helpers use `reasoning_token_count` terminology and return `int | None` where applicable.
- Add tests for provider-reported, estimated, missing, zero, no-usage, and source-validation cases.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`usage.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat-665-reasoning-token-usage/packages/data-designer-engine/src/data_designer/engine/models/usage.py) — `TokenUsageStats.reasoning_tokens` is now nullable and accompanied by `reasoning_token_count_source`.
- [`types.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat-665-reasoning-token-usage/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py) — canonical `Usage` now validates reasoning count/source consistency when clients construct responses.
- [`parsing.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat-665-reasoning-token-usage/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py) — provider-reported reasoning counts are parsed separately from estimated counts derived from reasoning content.
- [`registry.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat-665-reasoning-token-usage/packages/data-designer-engine/src/data_designer/engine/models/registry.py) — the usage summary omits reasoning counts when providers return neither a count nor reasoning content.
- [`token_counting.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/feat-665-reasoning-token-usage/packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py) — tiktoken is lazy-loaded and only accessed when token estimation is actually needed.

## 🧪 Testing

- [x] `PYTHONPATH=packages/data-designer-config/src:packages/data-designer-engine/src:packages/data-designer/src uv run --group dev pytest packages/data-designer-engine/tests/engine/models packages/data-designer-engine/tests/engine/analysis packages/data-designer/tests/test_lazy_imports.py -q` (`589 passed`)
- [x] `PYTHONPATH=packages/data-designer-config/src:packages/data-designer-engine/src:packages/data-designer/src uv run --group dev pytest packages/data-designer/tests/test_lazy_imports.py packages/data-designer-engine/tests/engine/models/clients/test_parsing.py packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py packages/data-designer-engine/tests/engine/models/clients/test_types.py packages/data-designer-engine/tests/engine/models/test_facade.py packages/data-designer-engine/tests/engine/utils/test_token_counting.py -q` (`159 passed`)
- [x] `uv run --group dev ruff check packages/data-designer-config/src/data_designer/lazy_heavy_imports.py packages/data-designer-engine/src/data_designer/engine/models/clients/types.py packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py packages/data-designer-engine/tests/engine/models/clients/test_parsing.py packages/data-designer-engine/tests/engine/models/clients/test_types.py packages/data-designer-engine/tests/engine/models/test_facade.py packages/data-designer-engine/tests/engine/utils/test_token_counting.py`
- [x] `uv run --group dev ruff format --check packages/data-designer-config/src/data_designer/lazy_heavy_imports.py packages/data-designer-engine/src/data_designer/engine/models/clients/types.py packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py packages/data-designer-engine/src/data_designer/engine/utils/token_counting.py packages/data-designer-engine/tests/engine/models/clients/test_anthropic_translation.py packages/data-designer-engine/tests/engine/models/clients/test_parsing.py packages/data-designer-engine/tests/engine/models/clients/test_types.py packages/data-designer-engine/tests/engine/models/test_facade.py packages/data-designer-engine/tests/engine/utils/test_token_counting.py`
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — usage accounting covered by unit/model tests)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A — no architecture docs needed)
