### PR TITLE
ci: add NVSkills request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## 📋 Summary
Adds the NVSkills request workflow so maintainers can trigger NVSkills CI from pull request comments once this workflow exists on the default branch.

## 🔗 Related Issue
N/A

## 🔄 Changes
- Add `.github/workflows/request-nvskills-ci.yml` from `NVIDIA/skills`.
- Enable `/nvskills-ci` pull request comment requests and NVSkills signature push handling.

## 🧪 Testing
- [ ] `make test` passes (N/A - workflow-only change)
- [ ] Unit tests added/updated (N/A - no Python logic)
- [ ] E2E tests added/updated (N/A - no app workflow)
- [x] Parsed workflow YAML with Ruby `YAML.load_file`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A - CI workflow only)