### PR TITLE
fix: keep async idle benchmark artifacts in scratch

### DIFF
--- a/packages/data-designer-engine/tests/engine/test_async_scheduling_benchmark.py
+++ b/packages/data-designer-engine/tests/engine/test_async_scheduling_benchmark.py
@@ -287,6 +287,33 @@ def test_idle_regression_skip_run_does_not_generate_missing_artifacts(tmp_path: 
         report._run_or_load_case(case, tmp_path, skip_run=True)
 
 
+def test_idle_benchmark_defaults_write_to_scratch() -> None:
+    report = _load_idle_report_module()
+    regression = _load_idle_regression_module()
+
+    assert report.DEFAULT_ARTIFACT_DIR == Path(".scratch/async-scheduling-idle-analysis/artifacts")
+    assert report.DEFAULT_REPORT_PATH == Path(
+        ".scratch/async-scheduling-idle-analysis/async-scheduling-idle-analysis.html"
+    )
+    assert regression.DEFAULT_ARTIFACT_DIR == Path(".scratch/async-scheduling-idle-regression/artifacts")
+    assert regression.DEFAULT_REPORT_PATH == Path(
+        ".scratch/async-scheduling-idle-regression/async-scheduling-idle-regression.html"
+    )
+
+
+def test_idle_report_links_artifacts_relative_to_report() -> None:
+    report = _load_idle_report_module()
+
+    assert (
+        report._relative_href(
+            Path(".scratch/async-scheduling-idle-analysis/async-scheduling-idle-analysis.html"),
+            Path(".scratch/async-scheduling-idle-analysis/artifacts/case.json"),
+        )
+        == "artifacts/case.json"
+    )
+    assert report._relative_href(Path("reports/idle.html"), Path("artifacts/case.json")) == "../artifacts/case.json"
+
+
 def test_idle_regression_requires_adaptation_controls() -> None:
     regression = _load_idle_regression_module()
     summary = _idle_regression_summary()

--- a/scripts/benchmarks/generate_async_scheduling_idle_report.py
+++ b/scripts/benchmarks/generate_async_scheduling_idle_report.py
@@ -9,6 +9,7 @@ import argparse
 import html
 import json
 import math
+import os
 import subprocess
 import sys
 from collections.abc import Iterable, Mapping, Sequence
@@ -16,8 +17,9 @@ from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
 
-DEFAULT_ARTIFACT_DIR = Path("artifacts/async-scheduling-idle-analysis")
-DEFAULT_REPORT_PATH = Path("reports/async-scheduling-idle-analysis.html")
+DEFAULT_OUTPUT_ROOT = Path(".scratch/async-scheduling-idle-analysis")
+DEFAULT_ARTIFACT_DIR = DEFAULT_OUTPUT_ROOT / "artifacts"
+DEFAULT_REPORT_PATH = DEFAULT_OUTPUT_ROOT / "async-scheduling-idle-analysis.html"
 BENCHMARK_SCRIPT = Path("scripts/benchmarks/benchmark_async_scheduling.py")
 IDLE_SUITE_ID = "async-scheduling-idle-regression"
 IDLE_SUITE_VERSION = "1.1"
@@ -1762,7 +1764,9 @@ def _class_slug(idle_class: str) -> str:
 
 def _relative_href(report_path: Path, target_path: Path) -> str:
     try:
-        return Path("../" + str(target_path)).as_posix() if not target_path.is_absolute() else target_path.as_uri()
+        if target_path.is_absolute():
+            return target_path.as_uri()
+        return Path(os.path.relpath(target_path, start=report_path.parent)).as_posix()
     except ValueError:
         return str(target_path)
 

--- a/scripts/benchmarks/run_async_scheduling_idle_regression.py
+++ b/scripts/benchmarks/run_async_scheduling_idle_regression.py
@@ -23,8 +23,9 @@ from generate_async_scheduling_idle_report import (
     write_idle_results_summary,
 )
 
-DEFAULT_ARTIFACT_DIR = Path("artifacts/async-scheduling-idle-regression")
-DEFAULT_REPORT_PATH = Path("reports/async-scheduling-idle-regression.html")
+DEFAULT_OUTPUT_ROOT = Path(".scratch/async-scheduling-idle-regression")
+DEFAULT_ARTIFACT_DIR = DEFAULT_OUTPUT_ROOT / "artifacts"
+DEFAULT_REPORT_PATH = DEFAULT_OUTPUT_ROOT / "async-scheduling-idle-regression.html"
 DEFAULT_SUMMARY_PATH = DEFAULT_ARTIFACT_DIR / "idle_regression_summary.json"
 DEFAULT_CHECKS_PATH = DEFAULT_ARTIFACT_DIR / "idle_regression_checks.json"
 CHECKS_SCHEMA_VERSION = "async-scheduling-idle-checks-v1"


### PR DESCRIPTION
## Summary

- write async idle benchmark defaults under ignored `.scratch/` paths
- keep generated report links relative to the report location
- add regression coverage for default paths and artifact links

## Why

The idle benchmark scripts previously wrote generated artifacts and reports into tracked repository paths by default. Running the documented smoke flow could leave an untracked worktree.

## Validation

- `.venv/bin/pytest packages/data-designer-engine/tests/engine/test_async_scheduling_benchmark.py`
- `.venv/bin/ruff check --fix .`
- `.venv/bin/ruff format .`
