### PR TITLE
docs: publish devnote figure component

### DIFF
--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -4,12 +4,15 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/publish-fern-devnotes.yml"
       - "fern/assets/**"
       - "fern/components/Authors.tsx"
       - "fern/components/BlogCard.tsx"
+      - "fern/components/Figure.tsx"
       - "fern/components/MetricsTable.tsx"
       - "fern/components/TrajectoryViewer.tsx"
       - "fern/components/devnotes/**"
+      - "fern/scripts/fern-published-branch.py"
       - "fern/styles/authors.css"
       - "fern/styles/blog-card.css"
       - "fern/styles/metrics-table.css"

--- a/fern/scripts/fern-published-branch.py
+++ b/fern/scripts/fern-published-branch.py
@@ -45,6 +45,7 @@ FERN_DEVNOTE_SUPPORT_PATHS = [
     "fern/assets",
     "fern/components/Authors.tsx",
     "fern/components/BlogCard.tsx",
+    "fern/components/Figure.tsx",
     "fern/components/MetricsTable.tsx",
     "fern/components/TrajectoryViewer.tsx",
     "fern/components/devnotes",

--- a/packages/data-designer/tests/docs/test_fern_published_branch.py
+++ b/packages/data-designer/tests/docs/test_fern_published_branch.py
@@ -63,6 +63,7 @@ redirects:
     )
     write_text(source_root / "fern" / "fern.config.json", '{"organization": "nvidia", "version": "5.41.1"}\n')
     write_text(source_root / "fern" / "assets" / "current-devnote-asset.png", "new asset")
+    write_text(source_root / "fern" / "components" / "Figure.tsx", "export const Figure = () => null;\n")
     write_text(
         source_root / "fern" / "versions" / "latest.yml",
         """navigation:
@@ -125,5 +126,8 @@ redirects:
         '{"organization": "nvidia", "version": "5.41.1"}\n'
     )
     assert (published_root / "fern" / "assets" / "current-devnote-asset.png").read_text() == "new asset"
+    assert (published_root / "fern" / "components" / "Figure.tsx").read_text() == (
+        "export const Figure = () => null;\n"
+    )
     assert not (published_root / "fern" / "assets" / "published-only-asset.png").exists()
     assert (published_root / "fern" / "versions" / "latest" / "pages" / "devnotes" / "posts" / "new-note.mdx").exists()


### PR DESCRIPTION
## 📋 Summary

This PR fixes the Fern Dev Notes publish path so MDX pages that import the shared `Figure` component can render after being patched into the `docs-website` branch. It also makes the Dev Notes publish workflow rerun when the support copier or figure component changes, so this repair can publish without waiting for an unrelated docs edit.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Copy [`Figure.tsx`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/fern-devnote-figure-component/fern/components/Figure.tsx) as part of the Dev Notes support files used by [`fern-published-branch.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/fern-devnote-figure-component/fern/scripts/fern-published-branch.py).
- Update [`publish-fern-devnotes.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/fern-devnote-figure-component/.github/workflows/publish-fern-devnotes.yml) path filters so changes to the workflow, publish script, or `Figure.tsx` trigger Dev Notes publishing.
- Add a regression assertion to [`test_fern_published_branch.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/johnny/fix/fern-devnote-figure-component/packages/data-designer/tests/docs/test_fern_published_branch.py) confirming the figure component is copied into the published tree.

## 🧪 Testing

- [ ] `make test` passes (not run; focused docs validation below)
- [x] `uv run --group dev pytest packages/data-designer/tests/docs/test_fern_published_branch.py -q`
- [x] `uv run ruff format --check fern/scripts/fern-published-branch.py packages/data-designer/tests/docs/test_fern_published_branch.py`
- [x] `uv run ruff check fern/scripts/fern-published-branch.py packages/data-designer/tests/docs/test_fern_published_branch.py`
- [x] `npx -y fern-api@5.41.1 check`
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — docs publish workflow/support-file fix)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — no architecture docs changed)