### PR TITLE
ci: allow nvskills signing account for dco

### DIFF
--- a/.github/workflows/dco-assistant.yml
+++ b/.github/workflows/dco-assistant.yml
@@ -72,7 +72,7 @@ jobs:
           path-to-signatures: "dco-signatures.json"
           path-to-document: 'https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/DCO'
           branch: 'signatures'
-          allowlist: dependabot[bot]
+          allowlist: dependabot[bot],svc-nvskills-signing
           create-file-commit-message: "chore: create file to store dco signatures"
           signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
           custom-notsigned-prcomment: "Thank you for your submission! We ask that $you sign our [Developer Certificate of Origin](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/DCO) before we can accept your contribution. You can sign the DCO by adding a comment below using this text:"


### PR DESCRIPTION
## 📋 Summary

Allow the NVSkills signing service account to pass the DCO Assistant allowlist. This lets NVSkills-generated signature commits, such as the one currently on #718, satisfy DCO without requiring the service account to manually sign.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Add `svc-nvskills-signing` to the DCO Assistant allowlist in `.github/workflows/dco-assistant.yml`.

## 🧪 Testing

- [x] `git diff --check`
- [x] Unit tests added/updated: N/A — CI workflow allowlist only
- [x] E2E tests added/updated: N/A — CI workflow allowlist only

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated: N/A — CI workflow change only