### PR TITLE
feat: Support remote filesystem seeds

### DIFF
--- a/fern/versions/latest/pages/concepts/seed-datasets.mdx
+++ b/fern/versions/latest/pages/concepts/seed-datasets.mdx
@@ -138,7 +138,7 @@ Directory-backed seed datasets expose these columns:
 
 <Note>
 Filesystem matching
-`file_pattern` matches file names only, not relative paths. `recursive=True` is the default, so nested subdirectories are searched unless you turn it off.
+`file_pattern` matches file names only, not relative paths. `recursive=True` is the default, so nested subdirectories are searched unless you turn it off. Relative local `path` values are resolved by the active filesystem provider when the seed is validated or read, not when the config object is constructed.
 </Note>
 
 ### 📄 FileContentsSeedSource

--- a/fern/versions/latest/pages/plugins/filesystem_seed_reader.mdx
+++ b/fern/versions/latest/pages/plugins/filesystem_seed_reader.mdx
@@ -165,4 +165,11 @@ If you need more control, `FileSystemSeedReader` also lets you override:
 - `on_attach(...)` for per-attachment setup
 - `create_filesystem_context(...)` for custom rooted filesystem behavior
 
-Most filesystem plugins do not need either hook.
+For new non-local backends, prefer passing a `FileSystemProvider` to the reader
+constructor. The default `create_filesystem_context(...)` implementation calls
+the provider's existence preflight and then asks it to create the rooted
+filesystem context. Overriding `create_filesystem_context(...)` remains supported
+for existing plugins, but that override takes ownership of any backend-specific
+existence checks.
+
+Most filesystem plugins do not need these hooks.

--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -100,9 +100,9 @@ class FileSystemSeedSource(SeedSource, ABC):
     ``FileSystemSeedReader`` implementation.
 
     Attributes:
-        path: Directory containing seed artifacts. Relative paths are resolved
-            from the current working directory when the config is loaded, not
-            from the config file location.
+        path: Directory containing seed artifacts. Relative local paths are
+            resolved by the active filesystem provider when the seed is
+            validated or read, not when the config object is constructed.
         file_pattern: Case-sensitive filename pattern used to match files under
             the provided directory. Patterns match basenames only, not relative
             paths. Defaults to ``'*'``.
@@ -115,8 +115,8 @@ class FileSystemSeedSource(SeedSource, ABC):
     path: str = Field(
         ...,
         description=(
-            "Directory containing seed artifacts. Relative paths are resolved from the current working "
-            "directory when the config is loaded, not from the config file location."
+            "Directory containing seed artifacts. Relative local paths are resolved by the active filesystem "
+            "provider when the seed is validated or read, not when the config object is constructed."
         ),
     )
     file_pattern: str = Field(
@@ -155,6 +155,13 @@ class FileSystemSeedSource(SeedSource, ABC):
 class DirectorySeedSource(FileSystemSeedSource):
     seed_type: Literal["directory"] = "directory"
 
+    def model_post_init(self, __context: Any) -> None:
+        self._runtime_path = self.path
+
+    @property
+    def runtime_path(self) -> str:
+        return self.path
+
 
 class FileContentsSeedSource(FileSystemSeedSource):
     seed_type: Literal["file_contents"] = "file_contents"
@@ -171,6 +178,13 @@ class FileContentsSeedSource(FileSystemSeedSource):
         except LookupError as error:
             raise ValueError(f"🛑 Unknown encoding: {value!r}. Use a valid Python codec name.") from error
         return value
+
+    def model_post_init(self, __context: Any) -> None:
+        self._runtime_path = self.path
+
+    @property
+    def runtime_path(self) -> str:
+        return self.path
 
 
 def _resolve_filesystem_runtime_path(path: str) -> str:
@@ -203,6 +217,15 @@ def get_pi_coding_agent_default_path() -> str:
 
 
 def _validate_filesystem_seed_source_path(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not value.strip():
+        raise InvalidFilePathError("🛑 FileSystemSeedSource.path must be a non-empty string.")
+    return value
+
+
+def _validate_local_filesystem_seed_source_path(value: str | None) -> str | None:
+    value = _validate_filesystem_seed_source_path(value)
     if value is None:
         return None
     path = Path(value).expanduser().resolve()
@@ -272,6 +295,10 @@ class AgentRolloutSeedSource(FileSystemSeedSource):
             "and Hermes Agent defaults to '*.json*'."
         ),
     )
+
+    @field_validator("path", mode="after")
+    def validate_path(cls, value: str | None) -> str | None:
+        return _validate_local_filesystem_seed_source_path(value)
 
     @model_validator(mode="after")
     def validate_runtime_path_source(self) -> Self:

--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -133,7 +133,11 @@ class FileSystemSeedSource(SeedSource, ABC):
     def validate_path(cls, value: str | None) -> str | None:
         # Signature is str | None because AgentRolloutSeedSource overrides path to str | None
         # and inherited validators fire for all subclasses.
-        return _validate_filesystem_seed_source_path(value)
+        if value is None:
+            return None
+        if not value.strip():
+            raise InvalidFilePathError("🛑 FileSystemSeedSource.path must be a non-empty string.")
+        return value
 
     @field_validator("file_pattern", mode="after")
     def validate_file_pattern(cls, value: str | None) -> str | None:
