### PR TITLE
fix: roll back setup-uv action bump

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
       - name: Set up Python

--- a/.github/workflows/build-fern-docs.yml
+++ b/.github/workflows/build-fern-docs.yml
@@ -131,7 +131,7 @@ jobs:
           python3 workflow/fern/scripts/fern-release-version.py --root website/fern check --version "$RELEASE_TAG" --require-latest-matches-release
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
 
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ env.FERN_PUBLISHED_BRANCH }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
 

--- a/.github/workflows/build-notebooks.yml
+++ b/.github/workflows/build-notebooks.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
       - name: Set up Python

--- a/.github/workflows/check-colab-notebooks.yml
+++ b/.github/workflows/check-colab-notebooks.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -192,7 +192,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -215,7 +215,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: "3.11"
@@ -242,7 +242,7 @@ jobs:
           fetch-depth: 0  # Full history needed for file creation dates
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: "3.11"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
 

--- a/.github/workflows/health-checks.yml
+++ b/.github/workflows/health-checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
           python-version: "3.11"

--- a/.github/workflows/publish-devnotes.yml
+++ b/.github/workflows/publish-devnotes.yml
@@ -47,7 +47,7 @@ jobs:
           git show ${{ github.sha }}:mkdocs.yml > /tmp/mkdocs-head.yml
           python3 .github/scripts/patch-devnotes-nav.py /tmp/mkdocs-head.yml mkdocs.yml
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
       - name: Set up Python

--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -83,7 +83,7 @@ jobs:
             --metadata-published-branch "$PUBLISHED_BRANCH"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.5"
 


### PR DESCRIPTION
## Summary

- Roll back `astral-sh/setup-uv` from `v8.2.0` to `v8.1.0` across workflows.
- Keep the `actions/checkout` and FW-CI template bumps from #739 intact.

## Root Cause

After #739 merged, the `Publish Fern devnotes` push workflow failed in the `Install uv` step. `setup-uv@v8.2.0` added a hard 5-second fetch timeout around manifest requests; the main run timed out while fetching `https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson` before installing pinned `uv` `0.9.5`.

Rolling back the action pin removes that new timeout behavior while preserving the existing `uv` versions used by the workflows.

## Validation

- `make install-dev`
- `git diff --check`
- Parsed all `.github/workflows/*.yml` with PyYAML
- Commit pre-commit hooks passed: whitespace, EOF, YAML, merge conflicts, line endings

Note: repo-wide `.venv/bin/ruff check --fix . && .venv/bin/ruff format .` was attempted, but Ruff failed on an unrelated existing notebook error in `docs/colab_notebooks/7-nemotron-personas.ipynb` (`from __future__` import not at the beginning of the cell). No Python files are changed in this PR.
