### PR TITLE
fix: restore chat completion multi-choice support

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
@@ -17,6 +17,7 @@ from data_designer.engine.models.clients.throttle_manager import ThrottleDomain,
 from data_designer.engine.models.clients.throttled import ThrottledModelClient
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
+    ChatCompletionChoice,
     ChatCompletionRequest,
     ChatCompletionResponse,
     EmbeddingRequest,
@@ -31,6 +32,7 @@ from data_designer.engine.models.clients.types import (
 
 __all__ = [
     "AssistantMessage",
+    "ChatCompletionChoice",
     "ChatCompletionRequest",
     "ChatCompletionResponse",
     "EmbeddingRequest",

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic.py
@@ -44,6 +44,7 @@ class AnthropicClient(HttpModelClient):
             "stop",
             "max_tokens",
             "tools",
+            "n",
             "response_format",
             "frequency_penalty",
             "presence_penalty",

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/parsing.py
@@ -19,6 +19,7 @@ from data_designer.config.utils.image_helpers import (
 )
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
+    ChatCompletionChoice,
     ChatCompletionResponse,
     ImagePayload,
     ToolCall,
@@ -36,35 +37,75 @@ logger = logging.getLogger(__name__)
 
 
 def parse_chat_completion_response(response: Any) -> ChatCompletionResponse:
-    first_choice = get_first_value_or_none(get_value_from(response, "choices"))
-    message = get_value_from(first_choice, "message")
-    tool_calls = extract_tool_calls(get_value_from(message, "tool_calls"))
-    images = extract_images_from_chat_message(message)
-    assistant_message = AssistantMessage(
-        content=coerce_message_content(get_value_from(message, "content")),
-        reasoning_content=extract_reasoning_content(message),
-        tool_calls=tool_calls,
-        images=images,
+    choices = [
+        parse_chat_completion_choice(choice) for choice in normalize_choice_list(get_value_from(response, "choices"))
+    ]
+    assistant_message = choices[0].message if choices else AssistantMessage()
+    generated_images = sum(len(choice.message.images) for choice in choices)
+    usage = extract_usage(
+        get_value_from(response, "usage"),
+        generated_images=generated_images if generated_images else None,
     )
-    usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
     usage = fill_reasoning_token_count_from_content(usage, assistant_message.reasoning_content)
-    return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
+    return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response, choices=choices)
 
 
 async def aparse_chat_completion_response(response: Any) -> ChatCompletionResponse:
-    first_choice = get_first_value_or_none(get_value_from(response, "choices"))
-    message = get_value_from(first_choice, "message")
-    tool_calls = extract_tool_calls(get_value_from(message, "tool_calls"))
-    images = await aextract_images_from_chat_message(message)
-    assistant_message = AssistantMessage(
+    choices = [
+        await aparse_chat_completion_choice(choice)
+        for choice in normalize_choice_list(get_value_from(response, "choices"))
+    ]
+    assistant_message = choices[0].message if choices else AssistantMessage()
+    generated_images = sum(len(choice.message.images) for choice in choices)
+    usage = extract_usage(
+        get_value_from(response, "usage"),
+        generated_images=generated_images if generated_images else None,
+    )
+    usage = fill_reasoning_token_count_from_content(usage, assistant_message.reasoning_content)
+    return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response, choices=choices)
+
+
+def normalize_choice_list(raw_choices: Any) -> list[Any]:
+    if raw_choices is None:
+        return []
+    if isinstance(raw_choices, list):
+        return raw_choices
+    return [raw_choices]
+
+
+def parse_chat_completion_choice(choice: Any) -> ChatCompletionChoice:
+    message = get_value_from(choice, "message")
+    return ChatCompletionChoice(
+        message=parse_assistant_message(message, images=extract_images_from_chat_message(message)),
+        index=parse_choice_index(get_value_from(choice, "index")),
+        finish_reason=parse_choice_finish_reason(get_value_from(choice, "finish_reason")),
+    )
+
+
+async def aparse_chat_completion_choice(choice: Any) -> ChatCompletionChoice:
+    message = get_value_from(choice, "message")
+    return ChatCompletionChoice(
+        message=parse_assistant_message(message, images=await aextract_images_from_chat_message(message)),
+        index=parse_choice_index(get_value_from(choice, "index")),
+        finish_reason=parse_choice_finish_reason(get_value_from(choice, "finish_reason")),
+    )
+
+
+def parse_assistant_message(message: Any, *, images: list[ImagePayload]) -> AssistantMessage:
+    return AssistantMessage(
         content=coerce_message_content(get_value_from(message, "content")),
         reasoning_content=extract_reasoning_content(message),
-        tool_calls=tool_calls,
+        tool_calls=extract_tool_calls(get_value_from(message, "tool_calls")),
         images=images,
     )
-    usage = extract_usage(get_value_from(response, "usage"), generated_images=len(images) if images else None)
-    usage = fill_reasoning_token_count_from_content(usage, assistant_message.reasoning_content)
-    return ChatCompletionResponse(message=assistant_message, usage=usage, raw=response)
+
+
+def parse_choice_index(index: Any) -> int | None:
+    return index if isinstance(index, int) else None
+
+
+def parse_choice_finish_reason(finish_reason: Any) -> str | None:
+    return finish_reason if isinstance(finish_reason, str) else None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
@@ -61,6 +61,7 @@ class ChatCompletionRequest:
     model: str
     messages: list[dict[str, Any]]
     tools: list[dict[str, Any]] | None = None
+    n: int | None = None
     temperature: float | None = None
     top_p: float | None = None
     max_tokens: int | None = None
@@ -75,10 +76,26 @@ class ChatCompletionRequest:
 
 
 @dataclass
+class ChatCompletionChoice:
+    message: AssistantMessage
+    index: int | None = None
+    finish_reason: str | None = None
+
+
+@dataclass
 class ChatCompletionResponse:
     message: AssistantMessage
     usage: Usage | None = None
     raw: Any | None = None
+    choices: list[ChatCompletionChoice] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.choices:
+            self.choices = [ChatCompletionChoice(message=self.message)]
+
+    @property
+    def messages(self) -> list[AssistantMessage]:
+        return [choice.message for choice in self.choices]
 
 
 @dataclass

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -55,6 +55,23 @@ def _identity(x: Any) -> Any:
     return x
 
 
+def _drop_multi_choice_request_fields(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Remove request controls that would make a single-result API discard choices."""
+    sanitized = dict(kwargs)
+    sanitized.pop("n", None)
+
+    extra_body = sanitized.get("extra_body")
+    if isinstance(extra_body, dict) and "n" in extra_body:
+        extra_body = dict(extra_body)
+        extra_body.pop("n", None)
+        if extra_body:
+            sanitized["extra_body"] = extra_body
+        else:
+            sanitized.pop("extra_body", None)
+
+    return sanitized
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -199,7 +216,12 @@ class ModelFacade:
     # --- completion / acompletion ---
 
     def completion(
-        self, messages: list[ChatMessage], skip_usage_tracking: bool = False, **kwargs: Any
+        self,
+        messages: list[ChatMessage],
+        skip_usage_tracking: bool = False,
+        *,
+        _allow_multiple_choices: bool = True,
+        **kwargs: Any,
     ) -> ChatCompletionResponse:
         message_payloads = [message.to_dict() for message in messages]
         logger.debug(
@@ -208,6 +230,8 @@ class ModelFacade:
         )
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
+        if not _allow_multiple_choices:
+            kwargs = _drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
             response = self._client.completion(request)
@@ -229,7 +253,12 @@ class ModelFacade:
                 )
 
     async def acompletion(
-        self, messages: list[ChatMessage], skip_usage_tracking: bool = False, **kwargs: Any
+        self,
+        messages: list[ChatMessage],
+        skip_usage_tracking: bool = False,
+        *,
+        _allow_multiple_choices: bool = True,
+        **kwargs: Any,
     ) -> ChatCompletionResponse:
         message_payloads = [message.to_dict() for message in messages]
         logger.debug(
@@ -238,6 +267,8 @@ class ModelFacade:
         )
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
+        if not _allow_multiple_choices:
+            kwargs = _drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
             response = await self._client.acompletion(request)
@@ -347,13 +378,13 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
-            completion_kwargs.pop("n", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 
             completion_response = self.completion(
                 messages,
                 skip_usage_tracking=skip_usage_tracking,
+                _allow_multiple_choices=False,
                 **completion_kwargs,
             )
 
@@ -453,13 +484,13 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
-            completion_kwargs.pop("n", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 
             completion_response = await self.acompletion(
                 messages,
                 skip_usage_tracking=skip_usage_tracking,
+                _allow_multiple_choices=False,
                 **completion_kwargs,
             )
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -55,23 +55,6 @@ def _identity(x: Any) -> Any:
     return x
 
 
-def _drop_multi_choice_request_fields(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Remove request controls that would make a single-result API discard choices."""
-    sanitized = dict(kwargs)
-    sanitized.pop("n", None)
-
-    extra_body = sanitized.get("extra_body")
-    if isinstance(extra_body, dict) and "n" in extra_body:
-        extra_body = dict(extra_body)
-        extra_body.pop("n", None)
-        if extra_body:
-            sanitized["extra_body"] = extra_body
-        else:
-            sanitized.pop("extra_body", None)
-
-    return sanitized
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -231,7 +214,7 @@ class ModelFacade:
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
         if not allow_multiple_choices:
-            kwargs = _drop_multi_choice_request_fields(kwargs)
+            kwargs = self._drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
             response = self._client.completion(request)
@@ -268,7 +251,7 @@ class ModelFacade:
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
         if not allow_multiple_choices:
-            kwargs = _drop_multi_choice_request_fields(kwargs)
+            kwargs = self._drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
             response = await self._client.acompletion(request)
@@ -765,6 +748,23 @@ class ModelFacade:
             return self._mcp_registry.get_mcp(tool_alias=tool_alias)
         except ValueError as exc:
             raise MCPConfigurationError(f"Tool alias {tool_alias!r} is not registered.") from exc
+
+    @staticmethod
+    def _drop_multi_choice_request_fields(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Remove request controls that would make a single-result API discard choices."""
+        sanitized = dict(kwargs)
+        sanitized.pop("n", None)
+
+        extra_body = sanitized.get("extra_body")
+        if isinstance(extra_body, dict) and "n" in extra_body:
+            extra_body = dict(extra_body)
+            extra_body.pop("n", None)
+            if extra_body:
+                sanitized["extra_body"] = extra_body
+            else:
+                sanitized.pop("extra_body", None)
+
+        return sanitized
 
     def _build_chat_completion_request(
         self, messages: list[dict[str, Any]], kwargs: dict[str, Any]

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -85,6 +85,7 @@ _COMPLETION_REQUEST_FIELDS = frozenset(
     {
         "temperature",
         "top_p",
+        "n",
         "max_tokens",
         "stop",
         "seed",

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -347,6 +347,7 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
+            completion_kwargs.pop("n", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 
@@ -452,6 +453,7 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
+            completion_kwargs.pop("n", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -220,7 +220,7 @@ class ModelFacade:
         messages: list[ChatMessage],
         skip_usage_tracking: bool = False,
         *,
-        _allow_multiple_choices: bool = True,
+        allow_multiple_choices: bool = True,
         **kwargs: Any,
     ) -> ChatCompletionResponse:
         message_payloads = [message.to_dict() for message in messages]
@@ -230,7 +230,7 @@ class ModelFacade:
         )
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
-        if not _allow_multiple_choices:
+        if not allow_multiple_choices:
             kwargs = _drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
@@ -257,7 +257,7 @@ class ModelFacade:
         messages: list[ChatMessage],
         skip_usage_tracking: bool = False,
         *,
-        _allow_multiple_choices: bool = True,
+        allow_multiple_choices: bool = True,
         **kwargs: Any,
     ) -> ChatCompletionResponse:
         message_payloads = [message.to_dict() for message in messages]
@@ -267,7 +267,7 @@ class ModelFacade:
         )
         response = None
         kwargs = self.consolidate_kwargs(**kwargs)
-        if not _allow_multiple_choices:
+        if not allow_multiple_choices:
             kwargs = _drop_multi_choice_request_fields(kwargs)
         try:
             request = self._build_chat_completion_request(message_payloads, kwargs)
@@ -378,13 +378,14 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
+            completion_kwargs.pop("allow_multiple_choices", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 
             completion_response = self.completion(
                 messages,
                 skip_usage_tracking=skip_usage_tracking,
-                _allow_multiple_choices=False,
+                allow_multiple_choices=False,
                 **completion_kwargs,
             )
 
@@ -484,13 +485,14 @@ class ModelFacade:
 
         while True:
             completion_kwargs = dict(kwargs)
+            completion_kwargs.pop("allow_multiple_choices", None)
             if tool_schemas is not None:
                 completion_kwargs["tools"] = tool_schemas
 
             completion_response = await self.acompletion(
                 messages,
                 skip_usage_tracking=skip_usage_tracking,
-                _allow_multiple_choices=False,
+                allow_multiple_choices=False,
                 **completion_kwargs,
             )
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -738,17 +738,6 @@ class ModelFacade:
 
     # --- private helpers ---
 
-    def _get_mcp_facade(self, tool_alias: str | None) -> MCPFacade | None:
-        if tool_alias is None:
-            return None
-        if self._mcp_registry is None:
-            raise MCPConfigurationError(f"Tool alias {tool_alias!r} specified but no MCPRegistry configured.")
-
-        try:
-            return self._mcp_registry.get_mcp(tool_alias=tool_alias)
-        except ValueError as exc:
-            raise MCPConfigurationError(f"Tool alias {tool_alias!r} is not registered.") from exc
-
     @staticmethod
     def _drop_multi_choice_request_fields(kwargs: dict[str, Any]) -> dict[str, Any]:
         """Remove request controls that would make a single-result API discard choices."""
@@ -765,6 +754,17 @@ class ModelFacade:
                 sanitized.pop("extra_body", None)
 
         return sanitized
+
+    def _get_mcp_facade(self, tool_alias: str | None) -> MCPFacade | None:
+        if tool_alias is None:
+            return None
+        if self._mcp_registry is None:
+            raise MCPConfigurationError(f"Tool alias {tool_alias!r} specified but no MCPRegistry configured.")
+
+        try:
+            return self._mcp_registry.get_mcp(tool_alias=tool_alias)
+        except ValueError as exc:
+            raise MCPConfigurationError(f"Tool alias {tool_alias!r} is not registered.") from exc
 
     def _build_chat_completion_request(
         self, messages: list[dict[str, Any]], kwargs: dict[str, Any]

--- a/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_anthropic.py
@@ -401,11 +401,12 @@ def test_completion_excludes_openai_specific_params() -> None:
         frequency_penalty=0.5,
         presence_penalty=0.5,
         seed=42,
+        n=4,
     )
     client.completion(request)
 
     payload = sync_mock.post.call_args.kwargs["json"]
-    for field in ("response_format", "frequency_penalty", "presence_penalty", "seed"):
+    for field in ("response_format", "frequency_penalty", "presence_penalty", "seed", "n"):
         assert field not in payload, f"{field!r} should be excluded from Anthropic payload"
 
 

--- a/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_openai_compatible.py
@@ -115,6 +115,7 @@ def test_completion_posts_to_chat_completions_route() -> None:
     request = ChatCompletionRequest(
         model=MODEL,
         messages=[{"role": "user", "content": "Hi"}],
+        n=4,
         temperature=0.7,
         extra_body={"seed": 42},
         extra_headers={"X-Trace": "1"},
@@ -125,6 +126,7 @@ def test_completion_posts_to_chat_completions_route() -> None:
     assert "/chat/completions" in call_args.args[0]
     payload = call_args.kwargs["json"]
     assert payload["model"] == MODEL
+    assert payload["n"] == 4
     assert payload["temperature"] == 0.7
     assert payload["seed"] == 42
     assert "timeout" not in payload

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pytest
 
 from data_designer.engine.models.clients.parsing import (
+    aparse_chat_completion_response,
     extract_reasoning_content,
     extract_tool_calls,
     extract_usage,
@@ -59,6 +60,31 @@ def test_parse_chat_completion_response_preserves_all_choices() -> None:
     assert [choice.index for choice in response.choices] == [0, 1]
     assert [choice.finish_reason for choice in response.choices] == ["stop", "length"]
     assert [message.content for message in response.messages] == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_aparse_chat_completion_response_preserves_all_choices() -> None:
+    response = await aparse_chat_completion_response(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "first"},
+                    "finish_reason": "stop",
+                },
+                {
+                    "index": 1,
+                    "message": {"role": "assistant", "content": "second"},
+                    "finish_reason": "length",
+                },
+            ],
+        }
+    )
+
+    assert response.message.content == "first"
+    assert [choice.message.content for choice in response.choices] == ["first", "second"]
+    assert [choice.index for choice in response.choices] == [0, 1]
+    assert [choice.finish_reason for choice in response.choices] == ["stop", "length"]
 
 
 # --- TransportKwargs.from_request: extra_body flattening (default) ---

--- a/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_parsing.py
@@ -13,13 +13,53 @@ from data_designer.engine.models.clients.parsing import (
     parse_chat_completion_response,
 )
 from data_designer.engine.models.clients.types import (
+    AssistantMessage,
     ChatCompletionRequest,
+    ChatCompletionResponse,
     EmbeddingRequest,
     ImageGenerationRequest,
     TransportKwargs,
     Usage,
 )
 from data_designer.engine.models.usage import TokenCountSource
+
+# --- ChatCompletionResponse compatibility ---
+
+
+def test_chat_completion_response_exposes_choices_for_single_message() -> None:
+    message = AssistantMessage(content="ok")
+    response = ChatCompletionResponse(message=message)
+
+    assert response.message is message
+    assert response.choices[0].message is message
+    assert response.messages == [message]
+
+
+def test_parse_chat_completion_response_preserves_all_choices() -> None:
+    response = parse_chat_completion_response(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "first"},
+                    "finish_reason": "stop",
+                },
+                {
+                    "index": 1,
+                    "message": {"role": "assistant", "content": "second"},
+                    "finish_reason": "length",
+                },
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        }
+    )
+
+    assert response.message.content == "first"
+    assert [choice.message.content for choice in response.choices] == ["first", "second"]
+    assert [choice.index for choice in response.choices] == [0, 1]
+    assert [choice.finish_reason for choice in response.choices] == ["stop", "length"]
+    assert [message.content for message in response.messages] == ["first", "second"]
+
 
 # --- TransportKwargs.from_request: extra_body flattening (default) ---
 
@@ -37,6 +77,13 @@ def test_extra_body_keys_are_flattened_into_body() -> None:
     assert transport.body["reasoning_effort"] == "high"
     assert transport.body["seed"] == 42
     assert "extra_body" not in transport.body
+
+
+def test_chat_completion_request_n_is_forwarded_into_body() -> None:
+    request = ChatCompletionRequest(model="m", messages=[], n=4)
+    transport = TransportKwargs.from_request(request)
+
+    assert transport.body["n"] == 4
 
 
 def test_extra_body_none_produces_no_extra_keys() -> None:

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -124,7 +124,7 @@ def test_generate_with_system_prompt(
 
 
 @patch.object(ModelFacade, "completion", autospec=True)
-def test_generate_forwards_n_to_completion(
+def test_generate_drops_n_before_completion(
     mock_completion: Any,
     stub_model_facade: ModelFacade,
 ) -> None:
@@ -132,7 +132,20 @@ def test_generate_forwards_n_to_completion(
 
     stub_model_facade.generate(prompt="does not matter", parser=lambda x: x, n=4)
 
-    assert mock_completion.call_args.kwargs["n"] == 4
+    assert "n" not in mock_completion.call_args.kwargs
+
+
+@patch.object(ModelFacade, "acompletion", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_agenerate_drops_n_before_acompletion(
+    mock_acompletion: AsyncMock,
+    stub_model_facade: ModelFacade,
+) -> None:
+    mock_acompletion.return_value = _make_response("Hello!")
+
+    await stub_model_facade.agenerate(prompt="does not matter", parser=lambda x: x, n=4)
+
+    assert "n" not in mock_acompletion.call_args.kwargs
 
 
 @patch.object(ModelFacade, "completion", autospec=True)

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -11,6 +11,7 @@ import pytest
 from data_designer.engine.mcp.errors import MCPConfigurationError, MCPToolError
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
+    ChatCompletionRequest,
     ChatCompletionResponse,
     EmbeddingResponse,
     ImageGenerationResponse,
@@ -120,6 +121,18 @@ def test_generate_with_system_prompt(
     stub_model_facade.generate(prompt="does not matter", system_prompt=system_prompt, parser=lambda x: x)
     assert mock_completion.call_count == 1
     assert captured_messages[0] == expected_messages
+
+
+@patch.object(ModelFacade, "completion", autospec=True)
+def test_generate_forwards_n_to_completion(
+    mock_completion: Any,
+    stub_model_facade: ModelFacade,
+) -> None:
+    mock_completion.return_value = _make_response("Hello!")
+
+    stub_model_facade.generate(prompt="does not matter", parser=lambda x: x, n=4)
+
+    assert mock_completion.call_args.kwargs["n"] == 4
 
 
 @patch.object(ModelFacade, "completion", autospec=True)
@@ -419,6 +432,21 @@ def test_completion_with_kwargs(
 
     assert result == expected_response
     assert stub_model_client.completion.call_count == 1
+
+
+def test_completion_forwards_n_to_request(
+    stub_completion_messages: list[ChatMessage],
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    expected_response = _make_response("Test response")
+    stub_model_client.completion.return_value = expected_response
+
+    stub_model_facade.completion(stub_completion_messages, n=4)
+
+    request = stub_model_client.completion.call_args.args[0]
+    assert isinstance(request, ChatCompletionRequest)
+    assert request.n == 4
 
 
 def test_generate_text_embeddings_success(

--- a/packages/data-designer-engine/tests/engine/models/test_facade.py
+++ b/packages/data-designer-engine/tests/engine/models/test_facade.py
@@ -32,6 +32,15 @@ def _make_response(content: str | None = None, **kwargs: Any) -> ChatCompletionR
     return make_stub_completion_response(content=content, **kwargs)
 
 
+def _assert_no_multi_choice_request(
+    request: Any,
+    expected_extra_body: dict[str, Any] | None = None,
+) -> None:
+    assert isinstance(request, ChatCompletionRequest)
+    assert request.n is None
+    assert request.extra_body == expected_extra_body
+
+
 @pytest.fixture
 def stub_model_facade(
     stub_model_configs: list[Any],
@@ -123,29 +132,76 @@ def test_generate_with_system_prompt(
     assert captured_messages[0] == expected_messages
 
 
-@patch.object(ModelFacade, "completion", autospec=True)
-def test_generate_drops_n_before_completion(
-    mock_completion: Any,
+def test_generate_drops_n_from_single_result_request(
     stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
 ) -> None:
-    mock_completion.return_value = _make_response("Hello!")
+    stub_model_client.completion.return_value = _make_response("Hello!")
 
     stub_model_facade.generate(prompt="does not matter", parser=lambda x: x, n=4)
 
-    assert "n" not in mock_completion.call_args.kwargs
+    _assert_no_multi_choice_request(stub_model_client.completion.call_args.args[0])
 
 
-@patch.object(ModelFacade, "acompletion", new_callable=AsyncMock)
-@pytest.mark.asyncio
-async def test_agenerate_drops_n_before_acompletion(
-    mock_acompletion: AsyncMock,
+def test_generate_drops_extra_body_n_from_single_result_request(
     stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
 ) -> None:
-    mock_acompletion.return_value = _make_response("Hello!")
+    stub_model_client.completion.return_value = _make_response("Hello!")
+
+    stub_model_facade.generate(prompt="does not matter", parser=lambda x: x, extra_body={"n": 4, "seed": 42})
+
+    _assert_no_multi_choice_request(
+        stub_model_client.completion.call_args.args[0],
+        expected_extra_body={"seed": 42},
+    )
+
+
+def test_generate_drops_configured_extra_body_n_from_single_result_request(
+    stub_model_configs: list[Any],
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    stub_model_configs[0].inference_parameters.extra_body = {"n": 4, "seed": 42}
+    stub_model_facade.model_provider.extra_body = {"n": 5, "provider": "kept"}
+    stub_model_client.completion.return_value = _make_response("Hello!")
+
+    stub_model_facade.generate(prompt="does not matter", parser=lambda x: x)
+
+    _assert_no_multi_choice_request(
+        stub_model_client.completion.call_args.args[0],
+        expected_extra_body={"seed": 42, "provider": "kept"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_agenerate_drops_n_from_single_result_request(
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    stub_model_client.acompletion = AsyncMock(return_value=_make_response("Hello!"))
 
     await stub_model_facade.agenerate(prompt="does not matter", parser=lambda x: x, n=4)
 
-    assert "n" not in mock_acompletion.call_args.kwargs
+    _assert_no_multi_choice_request(stub_model_client.acompletion.call_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_agenerate_drops_configured_extra_body_n_from_single_result_request(
+    stub_model_configs: list[Any],
+    stub_model_facade: ModelFacade,
+    stub_model_client: MagicMock,
+) -> None:
+    stub_model_configs[0].inference_parameters.extra_body = {"n": 4, "seed": 42}
+    stub_model_facade.model_provider.extra_body = {"n": 5, "provider": "kept"}
+    stub_model_client.acompletion = AsyncMock(return_value=_make_response("Hello!"))
+
+    await stub_model_facade.agenerate(prompt="does not matter", parser=lambda x: x)
+
+    _assert_no_multi_choice_request(
+        stub_model_client.acompletion.call_args.args[0],
+        expected_extra_body={"seed": 42, "provider": "kept"},
+    )
 
 
 @patch.object(ModelFacade, "completion", autospec=True)


### PR DESCRIPTION
## 📋 Summary

Restores chat completion multi-choice compatibility by reintroducing the `n` request field and preserving all returned choices in the canonical response. Existing single-choice callers can continue using `response.message`, while callers that request multiple completions can use `response.choices`.

## 🔗 Related Issue

Fixes #620

## 🔄 Changes

- Add `ChatCompletionRequest.n` and export a new `ChatCompletionChoice` response type.
- Preserve every returned chat completion choice in `ChatCompletionResponse.choices`, while keeping `response.message` as the first choice for existing callers.
- Parse all OpenAI-compatible chat completion choices instead of discarding everything after index 0.
- Forward `n` through `ModelFacade.completion()` and OpenAI-compatible transport bodies, while excluding it from Anthropic request forwarding.
- Strip `n` from `generate()` and `agenerate()` before delegating to completion because those APIs return one parsed result.
- Add tests for request forwarding, multi-choice parsing, async parsing, compatibility access, Anthropic `n` exclusion, and `generate(..., n=...)` stripping.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`types.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix-620-chat-completion-choices-n/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py) — updates the canonical chat completion response contract while preserving `response.message`.
- [`facade.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/nmulepati/fix-620-chat-completion-choices-n/packages/data-designer-engine/src/data_designer/engine/models/facade.py) — `completion(..., n=...)` exposes multiple choices, while `generate(..., n=...)` strips `n` because it returns a single parsed result.

## 🧪 Testing

- [ ] `make test` passes (not run; focused model suite was run instead)
- [x] `PYTHONPATH=packages/data-designer-config/src:packages/data-designer-engine/src:packages/data-designer/src uv run --group dev pytest packages/data-designer-engine/tests/engine/models -q` passes (`532 passed`)
- [x] `uv run --group dev ruff check ...` passes for touched files
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no E2E surface)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — no architecture docs needed)
