### PR TITLE
fix(devnotes): include Figure component in Fern dev-notes publish alllowlist

### DIFF
--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -7,6 +7,7 @@ on:
       - "fern/assets/**"
       - "fern/components/Authors.tsx"
       - "fern/components/BlogCard.tsx"
+      - "fern/components/Figure.tsx"
       - "fern/components/MetricsTable.tsx"
       - "fern/components/TrajectoryViewer.tsx"
       - "fern/components/devnotes/**"

--- a/fern/scripts/fern-published-branch.py
+++ b/fern/scripts/fern-published-branch.py
@@ -45,6 +45,7 @@ FERN_DEVNOTE_SUPPORT_PATHS = [
     "fern/assets",
     "fern/components/Authors.tsx",
     "fern/components/BlogCard.tsx",
+    "fern/components/Figure.tsx",
     "fern/components/MetricsTable.tsx",
     "fern/components/TrajectoryViewer.tsx",
     "fern/components/devnotes",


### PR DESCRIPTION
## 📋 Summary

The Fern dev-notes publish workflow patches only an explicit allowlist of component files into the `docs-website` deploy branch. The new `<Figure>` component shipped by the Nemotron-Personas dev note (#611) wasn't on that allowlist, so the deployed site fails to resolve the import and renders an MDX compile error (`Could not resolve "../../../../../components/Figure"`) in place of the post. This PR adds `fern/components/Figure.tsx` to both the workflow trigger paths and the `FERN_DEVNOTE_SUPPORT_PATHS` list used by the patch-devnotes script.

## 🔗 Related Issue

Follow-up to #611 — without this fix, the Nemotron-Personas dev note renders as a compile error on the deployed Fern site.

## 🔄 Changes

- Add `fern/components/Figure.tsx` to `.github/workflows/publish-fern-devnotes.yml` trigger paths, so future edits to the component re-trigger a republish.
- Add `fern/components/Figure.tsx` to `FERN_DEVNOTE_SUPPORT_PATHS` in `fern/scripts/fern-published-branch.py`, so the file is actually copied into the `docs-website` deploy branch alongside the other dev-note kit components.

## 🧪 Testing

- `fern check` passes locally with the existing dev-note pages.
- Verified `fern/components/Figure.tsx` is committed at HEAD and resolves locally; the gap was only on the deploy-branch copy step.
- [ ] `make test` passes — N/A (docs-only fix, no Python changes).
- [ ] Unit tests added/updated — N/A.
- [ ] E2E tests added/updated — N/A.

## ✅ Checklist

- [x] Follows commit message conventions (`fix(devnotes): ...`).
- [ ] Commits are signed off (DCO).
- [ ] Architecture docs updated — N/A (mechanical allowlist addition, follows the existing pattern documented in the script comments).