@@ -195,14 +199,6 @@ def get_hermes_agent_default_path() -> str:
 
 def get_pi_coding_agent_default_path() -> str:
     return str(Path("~/.pi/agent/sessions").expanduser())
-
-
-def _validate_filesystem_seed_source_path(value: str | None) -> str | None:
-    if value is None:
-        return None
-    if not value.strip():
-        raise InvalidFilePathError("🛑 FileSystemSeedSource.path must be a non-empty string.")
-    return value
 
 
 def _validate_filesystem_seed_source_file_pattern(value: str | None) -> str | None:

--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -253,8 +253,8 @@ class AgentRolloutSeedSource(FileSystemSeedSource):
             "Claude Code defaults to ~/.claude/projects, Codex defaults to ~/.codex/sessions, "
             "Hermes Agent defaults to ~/.hermes/sessions, "
             "and Pi Coding Agent defaults to ~/.pi/agent/sessions. "
-            "Relative paths are resolved from the current working directory when the config is loaded, "
-            "not from the config file location."
+            "Relative local paths are resolved by the active filesystem provider when the seed is "
+            "validated or read, not when the config object is constructed."
         ),
     )
 

--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -110,8 +110,6 @@ class FileSystemSeedSource(SeedSource, ABC):
             directory for matching files. Defaults to ``True``.
     """
 
-    _runtime_path: str | None = PrivateAttr(default=None)
-
     path: str = Field(
         ...,
         description=(
@@ -137,30 +135,20 @@ class FileSystemSeedSource(SeedSource, ABC):
         # and inherited validators fire for all subclasses.
         return _validate_filesystem_seed_source_path(value)
 
-    def model_post_init(self, __context: Any) -> None:
-        # None guard is exercised by AgentRolloutSeedSource (path: str | None) via inheritance.
-        self._runtime_path = None if self.path is None else _resolve_filesystem_runtime_path(self.path)
-
-    @property
-    def runtime_path(self) -> str:
-        if self._runtime_path is None:
-            self._runtime_path = _resolve_filesystem_runtime_path(self.path)
-        return self._runtime_path
-
     @field_validator("file_pattern", mode="after")
     def validate_file_pattern(cls, value: str | None) -> str | None:
         return _validate_filesystem_seed_source_file_pattern(value)
 
+    @property
+    def runtime_path(self) -> str:
+        # Path resolution and existence checks are the filesystem provider's job at read
+        # time, not the config object's. Keeping the raw value here preserves relative
+        # paths and avoids assuming a local filesystem.
+        return self.path
+
 
 class DirectorySeedSource(FileSystemSeedSource):
     seed_type: Literal["directory"] = "directory"
-
-    def model_post_init(self, __context: Any) -> None:
-        self._runtime_path = self.path
-
-    @property
-    def runtime_path(self) -> str:
-        return self.path
 
 
 class FileContentsSeedSource(FileSystemSeedSource):
@@ -178,13 +166,6 @@ class FileContentsSeedSource(FileSystemSeedSource):
         except LookupError as error:
             raise ValueError(f"🛑 Unknown encoding: {value!r}. Use a valid Python codec name.") from error
         return value
-
-    def model_post_init(self, __context: Any) -> None:
-        self._runtime_path = self.path
-
-    @property
-    def runtime_path(self) -> str:
-        return self.path
 
 
 def _resolve_filesystem_runtime_path(path: str) -> str:
@@ -221,16 +202,6 @@ def _validate_filesystem_seed_source_path(value: str | None) -> str | None:
         return None
     if not value.strip():
         raise InvalidFilePathError("🛑 FileSystemSeedSource.path must be a non-empty string.")
-    return value
-
-
-def _validate_local_filesystem_seed_source_path(value: str | None) -> str | None:
-    value = _validate_filesystem_seed_source_path(value)
-    if value is None:
-        return None
-    path = Path(value).expanduser().resolve()
-    if not path.is_dir():
-        raise InvalidFilePathError(f"🛑 Path {path} is not a directory.")
     return value
 
 
@@ -296,10 +267,6 @@ class AgentRolloutSeedSource(FileSystemSeedSource):
         ),
     )
 
-    @field_validator("path", mode="after")
-    def validate_path(cls, value: str | None) -> str | None:
-        return _validate_local_filesystem_seed_source_path(value)
-
     @model_validator(mode="after")
     def validate_runtime_path_source(self) -> Self:
         default_path, _ = get_agent_rollout_format_defaults(self.format)
@@ -309,14 +276,14 @@ class AgentRolloutSeedSource(FileSystemSeedSource):
 
     @property
     def runtime_path(self) -> str:
-        if self._runtime_path is not None:
-            return self._runtime_path
+        # Path resolution and existence checks happen in the filesystem provider at read
+        # time. When no explicit path is given, fall back to the format's default root.
+        if self.path is not None:
+            return self.path
         default_path, _ = get_agent_rollout_format_defaults(self.format)
-        resolved_path = self.path if self.path is not None else default_path
-        if resolved_path is None:
+        if default_path is None:
             raise ValueError(f"🛑 AgentRolloutSeedSource.path is required for format {self.format.value!r}.")
-        self._runtime_path = _resolve_filesystem_runtime_path(resolved_path)
-        return self._runtime_path
+        return default_path
 
     @property
     def resolved_file_pattern(self) -> str:

--- a/packages/data-designer-config/src/data_designer/config/seed_source.py
+++ b/packages/data-designer-config/src/data_designer/config/seed_source.py
@@ -277,8 +277,6 @@ class AgentRolloutSeedSource(FileSystemSeedSource):
         if self.path is not None:
             return self.path
         default_path, _ = get_agent_rollout_format_defaults(self.format)
-        if default_path is None:
-            raise ValueError(f"🛑 AgentRolloutSeedSource.path is required for format {self.format.value!r}.")
         return default_path
 
     @property

--- a/packages/data-designer-config/tests/config/test_seed_source.py
+++ b/packages/data-designer-config/tests/config/test_seed_source.py
@@ -95,12 +95,14 @@ def test_dataframe_seed_source_serialization() -> None:
     assert serialized == {"seed_type": "df"}
 
 
-def test_directory_seed_source_requires_directory(tmp_path: Path) -> None:
+def test_directory_seed_source_defers_directory_existence_validation(tmp_path: Path) -> None:
     file_path = tmp_path / "file.txt"
     file_path.write_text("alpha", encoding="utf-8")
 
-    with pytest.raises(InvalidFilePathError, match="is not a directory"):
-        DirectorySeedSource(path=str(file_path))
+    source = DirectorySeedSource(path=str(file_path))
+
+    assert source.path == str(file_path)
+    assert source.runtime_path == str(file_path)
 
 
 def test_directory_seed_source_preserves_relative_path_input(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,7 +148,7 @@ def test_file_contents_seed_source_preserves_relative_path_input(
         pytest.param(FileContentsSeedSource, {"file_pattern": "*.txt"}, id="file-contents"),
     ],
 )
-def test_filesystem_seed_sources_cache_runtime_path_across_cwd_changes(
+def test_filesystem_seed_sources_preserve_raw_runtime_path_across_cwd_changes(
     source_type: type[DirectorySeedSource] | type[FileContentsSeedSource],
     source_kwargs: dict[str, str],
     tmp_path: Path,
@@ -160,12 +162,11 @@ def test_filesystem_seed_sources_cache_runtime_path_across_cwd_changes(
 
     monkeypatch.chdir(initial_root)
     source = source_type(path="seed-dir", **source_kwargs)
-    expected_runtime_path = str(initial_seed_dir.resolve())
 
     monkeypatch.chdir(later_root)
 
     assert source.path == "seed-dir"
-    assert source.runtime_path == expected_runtime_path
+    assert source.runtime_path == "seed-dir"
     assert source.model_dump(mode="json")["path"] == "seed-dir"
 
 
@@ -176,10 +177,10 @@ def test_seed_source_path_descriptions_document_cwd_resolution() -> None:
 
     assert "current working directory" in local_path_description
     assert "config file location" in local_path_description
-    assert "current working directory" in directory_path_description
-    assert "config file location" in directory_path_description
-    assert "current working directory" in file_contents_path_description
-    assert "config file location" in file_contents_path_description
+    assert "active filesystem provider" in directory_path_description
+    assert "config object is constructed" in directory_path_description
+    assert "active filesystem provider" in file_contents_path_description
+    assert "config object is constructed" in file_contents_path_description
 
 
 def test_file_contents_seed_source_parses_from_dict(tmp_path: Path) -> None:

--- a/packages/data-designer-config/tests/config/test_seed_source.py
+++ b/packages/data-designer-config/tests/config/test_seed_source.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
@@ -15,6 +16,7 @@ from data_designer.config.seed_source import (
     AgentRolloutSeedSource,
     DirectorySeedSource,
     FileContentsSeedSource,
+    FileSystemSeedSource,
     LocalFileSeedSource,
 )
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
@@ -224,6 +226,17 @@ def test_filesystem_seed_sources_reject_path_like_file_patterns(
         source_type(path=str(tmp_path), file_pattern=file_pattern)
 
 
+def test_filesystem_seed_source_subclass_inherits_runtime_path(tmp_path: Path) -> None:
+    # Plugin authors subclass FileSystemSeedSource directly; readers rely on
+    # `source.runtime_path`, so the base must provide it without an override.
+    class PluginSeedSource(FileSystemSeedSource):
+        seed_type: Literal["plugin-seed-source"] = "plugin-seed-source"
+
+    source = PluginSeedSource(path=str(tmp_path))
+
+    assert source.runtime_path == str(tmp_path)
+
+
 @pytest.mark.parametrize(
     ("rollout_format", "file_pattern", "error_message"),
     [
@@ -266,6 +279,46 @@ def test_agent_rollout_seed_source_rejects_invalid_file_patterns(
 def test_agent_rollout_seed_source_requires_explicit_atif_path() -> None:
     with pytest.raises(ValueError, match="path is required for format 'atif'"):
         AgentRolloutSeedSource(format=AgentRolloutFormat.ATIF)
+
+
+def test_agent_rollout_seed_source_defers_directory_existence_validation(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "does-not-exist"
+
+    source = AgentRolloutSeedSource(path=str(missing_dir), format=AgentRolloutFormat.ATIF)
+
+    assert source.path == str(missing_dir)
+    assert source.runtime_path == str(missing_dir)
+
+
+def test_agent_rollout_seed_source_preserves_raw_runtime_path_across_cwd_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_root = tmp_path / "initial"
+    later_root = tmp_path / "later"
+    (initial_root / "seed-dir").mkdir(parents=True)
+    later_root.mkdir()
+
+    monkeypatch.chdir(initial_root)
+    source = AgentRolloutSeedSource(path="seed-dir", format=AgentRolloutFormat.ATIF)
+
+    monkeypatch.chdir(later_root)
+
+    assert source.path == "seed-dir"
+    assert source.runtime_path == "seed-dir"
+    assert source.model_dump(mode="json")["path"] == "seed-dir"
+
+
+def test_agent_rollout_seed_source_runtime_path_falls_back_to_format_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    source = AgentRolloutSeedSource(format=AgentRolloutFormat.CLAUDE_CODE)
+
+    assert source.path is None
+    assert source.runtime_path == str(tmp_path / ".claude" / "projects")
 
 
 def test_agent_rollout_seed_source_uses_default_atif_file_pattern(tmp_path: Path) -> None:

--- a/packages/data-designer-engine/src/data_designer/engine/compiler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/compiler.py
@@ -10,7 +10,7 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.errors import InvalidConfigError
 from data_designer.config.sampler_params import UUIDSamplerParams
 from data_designer.engine.resources.resource_provider import ResourceProvider
-from data_designer.engine.resources.seed_reader import SeedReader
+from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderConfigError
 from data_designer.engine.validation import ViolationLevel, rich_print_violations, validate_data_designer_config
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,10 @@ def _resolve_and_add_seed_columns(config: DataDesignerConfig, seed_reader: SeedR
     if not seed_reader:
         return
 
-    seed_col_names = seed_reader.get_column_names()
+    try:
+        seed_col_names = seed_reader.get_column_names()
+    except SeedReaderConfigError as error:
+        raise InvalidConfigError(str(error)) from error
     existing_columns = {column.name for column in config.columns}
     colliding_columns = {name for name in seed_col_names if name in existing_columns}
     if colliding_columns:

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -30,6 +30,7 @@ from data_designer.config.seed_source import (
     SeedSource,
 )
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.config.utils.warning_helpers import warn_at_caller
 from data_designer.engine.resources.agent_rollout import (
     AgentRolloutFormatHandler,
     AgentRolloutParseContext,
@@ -441,10 +442,22 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
     def get_dataset_uri(self) -> str:
         return self._build_internal_table_name("rows")
 
-    def get_output_column_names(self) -> list[str]:
+    def _get_output_column_names(self) -> list[str]:
+        # This is an internal schema resolution helper. To fetch column names
+        # as a client of a FileSystemSeedReader, prefer ``get_column_names``
+        # to ensure preflight filesystem context validation runs.
         if self.output_columns is not None:
             return self.output_columns
         return list(self._get_row_manifest_dataframe().columns)
+
+    def get_output_column_names(self) -> list[str]:
+        warn_at_caller(
+            "``get_output_column_names`` is deprecated. Prefer ``get_column_names`` for fetching "
+            "column names as an external client of the reader, or ``_get_output_column_names`` as "
+            "an internal schema helper method.",
+            DeprecationWarning,
+        )
+        return self._get_output_column_names()
 
     @abstractmethod
     def build_manifest(self, *, context: SeedReaderFileSystemContext) -> pd.DataFrame | list[dict[str, Any]]: ...
@@ -458,8 +471,11 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         return manifest_row
 
     def get_column_names(self) -> list[str]:
+        # Calling `_get_filesystem_context` ensures that subclasses with fixed column names
+        # (e.g. see FileContentsSeedReader.output_columns) are still validated when this method
+        # is called during validation / config compilation.
         self._get_filesystem_context()
-        return self.get_output_column_names()
+        return self._get_output_column_names()
 
     def get_seed_dataset_size(self) -> int:
         self._ensure_attached()
@@ -491,7 +507,7 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
                 manifest_rows=manifest_records,
                 context=context,
             ),
-            output_columns=self.get_output_column_names(),
+            output_columns=self._get_output_column_names(),
             no_rows_error_message=self._get_empty_selected_manifest_rows_error_message(),
         )
 
@@ -526,7 +542,7 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
 
         self._output_df = create_seed_reader_output_dataframe(
             records=hydrated_records,
-            output_columns=self.get_output_column_names(),
+            output_columns=self._get_output_column_names(),
         )
         return self._output_df
 

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -412,6 +412,11 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
 
     def _reset_attachment_state(self) -> None:
         super()._reset_attachment_state()
+        # Plugin readers have historically been allowed to define __init__ without
+        # calling super().__init__(). Attach-time initialization keeps that contract
+        # while preserving any provider explicitly injected through the base init.
+        if not hasattr(self, "_fs_provider"):
+            self._fs_provider = LocalFileSystemProvider()
         self._filesystem_context = None
         self._output_df = None
         self._row_manifest_df = None
@@ -533,11 +538,7 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         return context
 
     def _get_fs_provider(self) -> FileSystemProvider:
-        provider = getattr(self, "_fs_provider", None)
-        if provider is None:
-            provider = LocalFileSystemProvider()
-            self._fs_provider = provider
-        return provider
+        return self._fs_provider
 
     def _get_manifest_dataset_uri(self) -> str:
         return self._build_internal_table_name("manifest")

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -458,6 +458,7 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         return manifest_row
 
     def get_column_names(self) -> list[str]:
+        self._get_filesystem_context()
         return self.get_output_column_names()
 
     def get_seed_dataset_size(self) -> int:

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -267,12 +267,6 @@ class SeedReader(ABC, Generic[SourceT]):
         query_result = conn.query(read_query)
         return DuckDBSeedReaderBatchReader(conn=conn, query_result=query_result, batch_size=batch_size)
 
-    def create_filesystem_context(self, root_path: Path | str) -> SeedReaderFileSystemContext:
-        """Create a rooted filesystem context for directory-backed seed readers."""
-        resolved_root_path = Path(root_path).expanduser().resolve()
-        rooted_fs = DirFileSystem(path=str(resolved_root_path), fs=LocalFileSystem())
-        return SeedReaderFileSystemContext(fs=rooted_fs, root_path=resolved_root_path)
-
     def get_matching_relative_paths(
         self,
         *,

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -428,7 +428,10 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         This hook is preserved for existing plugin readers. New host integrations
         should prefer passing a ``FileSystemProvider`` to the reader constructor.
         """
