### PR TITLE
fix: repair NGC persona downloads

### DIFF
--- a/docs/concepts/person_sampling.md
+++ b/docs/concepts/person_sampling.md
@@ -90,14 +90,17 @@ To download the Nemotron-Personas datasets from NGC, you will need to obtain an 
 2. **NGC CLI**: [NGC CLI](https://org.ngc.nvidia.com/setup/installers/cli)
 
 
-#### Step 1: Set Your NGC API Key
+#### Step 1: Create the default NGC CLI config
+
+Configure the NGC CLI with your API key. When prompted, paste the API key you obtained from NGC. This creates the default `~/.ngc/config` file that Data Designer checks before downloading persona datasets.
+
 ```bash
-export NGC_API_KEY="your-ngc-api-key-here"
+ngc config set
 ```
 
 #### Step 2 (option 1): Download Nemotron-Personas Datasets via the Data Designer CLI
 
-Once you have the NGC CLI and your NGC API key set up, you can download the datasets via the Data Designer CLI.
+Once you have configured the NGC CLI, you can download the datasets via the Data Designer CLI.
 
 You can pass the locales you want to download as arguments to the CLI command:
 ```bash
@@ -111,7 +114,7 @@ data-designer download personas
 
 #### Step 2 (option 2): Download Nemotron-Personas Datasets Directly
 
-Use the NGC CLI to download the datasets:
+Use the configured NGC CLI to download the datasets:
 ```bash
 # For Nemotron-Personas USA
 ngc registry resource download-version "nvidia/nemotron-personas/nemotron-personas-dataset-en_us"

--- a/fern/versions/latest/pages/concepts/person_sampling.mdx
+++ b/fern/versions/latest/pages/concepts/person_sampling.mdx
@@ -93,14 +93,17 @@ To download the Nemotron-Personas datasets from NGC, you will need to obtain an 
 2. **NGC CLI**: [NGC CLI](https://org.ngc.nvidia.com/setup/installers/cli)
 
 
-#### Step 1: Set Your NGC API Key
+#### Step 1: Create the default NGC CLI config
+
+Configure the NGC CLI with your API key. When prompted, paste the API key you obtained from NGC. This creates the default `~/.ngc/config` file that Data Designer checks before downloading persona datasets.
+
 ```bash
-export NGC_API_KEY="your-ngc-api-key-here"
+ngc config set
 ```
 
 #### Step 2 (option 1): Download Nemotron-Personas Datasets via the Data Designer CLI
 
-Once you have the NGC CLI and your NGC API key set up, you can download the datasets via the Data Designer CLI.
+Once you have configured the NGC CLI, you can download the datasets via the Data Designer CLI.
 
 You can pass the locales you want to download as arguments to the CLI command:
 ```bash
@@ -114,7 +117,7 @@ data-designer download personas
 
 #### Step 2 (option 2): Download Nemotron-Personas Datasets Directly
 
-Use the NGC CLI to download the datasets:
+Use the configured NGC CLI to download the datasets:
 ```bash
 # For Nemotron-Personas USA
 ngc registry resource download-version "nvidia/nemotron-personas/nemotron-personas-dataset-en_us"

--- a/packages/data-designer/src/data_designer/cli/controllers/download_controller.py
+++ b/packages/data-designer/src/data_designer/cli/controllers/download_controller.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from data_designer.cli.repositories.persona_repository import PersonaRepository
-from data_designer.cli.services.download_service import DownloadService
+from data_designer.cli.services.download_service import DownloadService, NgcConfigError
 from data_designer.cli.ui import (
     confirm_action,
     console,
@@ -73,6 +73,13 @@ class DownloadController:
         if not selected_locales:
             print_info("No locales selected")
             return
+
+        if not dry_run:
+            try:
+                self.service.ensure_ngc_config_exists()
+            except NgcConfigError as e:
+                print_error(str(e))
+                return
 
         # Show what will be downloaded
         console.print()
@@ -192,6 +199,12 @@ class DownloadController:
             print_error(f"NGC CLI error: {e}")
             return False
 
+        except NgcConfigError as e:
+            console.print()
+            print_error(f"✗ Failed to download Nemotron-Persona dataset for {locale}")
+            print_error(str(e))
+            return False
+
         except Exception as e:
             console.print()
             print_error(f"✗ Failed to download Nemotron-Persona dataset for {locale}")
@@ -214,6 +227,6 @@ def check_ngc_cli_with_instructions() -> bool:
     print_text("To download the Nemotron-Personas datasets, follow these steps:")
     print_text(f"    1. Create an NVIDIA NGC account: {NGC_URL}")
     print_text(f"    2. Install the NGC CLI: {NGC_CLI_INSTALL_URL}")
-    print_text("    3. Following the install instructions to set up the NGC CLI")
+    print_text("    3. Run 'ngc config set' to create a default NGC CLI config file")
     print_text("    4. Run 'data-designer download personas'")
     return False

--- a/packages/data-designer/src/data_designer/cli/controllers/download_controller.py
+++ b/packages/data-designer/src/data_designer/cli/controllers/download_controller.py
@@ -67,19 +67,19 @@ class DownloadController:
         if not dry_run and not check_ngc_cli_with_instructions():
             return
 
-        # Determine which locales to download
-        selected_locales = self._determine_locales(locales, all_locales)
-
-        if not selected_locales:
-            print_info("No locales selected")
-            return
-
         if not dry_run:
             try:
                 self.service.ensure_ngc_config_exists()
             except NgcConfigError as e:
                 print_error(str(e))
                 return
+
+        # Determine which locales to download
+        selected_locales = self._determine_locales(locales, all_locales)
+
+        if not selected_locales:
+            print_info("No locales selected")
+            return
 
         # Show what will be downloaded
         console.print()

--- a/packages/data-designer/src/data_designer/cli/services/download_service.py
+++ b/packages/data-designer/src/data_designer/cli/services/download_service.py
@@ -12,18 +12,44 @@ from pathlib import Path
 from data_designer.cli.repositories.persona_repository import PersonaRepository
 
 
+class NgcConfigError(RuntimeError):
+    """Raised when the NGC CLI default config file is missing."""
+
+
 class DownloadService:
     """Business logic for downloading assets via NGC CLI."""
 
-    def __init__(self, config_dir: Path, persona_repository: PersonaRepository):
+    config_dir: Path
+    managed_assets_dir: Path
+    ngc_config_path: Path
+    persona_repository: PersonaRepository
+
+    def __init__(
+        self,
+        config_dir: Path,
+        persona_repository: PersonaRepository,
+        ngc_config_path: Path | None = None,
+    ) -> None:
         self.config_dir = config_dir
         self.managed_assets_dir = config_dir / "managed-assets" / "datasets"
+        self.ngc_config_path = ngc_config_path if ngc_config_path is not None else Path.home() / ".ngc" / "config"
         self.persona_repository = persona_repository
 
     def get_available_locales(self) -> dict[str, str]:
         """Get dictionary of available persona locales (locale code -> locale code)."""
         locales = self.persona_repository.list_all()
         return {locale.code: locale.code for locale in locales}
+
+    def ensure_ngc_config_exists(self) -> None:
+        """Raise an actionable error when the default NGC CLI config is missing."""
+        if self.ngc_config_path.is_file():
+            return
+
+        raise NgcConfigError(
+            f"NGC CLI config file not found at {self.ngc_config_path}. "
+            "Run 'ngc config set' to create a default config file, then rerun "
+            "'data-designer download personas'."
+        )
 
     def download_persona_dataset(self, locale: str) -> Path:
         """Download persona dataset for a specific locale using NGC CLI and move to managed assets.
@@ -36,12 +62,14 @@ class DownloadService:
 
         Raises:
             ValueError: If locale is invalid
+            NgcConfigError: If the default NGC CLI config file does not exist
             subprocess.CalledProcessError: If NGC CLI command fails
         """
         locale_obj = self.persona_repository.get_by_code(locale)
         if not locale_obj:
             raise ValueError(f"Invalid locale: {locale}")
 
+        self.ensure_ngc_config_exists()
         self.managed_assets_dir.mkdir(parents=True, exist_ok=True)
 
         # Use temporary directory for download
@@ -53,8 +81,6 @@ class DownloadService:
                 "resource",
                 "download-version",
                 f"nvidia/nemotron-personas/{locale_obj.dataset_name}",
-                "--org",
-                "nvidia",
                 "--dest",
                 temp_dir,
             ]

--- a/packages/data-designer/tests/cli/controllers/test_download_controller.py
+++ b/packages/data-designer/tests/cli/controllers/test_download_controller.py
@@ -224,7 +224,7 @@ def test_run_personas_ngc_config_not_available(
     """Test run_personas exits early when the default NGC config is missing."""
     controller.service.ngc_config_path = controller.config_dir / ".ngc" / "missing"
 
-    controller.run_personas(locales=["en_US"], all_locales=False)
+    controller.run_personas(locales=None, all_locales=False)
 
     mock_check_ngc.assert_called_once()
     mock_print_error.assert_called_once()

--- a/packages/data-designer/tests/cli/controllers/test_download_controller.py
+++ b/packages/data-designer/tests/cli/controllers/test_download_controller.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -8,18 +10,29 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from data_designer.cli.controllers.download_controller import DownloadController
+from data_designer.cli.services.download_service import NgcConfigError
+
+
+def _create_ngc_config(controller: DownloadController, tmp_path: Path) -> None:
+    ngc_config_path = tmp_path / ".ngc" / "config"
+    ngc_config_path.parent.mkdir(parents=True, exist_ok=True)
+    ngc_config_path.touch()
+    controller.service.ngc_config_path = ngc_config_path
 
 
 @pytest.fixture
 def controller(tmp_path: Path) -> DownloadController:
     """Create a controller instance for testing."""
-    return DownloadController(tmp_path)
+    controller = DownloadController(tmp_path)
+    _create_ngc_config(controller, tmp_path)
+    return controller
 
 
 @pytest.fixture
 def controller_with_datasets(tmp_path: Path) -> DownloadController:
     """Create a controller instance with existing datasets."""
     controller = DownloadController(tmp_path)
+    _create_ngc_config(controller, tmp_path)
     # Create managed assets directory with sample parquet files
     managed_assets_dir = tmp_path / "managed-assets" / "datasets"
     managed_assets_dir.mkdir(parents=True, exist_ok=True)
@@ -195,6 +208,32 @@ def test_run_personas_ngc_cli_not_available(
     mock_check_ngc.assert_called_once()
 
 
+@patch.object(DownloadController, "_download_locale")
+@patch("data_designer.cli.controllers.download_controller.confirm_action")
+@patch("data_designer.cli.controllers.download_controller.select_multiple_with_arrows")
+@patch("data_designer.cli.controllers.download_controller.print_error")
+@patch("data_designer.cli.controllers.download_controller.check_ngc_cli_with_instructions", return_value=True)
+def test_run_personas_ngc_config_not_available(
+    mock_check_ngc: MagicMock,
+    mock_print_error: MagicMock,
+    mock_select: MagicMock,
+    mock_confirm: MagicMock,
+    mock_download: MagicMock,
+    controller: DownloadController,
+) -> None:
+    """Test run_personas exits early when the default NGC config is missing."""
+    controller.service.ngc_config_path = controller.config_dir / ".ngc" / "missing"
+
+    controller.run_personas(locales=["en_US"], all_locales=False)
+
+    mock_check_ngc.assert_called_once()
+    mock_print_error.assert_called_once()
+    assert "ngc config set" in mock_print_error.call_args.args[0]
+    mock_select.assert_not_called()
+    mock_confirm.assert_not_called()
+    mock_download.assert_not_called()
+
+
 def test_check_ngc_cli_available_with_version() -> None:
     """Test check_ngc_cli_with_instructions displays version when NGC CLI is available."""
     from data_designer.cli.controllers.download_controller import check_ngc_cli_with_instructions
@@ -282,6 +321,18 @@ def test_download_locale_subprocess_error(controller: DownloadController) -> Non
         controller.service,
         "download_persona_dataset",
         side_effect=subprocess.CalledProcessError(1, "ngc"),
+    ):
+        result = controller._download_locale("en_US")
+
+    assert result is False
+
+
+def test_download_locale_ngc_config_error(controller: DownloadController) -> None:
+    """Test _download_locale handles missing NGC config errors."""
+    with patch.object(
+        controller.service,
+        "download_persona_dataset",
+        side_effect=NgcConfigError("Run 'ngc config set'"),
     ):
         result = controller._download_locale("en_US")
 

--- a/packages/data-designer/tests/cli/services/test_download_service.py
+++ b/packages/data-designer/tests/cli/services/test_download_service.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -8,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from data_designer.cli.repositories.persona_repository import PersonaRepository
-from data_designer.cli.services.download_service import DownloadService
+from data_designer.cli.services.download_service import DownloadService, NgcConfigError
 
 
 @pytest.fixture
@@ -18,15 +20,28 @@ def persona_repository() -> PersonaRepository:
 
 
 @pytest.fixture
-def service(tmp_path: Path, persona_repository: PersonaRepository) -> DownloadService:
-    """Create a service instance for testing."""
-    return DownloadService(tmp_path, persona_repository)
+def ngc_config_path(tmp_path: Path) -> Path:
+    """Create a default NGC CLI config file for download tests."""
+    config_path = tmp_path / ".ngc" / "config"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.touch()
+    return config_path
 
 
 @pytest.fixture
-def service_with_datasets(tmp_path: Path, persona_repository: PersonaRepository) -> DownloadService:
+def service(tmp_path: Path, persona_repository: PersonaRepository, ngc_config_path: Path) -> DownloadService:
+    """Create a service instance for testing."""
+    return DownloadService(tmp_path, persona_repository, ngc_config_path=ngc_config_path)
+
+
+@pytest.fixture
+def service_with_datasets(
+    tmp_path: Path,
+    persona_repository: PersonaRepository,
+    ngc_config_path: Path,
+) -> DownloadService:
     """Create a service instance with existing datasets."""
-    service = DownloadService(tmp_path, persona_repository)
+    service = DownloadService(tmp_path, persona_repository, ngc_config_path=ngc_config_path)
     # Create managed assets directory with sample parquet files
     managed_assets_dir = tmp_path / "managed-assets" / "datasets"
     managed_assets_dir.mkdir(parents=True, exist_ok=True)
@@ -38,12 +53,13 @@ def service_with_datasets(tmp_path: Path, persona_repository: PersonaRepository)
     return service
 
 
-def test_init(tmp_path: Path, persona_repository: PersonaRepository) -> None:
+def test_init(tmp_path: Path, persona_repository: PersonaRepository, ngc_config_path: Path) -> None:
     """Test service initialization sets up paths correctly."""
-    service = DownloadService(tmp_path, persona_repository)
+    service = DownloadService(tmp_path, persona_repository, ngc_config_path=ngc_config_path)
     assert service.config_dir == tmp_path
     assert service.managed_assets_dir == tmp_path / "managed-assets" / "datasets"
     assert service.persona_repository is persona_repository
+    assert service.ngc_config_path == ngc_config_path
 
 
 def test_get_available_locales(service: DownloadService) -> None:
@@ -109,7 +125,6 @@ def test_download_persona_dataset_success(
     mock_subprocess: MagicMock,
     mock_glob: MagicMock,
     service: DownloadService,
-    tmp_path: Path,
 ) -> None:
     """Test successful persona dataset download."""
     # Setup mock temporary directory
@@ -137,8 +152,6 @@ def test_download_persona_dataset_success(
         "resource",
         "download-version",
         "nvidia/nemotron-personas/nemotron-personas-dataset-en_us",
-        "--org",
-        "nvidia",
         "--dest",
         temp_dir_path,
     ]
@@ -209,6 +222,23 @@ def test_download_persona_dataset_ngc_cli_error(
     # Should propagate the error
     with pytest.raises(subprocess.CalledProcessError):
         service.download_persona_dataset("en_US")
+
+
+@patch("data_designer.cli.services.download_service.subprocess.run")
+def test_download_persona_dataset_missing_ngc_config(
+    mock_subprocess: MagicMock,
+    tmp_path: Path,
+    persona_repository: PersonaRepository,
+) -> None:
+    """Test download fails early with instructions when the NGC config is missing."""
+    missing_config_path = tmp_path / ".ngc" / "config"
+    service = DownloadService(tmp_path, persona_repository, ngc_config_path=missing_config_path)
+
+    with pytest.raises(NgcConfigError, match="Run 'ngc config set'"):
+        service.download_persona_dataset("en_US")
+
+    mock_subprocess.assert_not_called()
+    assert not service.managed_assets_dir.exists()
 
 
 @patch("data_designer.cli.services.download_service.glob.glob")


### PR DESCRIPTION
## 📋 Summary

This PR fixes Nemotron-Persona dataset downloads with NGC CLI versions that reject the `--org` argument. It removes the unsupported flag, requires users to create the default NGC CLI config file, and keeps the setup docs aligned with the new behavior.

## 🔗 Related Issue

Closes #708

cc @3mei

## 🔄 Changes

- Remove `--org nvidia` from the `ngc registry resource download-version` command.
- Add an explicit missing-config error that tells users to run `ngc config set`.
- Preflight the default NGC config before prompting for persona dataset downloads.
- Update persona sampling docs in both Fern and legacy docs to describe the `ngc config set` setup path.
- Add tests for the updated NGC command shape and missing-config behavior.

## 🧪 Testing

- [ ] `make test` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — no E2E coverage for live NGC CLI downloads)

Focused checks run:

```bash
uv run --group dev pytest packages/data-designer/tests/cli/services/test_download_service.py packages/data-designer/tests/cli/controllers/test_download_controller.py
uv run --group dev ruff check packages/data-designer/src/data_designer/cli/controllers/download_controller.py packages/data-designer/src/data_designer/cli/services/download_service.py packages/data-designer/tests/cli/controllers/test_download_controller.py packages/data-designer/tests/cli/services/test_download_service.py
uv run --group dev ruff format --check packages/data-designer/src/data_designer/cli/controllers/download_controller.py packages/data-designer/src/data_designer/cli/services/download_service.py packages/data-designer/tests/cli/controllers/test_download_controller.py packages/data-designer/tests/cli/services/test_download_service.py
```

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — no architecture changes)
