### PR TITLE
fix(interface): reject duplicate names within output_processors (#675)

### DIFF
--- a/packages/data-designer/src/data_designer/interface/composite_workflow.py
+++ b/packages/data-designer/src/data_designer/interface/composite_workflow.py
@@ -558,6 +558,15 @@ def _validate_distinct_output_processors(
     config_builder: DataDesignerConfigBuilder,
     output_processors: list[ProcessorConfig],
 ) -> None:
+    seen: set[str] = set()
+    duplicate_within: set[str] = set()
+    for processor in output_processors:
+        if processor.name in seen:
+            duplicate_within.add(processor.name)
+        seen.add(processor.name)
+    if duplicate_within:
+        names = ", ".join(sorted(duplicate_within))
+        raise DataDesignerWorkflowError(f"Output processor names must be distinct within output_processors: {names}.")
     stage_processor_names = {processor.name for processor in config_builder.get_processor_configs()}
     duplicate_names = stage_processor_names.intersection(processor.name for processor in output_processors)
     if duplicate_names:

--- a/packages/data-designer/tests/interface/test_composite_workflow.py
+++ b/packages/data-designer/tests/interface/test_composite_workflow.py
@@ -378,6 +378,27 @@ def test_composite_workflow_rejects_duplicate_output_processor_names(
         )
 
 
+def test_composite_workflow_rejects_duplicate_names_within_output_processors(
+    stub_artifact_path: Path,
+    stub_model_providers: list[ModelProvider],
+    stub_model_configs: list[ModelConfig],
+) -> None:
+    stage = _category_builder(stub_model_configs)
+    workflow = _data_designer(stub_artifact_path, stub_model_providers).compose_workflow(
+        name="duplicate-within-output-processors"
+    )
+
+    with pytest.raises(DataDesignerWorkflowError, match="distinct within output_processors"):
+        workflow.add_stage(
+            "base",
+            stage,
+            output_processors=[
+                DropColumnsProcessorConfig(name="drop_scratch", column_names=["scratch"]),
+                DropColumnsProcessorConfig(name="drop_scratch", column_names=["other_scratch"]),
+            ],
+        )
+
+
 def test_composite_workflow_rejects_duplicate_stage_names(
     stub_artifact_path: Path,
     stub_model_providers: list[ModelProvider],


### PR DESCRIPTION
## 📋 Summary

`_validate_distinct_output_processors` only compared output-processor names against the stage's existing processors, so two output processors with the same name silently overwrote one another's artifact directory. This patch raises `DataDesignerWorkflowError` when names repeat within `output_processors`.

## 🔗 Related Issue

Fixes #675

## 🔄 Changes
- Detect intra-list duplicates in `_validate_distinct_output_processors` before the cross-list check.
- Add a regression test that asserts the new error message in `test_composite_workflow.py`.

## 🧪 Testing
- [x] Targeted pytest suite for `composite_workflow` (44 tests) passes.
- [x] Unit test added that fails without the fix.

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)

<!-- triaged-recheck: 2026-05-21T16:00:48Z -->