-        return self._get_fs_provider().create_context(runtime_path=str(root_path))
+        runtime_path = str(root_path)
+        provider = self._get_fs_provider()
+        provider.ensure_root_exists(runtime_path=runtime_path)
+        return provider.create_context(runtime_path=runtime_path)
 
     def create_duckdb_connection(self) -> duckdb.DuckDBPyConnection:
         return self.create_dataframe_duckdb_connection(
@@ -531,7 +534,6 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         self._ensure_attached()
         context = getattr(self, "_filesystem_context", None)
         if context is None:
-            self._get_fs_provider().ensure_root_exists(runtime_path=self.source.runtime_path)
             context = self.create_filesystem_context(self.source.runtime_path)
             self._filesystem_context = context
         return context

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Iterable, Sequence
 from copy import copy
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, get_args, get_origin
 
 from fsspec.implementations.dirfs import DirFileSystem
@@ -50,12 +50,37 @@ logger = logging.getLogger(__name__)
 class SeedReaderError(DataDesignerError): ...
 
 
+class SeedReaderConfigError(SeedReaderError): ...
+
+
 @dataclass(frozen=True)
 class SeedReaderFileSystemContext:
     """Filesystem and root path available to filesystem seed-reader plugins."""
 
     fs: AbstractFileSystem
-    root_path: Path
+    root_path: PurePath
+
+
+class FileSystemProvider(Protocol):
+    """Resolves a runtime path into a rooted fsspec filesystem."""
+
+    def create_context(self, *, runtime_path: str) -> SeedReaderFileSystemContext: ...
+
+    def ensure_root_exists(self, *, runtime_path: str) -> None: ...
+
+
+class LocalFileSystemProvider:
+    """Default filesystem provider backed by the local disk."""
+
+    def create_context(self, *, runtime_path: str) -> SeedReaderFileSystemContext:
+        resolved_root_path = Path(runtime_path).expanduser().resolve()
+        rooted_fs = DirFileSystem(path=str(resolved_root_path), fs=LocalFileSystem())
+        return SeedReaderFileSystemContext(fs=rooted_fs, root_path=resolved_root_path)
+
+    def ensure_root_exists(self, *, runtime_path: str) -> None:
+        resolved_root_path = Path(runtime_path).expanduser().resolve()
+        if not resolved_root_path.is_dir():
+            raise SeedReaderConfigError(f"🛑 Seed source directory '{resolved_root_path}' does not exist.")
 
 
 class SeedReaderBatch(Protocol):
@@ -388,11 +413,22 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
 
     output_columns: ClassVar[list[str] | None] = None
 
+    def __init__(self, fs_provider: FileSystemProvider | None = None) -> None:
+        self._fs_provider = fs_provider or LocalFileSystemProvider()
+
     def _reset_attachment_state(self) -> None:
         super()._reset_attachment_state()
         self._filesystem_context = None
         self._output_df = None
         self._row_manifest_df = None
+
+    def create_filesystem_context(self, root_path: Path | str) -> SeedReaderFileSystemContext:
+        """Create a rooted filesystem context for directory-backed seed readers.
+
+        This hook is preserved for existing plugin readers. New host integrations
+        should prefer passing a ``FileSystemProvider`` to the reader constructor.
+        """
+        return self._get_fs_provider().create_context(runtime_path=str(root_path))
 
     def create_duckdb_connection(self) -> duckdb.DuckDBPyConnection:
         return self.create_dataframe_duckdb_connection(
@@ -495,9 +531,17 @@ class FileSystemSeedReader(SeedReader[FileSystemSourceT], ABC):
         self._ensure_attached()
         context = getattr(self, "_filesystem_context", None)
         if context is None:
+            self._get_fs_provider().ensure_root_exists(runtime_path=self.source.runtime_path)
             context = self.create_filesystem_context(self.source.runtime_path)
             self._filesystem_context = context
         return context
+
+    def _get_fs_provider(self) -> FileSystemProvider:
+        provider = getattr(self, "_fs_provider", None)
+        if provider is None:
+            provider = LocalFileSystemProvider()
+            self._fs_provider = provider
+        return provider
 
     def _get_manifest_dataset_uri(self) -> str:
         return self._build_internal_table_name("manifest")

--- a/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/seed_reader.py
@@ -697,8 +697,17 @@ class AgentRolloutSeedReader(FileSystemSeedReader[AgentRolloutSeedSource]):
         if self._parse_context is not self._PARSE_CONTEXT_UNSET:
             return self._parse_context
 
+        # Agent rollout handlers operate on the local filesystem directly (root_path.glob,
+        # root_path / relative_path), so they require a concrete Path rather than the
+        # PurePath the context type permits for remote providers.
+        root_path = context.root_path
+        if not isinstance(root_path, Path):
+            raise SeedReaderConfigError(
+                f"🛑 Agent rollout seed readers require a local filesystem, but got non-local root path "
+                f"{root_path!r} ({type(root_path).__name__})."
+            )
         handler = self.get_format_handler()
-        self._parse_context = handler.build_parse_context(root_path=context.root_path, recursive=self.source.recursive)
+        self._parse_context = handler.build_parse_context(root_path=root_path, recursive=self.source.recursive)
         return self._parse_context
 
 

--- a/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
+++ b/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
@@ -738,7 +738,7 @@ def test_local_file_seed_reader_uses_load_time_runtime_path_when_cwd_changes(
     assert list(df["value"]) == [1]
 
 
-def test_directory_seed_reader_uses_load_time_runtime_path_when_cwd_changes(
+def test_directory_seed_reader_uses_read_time_runtime_path_when_cwd_changes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -760,8 +760,17 @@ def test_directory_seed_reader_uses_load_time_runtime_path_when_cwd_changes(
     df = reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
 
     assert source.path == "seed-dir"
-    assert list(df["relative_path"]) == ["alpha.txt"]
-    assert list(df["source_path"]) == [str((initial_seed_dir / "alpha.txt").resolve())]
+    assert list(df["relative_path"]) == ["beta.txt"]
+    assert list(df["source_path"]) == [str((later_seed_dir / "beta.txt").resolve())]
+
+
+def test_directory_seed_reader_reports_missing_root_before_matching_files(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing"
+    reader = DirectorySeedReader()
+    reader.attach(DirectorySeedSource(path=str(missing_dir), file_pattern="*.txt"), PlaintextResolver())
+
+    with pytest.raises(SeedReaderError, match="Seed source directory .* does not exist"):
+        reader.get_column_names()
 
 
 def test_filesystem_seed_reader_on_attach_requires_no_super_and_resets_state(tmp_path: Path) -> None:

--- a/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
+++ b/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from fsspec.implementations.memory import MemoryFileSystem
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.seed import IndexRange
@@ -29,6 +30,8 @@ from data_designer.engine.resources.seed_reader import (
     FileContentsSeedReader,
     FileSystemSeedReader,
     LocalFileSeedReader,
+    LocalFileSystemProvider,
+    SeedReaderConfigError,
     SeedReaderError,
     SeedReaderFileSystemContext,
     SeedReaderRegistry,
@@ -49,6 +52,20 @@ class TrackingFileContentsSeedReader(FileContentsSeedReader):
     ) -> dict[str, str]:
         self.hydrated_relative_paths.append(manifest_row["relative_path"])
         return super().hydrate_row(manifest_row=manifest_row, context=context)
+
+
+class StubFileSystemProvider:
+    def __init__(self, context: SeedReaderFileSystemContext) -> None:
+        self.context = context
+        self.ensure_root_exists_calls: list[str] = []
+        self.create_context_calls: list[str] = []
+
+    def ensure_root_exists(self, *, runtime_path: str) -> None:
+        self.ensure_root_exists_calls.append(runtime_path)
+
+    def create_context(self, *, runtime_path: str) -> SeedReaderFileSystemContext:
+        self.create_context_calls.append(runtime_path)
+        return self.context
 
 
 class PluginStyleDirectorySeedReader(FileSystemSeedReader[DirectorySeedSource]):
@@ -184,6 +201,16 @@ class ContextCountingDirectorySeedReader(FileSystemSeedReader[DirectorySeedSourc
             recursive=self.source.recursive,
         )
         return [{"relative_path": relative_path} for relative_path in matched_paths]
+
+
+class ContextCapturingDirectorySeedReader(FileSystemSeedReader[DirectorySeedSource]):
+    def __init__(self, fs_provider: StubFileSystemProvider) -> None:
+        super().__init__(fs_provider=fs_provider)
+        self.manifest_context: SeedReaderFileSystemContext | None = None
+
+    def build_manifest(self, *, context: SeedReaderFileSystemContext) -> list[dict[str, str]]:
+        self.manifest_context = context
+        return [{"label": "captured"}]
 
 
 class TrackingAgentRolloutSeedReader(AgentRolloutSeedReader):
@@ -475,6 +502,61 @@ def test_plugin_style_filesystem_seed_reader_can_fan_out_rows(tmp_path: Path) ->
     assert list(df["relative_path"]) == ["alpha.txt", "alpha.txt", "beta.txt"]
     assert list(df["line_index"]) == [0, 1, 0]
     assert list(df["line"]) == ["alpha-0", "alpha-1", "beta-0"]
+
+
+def test_filesystem_seed_reader_uses_injected_filesystem_provider() -> None:
+    context = SeedReaderFileSystemContext(
+        fs=MemoryFileSystem(),
+        root_path=Path("remote-root"),
+    )
+    context.fs.pipe("alpha.txt", b"alpha")
+    provider = StubFileSystemProvider(context)
+    reader = DirectorySeedReader(fs_provider=provider)
+    reader.attach(
+        DirectorySeedSource(path="remote-root", file_pattern="*.txt"),
+        PlaintextResolver(),
+    )
+
+    df = reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
+
+    assert provider.ensure_root_exists_calls == ["remote-root"]
+    assert provider.create_context_calls == ["remote-root"]
+    assert list(df["relative_path"]) == ["alpha.txt"]
+    assert list(df["source_path"]) == ["remote-root/alpha.txt"]
+
+
+def test_filesystem_seed_reader_passes_provider_context_to_manifest_builder() -> None:
+    context = SeedReaderFileSystemContext(
+        fs=MemoryFileSystem(),
+        root_path=Path("captured-root"),
+    )
+    provider = StubFileSystemProvider(context)
+    reader = ContextCapturingDirectorySeedReader(fs_provider=provider)
+    reader.attach(
+        DirectorySeedSource(path="captured-root"),
+        PlaintextResolver(),
+    )
+
+    assert reader.get_column_names() == ["label"]
+    assert reader.manifest_context is context
+
+
+def test_local_filesystem_provider_creates_context_for_existing_directory(tmp_path: Path) -> None:
+    (tmp_path / "alpha.txt").write_text("alpha", encoding="utf-8")
+
+    provider = LocalFileSystemProvider()
+    provider.ensure_root_exists(runtime_path=str(tmp_path))
+    context = provider.create_context(runtime_path=str(tmp_path))
+
+    assert context.root_path == tmp_path.resolve()
+    assert context.fs.find("", withdirs=False) == ["alpha.txt"]
+
+
+def test_local_filesystem_provider_rejects_missing_directory(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing"
+
+    with pytest.raises(SeedReaderConfigError, match="Seed source directory .* does not exist"):
+        LocalFileSystemProvider().ensure_root_exists(runtime_path=str(missing_dir))
 
 
 def test_directory_seed_reader_matches_files_recursively(tmp_path: Path) -> None:

--- a/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
+++ b/packages/data-designer-engine/tests/engine/resources/test_seed_reader.py
@@ -213,6 +213,13 @@ class ContextCapturingDirectorySeedReader(FileSystemSeedReader[DirectorySeedSour
         return [{"label": "captured"}]
 
 
+class FixedSchemaDirectorySeedReader(FileSystemSeedReader[DirectorySeedSource]):
+    output_columns = ["label"]
+
+    def build_manifest(self, *, context: SeedReaderFileSystemContext) -> list[dict[str, str]]:
+        return [{"label": str(context.root_path)}]
+
+
 class TrackingAgentRolloutSeedReader(AgentRolloutSeedReader):
     def __init__(self) -> None:
         super().__init__()
@@ -541,6 +548,23 @@ def test_filesystem_seed_reader_passes_provider_context_to_manifest_builder() ->
     assert reader.manifest_context is context
 
 
+def test_fixed_schema_filesystem_seed_reader_get_column_names_runs_provider_preflight() -> None:
+    context = SeedReaderFileSystemContext(
+        fs=MemoryFileSystem(),
+        root_path=Path("fixed-root"),
+    )
+    provider = StubFileSystemProvider(context)
+    reader = FixedSchemaDirectorySeedReader(fs_provider=provider)
+    reader.attach(
+        DirectorySeedSource(path="fixed-root"),
+        PlaintextResolver(),
+    )
+
+    assert reader.get_column_names() == ["label"]
+    assert provider.ensure_root_exists_calls == ["fixed-root"]
+    assert provider.create_context_calls == ["fixed-root"]
+
+
 def test_local_filesystem_provider_creates_context_for_existing_directory(tmp_path: Path) -> None:
     (tmp_path / "alpha.txt").write_text("alpha", encoding="utf-8")
 
@@ -656,6 +680,18 @@ def test_file_contents_seed_reader_wraps_unknown_encoding_errors(tmp_path: Path)
 
     with pytest.raises(SeedReaderError, match="Failed to decode file .* using encoding 'utf-999'"):
         reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
+
+
+def test_file_contents_seed_reader_get_column_names_rejects_missing_root(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing"
+    reader = FileContentsSeedReader()
+    reader.attach(
+        FileContentsSeedSource(path=str(missing_dir), file_pattern="*.txt"),
+        PlaintextResolver(),
+    )
+
+    with pytest.raises(SeedReaderConfigError, match="Seed source directory .* does not exist"):
+        reader.get_column_names()
 
 
 def test_file_contents_seed_reader_hydrates_only_selected_manifest_rows(tmp_path: Path) -> None:
@@ -1197,6 +1233,18 @@ def test_agent_rollout_seed_reader_wraps_os_errors_as_seed_reader_error(
     ):
         with pytest.raises(SeedReaderError, match="Failed to read agent rollout file"):
             reader.create_duckdb_connection().execute(f"SELECT * FROM '{reader.get_dataset_uri()}'").df()
+
+
+def test_agent_rollout_seed_reader_get_column_names_rejects_missing_root(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing"
+    reader = AgentRolloutSeedReader()
+    reader.attach(
+        AgentRolloutSeedSource(path=str(missing_dir), format=AgentRolloutFormat.ATIF),
+        PlaintextResolver(),
+    )
+
+    with pytest.raises(SeedReaderConfigError, match="Seed source directory .* does not exist"):
+        reader.get_column_names()
 
 
 def test_agent_rollout_seed_reader_uses_resolved_file_pattern_when_model_construct_skips_validation(

--- a/packages/data-designer-engine/tests/engine/test_compiler.py
+++ b/packages/data-designer-engine/tests/engine/test_compiler.py
@@ -9,10 +9,11 @@ from data_designer.config.column_configs import ExpressionColumnConfig, SamplerC
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.errors import InvalidConfigError
 from data_designer.config.sampler_params import CategorySamplerParams, SamplerType, UUIDSamplerParams
-from data_designer.config.seed_source import HuggingFaceSeedSource
+from data_designer.config.seed_source import FileContentsSeedSource, HuggingFaceSeedSource
 from data_designer.engine.compiler import compile_data_designer_config
 from data_designer.engine.resources.resource_provider import ResourceProvider
-from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderConfigError
+from data_designer.engine.resources.seed_reader import FileContentsSeedReader, SeedReader, SeedReaderConfigError
+from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.engine.validation import Violation, ViolationLevel, ViolationType
 
 
@@ -63,6 +64,23 @@ def test_seed_reader_config_errors_are_invalid_config_errors(resource_provider: 
 
     with pytest.raises(InvalidConfigError, match="missing seed root") as excinfo:
         compile_data_designer_config(builder.build(), resource_provider)
+
+    assert isinstance(excinfo.value.__cause__, SeedReaderConfigError)
+
+
+def test_compile_rejects_missing_fixed_schema_filesystem_seed_root(
+    stub_resource_provider: ResourceProvider,
+    tmp_path,
+):
+    missing_dir = tmp_path / "missing"
+    builder = DataDesignerConfigBuilder()
+    builder.with_seed_dataset(FileContentsSeedSource(path=str(missing_dir), file_pattern="*.txt"))
+    reader = FileContentsSeedReader()
+    reader.attach(builder.build().seed_config.source, PlaintextResolver())
+    stub_resource_provider.seed_reader = reader
+
+    with pytest.raises(InvalidConfigError, match="Seed source directory .* does not exist") as excinfo:
+        compile_data_designer_config(builder.build(), stub_resource_provider)
 
     assert isinstance(excinfo.value.__cause__, SeedReaderConfigError)
 

--- a/packages/data-designer-engine/tests/engine/test_compiler.py
+++ b/packages/data-designer-engine/tests/engine/test_compiler.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from data_designer.config.sampler_params import CategorySamplerParams, SamplerTy
 from data_designer.config.seed_source import HuggingFaceSeedSource
 from data_designer.engine.compiler import compile_data_designer_config
 from data_designer.engine.resources.resource_provider import ResourceProvider
-from data_designer.engine.resources.seed_reader import SeedReader
+from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderConfigError
 from data_designer.engine.validation import Violation, ViolationLevel, ViolationType
 
 
@@ -53,6 +53,18 @@ def test_errors_on_seed_column_collisions(resource_provider: ResourceProvider):
         compile_data_designer_config(builder.build(), resource_provider)
 
     assert "city" in str(excinfo)
+
+
+def test_seed_reader_config_errors_are_invalid_config_errors(resource_provider: ResourceProvider):
+    builder = DataDesignerConfigBuilder()
+    builder.with_seed_dataset(HuggingFaceSeedSource(path="hf://datasets/test/data.csv"))
+    resource_provider.seed_reader = Mock(spec=SeedReader)
+    resource_provider.seed_reader.get_column_names.side_effect = SeedReaderConfigError("missing seed root")
+
+    with pytest.raises(InvalidConfigError, match="missing seed root") as excinfo:
+        compile_data_designer_config(builder.build(), resource_provider)
+
+    assert isinstance(excinfo.value.__cause__, SeedReaderConfigError)
 
 
 def test_validation_errors(resource_provider: ResourceProvider):


### PR DESCRIPTION
## 📋 Summary

Adds support for injecting fsspec filesystems into `DirectorySeedReader` and `FileContentsSeedReader` so that they can be used in non-local contexts

## 🔗 Related Issue

Implements [this plan](https://github.com/NVIDIA-NeMo/DataDesigner/tree/main/plans/remote-filesystem-seeds)

## 🔄 Changes

- Introduces `FileSystemProvider(Protocol)` and a default implementation `LocalFileSystemProvider`, adding a seam where previously the local filesystem was effectively hardcoded
- Updates `FileSystemSeedSource` and its subclasses to not validate dir/file existence upon config object creation, instead deferring that check to validation/read times
- Refactors `FileSystemSeedSource` and its subclasses

## 🧪 Testing
<!-- What testing was done? -->
- [x] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable) -- none added, but existing tests pass
- [x] Added an implementation for the Nemo Platform Data Designer plugin that uses the Files service's fsspec filesystem and confirmed Directory- and FileContents seeds work. See https://github.com/NVIDIA-NeMo/nemo-platform/pull/413

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
