### PR TITLE
fix: honor request waiter deadlines before admission

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/models/request_admission/controller.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/request_admission/controller.py
@@ -217,6 +217,18 @@ class AdaptiveRequestAdmissionController(RequestPressureSnapshotProvider):
         try:
             while True:
                 with self._lock:
+                    if waiter.assigned_lease is not None:
+                        return waiter.assigned_lease
+                    now = time.monotonic()
+                    if deadline is not None and now >= deadline:
+                        self._remove_waiter_locked(waiter)
+                        denied = RequestAdmissionDenied(
+                            item=item,
+                            reason="queue_timeout",
+                            snapshot=self._snapshot_locked(item.resource, now),
+                        )
+                        events.append(self._request_event_locked("request_wait_timeout", item=item, decision=denied))
+                        raise RequestAdmissionError(denied)
                     if not self._queue.contains(waiter.waiter_id) and waiter.assigned_lease is None:
                         self._enqueue_waiter_locked(waiter, events)
                     self._admit_waiters_locked(events)
@@ -258,6 +270,18 @@ class AdaptiveRequestAdmissionController(RequestPressureSnapshotProvider):
         try:
             while True:
                 with self._lock:
+                    if waiter.assigned_lease is not None:
+                        return waiter.assigned_lease
+                    now = time.monotonic()
+                    if deadline is not None and now >= deadline:
+                        self._remove_waiter_locked(waiter)
+                        denied = RequestAdmissionDenied(
+                            item=item,
+                            reason="queue_timeout",
+                            snapshot=self._snapshot_locked(item.resource, now),
+                        )
+                        events.append(self._request_event_locked("request_wait_timeout", item=item, decision=denied))
+                        raise RequestAdmissionError(denied)
                     if not self._queue.contains(waiter.waiter_id) and waiter.assigned_lease is None:
                         self._enqueue_waiter_locked(waiter, events)
                     self._admit_waiters_locked(events)
@@ -386,6 +410,7 @@ class AdaptiveRequestAdmissionController(RequestPressureSnapshotProvider):
     def _queued_waiter_ahead_locked(self, item: RequestAdmissionItem, now: float) -> bool:
         if not self._queue.has_waiters:
             return False
+        self._expire_waiters_locked(now)
         selection = self._queue.select_next(lambda waiter, _view: self._denial_for(waiter.item, now) is None)
         if selection is None:
             return False
@@ -408,9 +433,18 @@ class AdaptiveRequestAdmissionController(RequestPressureSnapshotProvider):
         state.waiters = max(0, state.waiters - 1)
         self._sequence += 1
 
+    def _expire_waiters_locked(self, now: float) -> None:
+        for waiter in self._queue.waiters():
+            if waiter.deadline_monotonic is not None and now >= waiter.deadline_monotonic:
+                self._remove_waiter_locked(waiter)
+                self._wake_waiter_locked(waiter)
+
     def _admit_waiters_locked(self, events: list[RequestAdmissionEvent]) -> None:
         while self._queue.has_waiters:
             now = time.monotonic()
+            self._expire_waiters_locked(now)
+            if not self._queue.has_waiters:
+                return
             selection = self._queue.select_next(lambda waiter, _view: self._denial_for(waiter.item, now) is None)
             if selection is None:
                 return

--- a/packages/data-designer-engine/src/data_designer/engine/models/request_admission/queue.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/request_admission/queue.py
@@ -64,6 +64,9 @@ class RequestFairQueue:
     def contains(self, waiter_id: str) -> bool:
         return waiter_id in self._queued
 
+    def waiters(self) -> tuple[RequestWaiter, ...]:
+        return tuple(self._queued.values())
+
     def enqueue(self, waiter: RequestWaiter) -> bool:
         if waiter.waiter_id in self._queued:
             return False

--- a/packages/data-designer-engine/tests/engine/models/request_admission/test_controller.py
+++ b/packages/data-designer-engine/tests/engine/models/request_admission/test_controller.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
+import time
 
 import pytest
 
@@ -209,6 +211,46 @@ async def test_request_admission_zero_async_timeout_is_immediate() -> None:
     assert snapshot is not None
     assert snapshot.waiters == 0
     controller.release(lease, RequestReleaseOutcome(kind="success"))
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_acquire_async_does_not_assign_expired_waiter_after_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _controller(cap=1)
+    monkeypatch.setattr(controller, "_wait_seconds_locked", lambda _item, _now, _deadline: 10.0)
+    lease = controller.try_acquire(_item(RequestDomain.CHAT))
+    assert isinstance(lease, RequestAdmissionLease)
+    queued = _item(RequestDomain.EMBEDDING, timeout=0.01)
+
+    queued_task = asyncio.create_task(controller.acquire_async(queued))
+    for _ in range(20):
+        snapshot = controller.pressure.snapshot(queued.resource)
+        if snapshot is not None and snapshot.waiters == 1:
+            break
+        await asyncio.sleep(0)
+    else:
+        raise AssertionError("async waiter did not enqueue")
+
+    def release_after_deadline() -> None:
+        time.sleep(0.03)
+        controller.release(lease, RequestReleaseOutcome(kind="success"))
+
+    release_thread = threading.Thread(target=release_after_deadline)
+    release_thread.start()
+    try:
+        time.sleep(0.06)
+        with pytest.raises(RequestAdmissionError) as exc_info:
+            await asyncio.wait_for(queued_task, timeout=0.5)
+    finally:
+        release_thread.join()
+
+    assert exc_info.value.decision.reason == "queue_timeout"
+    snapshot = controller.pressure.snapshot(queued.resource)
+    assert snapshot is not None
+    assert snapshot.waiters == 0
+    assert snapshot.active_lease_count == 0
+    assert snapshot.in_flight_count == 0
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
## Summary

- Expire queued request waiters before selecting them for admission.
- Check waiter deadlines before re-enqueuing a woken waiter.
- Add a regression for an async waiter whose deadline passes before another thread releases request capacity.

## Why

A queued async waiter could receive a request lease after its `deadline_monotonic` had already passed if the event loop was stalled and capacity was released from another thread. Queue wait timeouts should be terminal before admission assigns a lease.

## Validation

- `.venv/bin/ruff check --fix .`
- `.venv/bin/ruff format .`
- `.venv/bin/pytest packages/data-designer-engine/tests/engine/models/request_admission/test_controller.py`
- `.venv/bin/pytest packages/data-designer-engine/tests/engine/dataset_builders/scheduling/test_resolver.py packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py packages/data-designer-engine/tests/engine/models/request_admission/test_controller.py packages/data-designer-engine/tests/engine/models/clients/test_model_request_executor.py`