### PR TITLE
docs: publish image generation recipes

### DIFF
--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -21,6 +21,7 @@ on:
       - "fern/styles/trajectory-viewer.css"
       - "fern/versions/latest.yml"
       - "fern/versions/latest/pages/devnotes/**"
+      - "fern/versions/latest/pages/recipes/image_generation/**"
   workflow_dispatch:
 
 permissions: {}

--- a/fern/scripts/fern-published-branch.py
+++ b/fern/scripts/fern-published-branch.py
@@ -15,6 +15,8 @@ import tempfile
 from pathlib import Path
 
 DEVNOTES_SECTION_RE = re.compile(r"^  - section:\s+Dev Notes\s*$")
+RECIPES_SECTION_RE = re.compile(r"^  - section:\s+Recipes\s*$")
+IMAGE_GENERATION_SECTION_RE = re.compile(r"^      - section:\s+Image Generation\s*$")
 RETIRED_REFERENCE_SECTION_RE = re.compile(r"^  - section:\s+" + re.escape("Code " + "Reference") + r"\s*$")
 RETIRED_REFERENCE_DIR = "code" + "_reference"
 NAV_PATH_RE = re.compile(r"^(\s*path:\s+)\./([^#\s]+)(.*)$")
@@ -40,7 +42,8 @@ FERN_ROOT_CONFIG_PATHS = [
 ]
 # Dev-note kit components carry their own CSS (injected via a <style> tag), so no
 # stylesheet files are copied here — `css` is a theme-owned field and any local
-# `css:` list is dropped under `global-theme: nvidia`. See fern/docs.yml.
+# `css:` list is dropped under `global-theme: nvidia`. See fern/docs.yml. Image
+# generation recipes are published with the dev note that links to them.
 FERN_DEVNOTE_SUPPORT_PATHS = [
     "fern/assets",
     "fern/components/Authors.tsx",
@@ -51,6 +54,7 @@ FERN_DEVNOTE_SUPPORT_PATHS = [
     "fern/components/MetricsTable.tsx",
     "fern/components/TrajectoryViewer.tsx",
     "fern/components/devnotes",
+    "fern/versions/latest/pages/recipes/image_generation",
 ]
 RETIRED_REFERENCE_CLEAN_PAGE_PATHS = [
     "concepts/columns.mdx",
@@ -239,43 +243,57 @@ def merge_preserved_versions(source_versions: Path, published_versions: Path, pr
         copy_path(path, target)
 
 
-def extract_navigation_section(path: Path, section_re: re.Pattern[str]) -> list[str]:
-    lines = path.read_text().splitlines(keepends=True)
+def navigation_section_bounds(lines: list[str], section_re: re.Pattern[str], path: Path) -> tuple[int, int]:
     start = next((i for i, line in enumerate(lines) if section_re.match(line)), -1)
     if start == -1:
         raise PublishedBranchError(f"Section not found in {path}")
+    leading_whitespace = lines[start][: len(lines[start]) - len(lines[start].lstrip())]
+    sibling_prefix = f"{leading_whitespace}- "
     end = start + 1
     while end < len(lines):
-        if lines[end].startswith("  - ") and lines[end].strip():
+        if lines[end].startswith(sibling_prefix) and lines[end].strip():
             break
         end += 1
+    return start, end
+
+
+def extract_navigation_section(path: Path, section_re: re.Pattern[str]) -> list[str]:
+    lines = path.read_text().splitlines(keepends=True)
+    start, end = navigation_section_bounds(lines, section_re, path)
     return lines[start:end]
 
 
 def replace_navigation_section(path: Path, section_re: re.Pattern[str], block: list[str]) -> None:
     lines = path.read_text().splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if section_re.match(line)), -1)
-    if start == -1:
-        raise PublishedBranchError(f"Section not found in {path}")
-    end = start + 1
-    while end < len(lines):
-        if lines[end].startswith("  - ") and lines[end].strip():
-            break
-        end += 1
+    start, end = navigation_section_bounds(lines, section_re, path)
     lines[start:end] = block
+    path.write_text("".join(lines))
+
+
+def upsert_navigation_subsection(
+    path: Path, section_re: re.Pattern[str], parent_section_re: re.Pattern[str], block: list[str]
+) -> None:
+    lines = path.read_text().splitlines(keepends=True)
+    if any(section_re.match(line) for line in lines):
+        start, end = navigation_section_bounds(lines, section_re, path)
+        lines[start:end] = block
+    else:
+        parent_start, parent_end = navigation_section_bounds(lines, parent_section_re, path)
+        leading_whitespace = block[0][: len(block[0]) - len(block[0].lstrip())]
+        sibling_section_prefix = f"{leading_whitespace}- section:"
+        insert_at = next(
+            (index for index in range(parent_start + 1, parent_end) if lines[index].startswith(sibling_section_prefix)),
+            parent_end,
+        )
+        lines[insert_at:insert_at] = block
     path.write_text("".join(lines))
 
 
 def remove_navigation_section(path: Path, section_re: re.Pattern[str]) -> None:
     lines = path.read_text().splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if section_re.match(line)), -1)
-    if start == -1:
+    if not any(section_re.match(line) for line in lines):
         return
-    end = start + 1
-    while end < len(lines):
-        if lines[end].startswith("  - ") and lines[end].strip():
-            break
-        end += 1
+    start, end = navigation_section_bounds(lines, section_re, path)
     lines[start:end] = []
     path.write_text("".join(lines))
 
@@ -393,6 +411,11 @@ def replace_devnotes_block(path: Path, block: list[str]) -> None:
     replace_navigation_section(path, DEVNOTES_SECTION_RE, block)
 
 
+def patch_image_generation_recipes(source_nav: Path, target_nav: Path) -> None:
+    source_block = extract_navigation_section(source_nav, IMAGE_GENERATION_SECTION_RE)
+    upsert_navigation_subsection(target_nav, IMAGE_GENERATION_SECTION_RE, RECIPES_SECTION_RE, source_block)
+
+
 def patch_devnotes(args: argparse.Namespace) -> int:
     source_root = Path(args.source_root)
     published_root = Path(args.published_root)
@@ -410,6 +433,7 @@ def patch_devnotes(args: argparse.Namespace) -> int:
 
     source_block = extract_devnotes_block(source_nav)
     replace_devnotes_block(target_nav, rewrite_devnotes_block(source_root, published_root, source_block))
+    patch_image_generation_recipes(source_nav, target_nav)
     write_publish_metadata(published_root, args, "devnotes-patch")
     return 0
 

--- a/packages/data-designer/tests/docs/test_fern_published_branch.py
+++ b/packages/data-designer/tests/docs/test_fern_published_branch.py
@@ -72,6 +72,16 @@ redirects:
     write_text(
         source_root / "fern" / "versions" / "latest.yml",
         """navigation:
+  - section: Recipes
+    contents:
+      - page: Recipe Cards
+        path: ./latest/pages/recipes/cards.mdx
+      - section: Image Generation
+        contents:
+          - page: New Image Recipe
+            path: ./latest/pages/recipes/image_generation/new-image-recipe.mdx
+      - section: Code Generation
+        contents: []
   - section: Dev Notes
     contents:
       - page: New Note
@@ -81,6 +91,17 @@ redirects:
 """,
     )
     write_text(source_root / "fern" / "versions" / "latest" / "pages" / "devnotes" / "posts" / "new-note.mdx", "# New")
+    write_text(
+        source_root
+        / "fern"
+        / "versions"
+        / "latest"
+        / "pages"
+        / "recipes"
+        / "image_generation"
+        / "new-image-recipe.mdx",
+        "# New Image Recipe",
+    )
 
     write_text(
         published_root / "fern" / "docs.yml",
@@ -107,6 +128,14 @@ redirects:
     write_text(
         published_root / "fern" / "versions" / "latest.yml",
         """navigation:
+  - section: Recipes
+    contents:
+      - page: Recipe Cards
+        path: ./v0.6.0/pages/recipes/cards.mdx
+      - section: Code Generation
+        contents:
+          - page: Existing Recipe
+            path: ./v0.6.0/pages/recipes/code_generation/existing.mdx
   - section: Dev Notes
     contents:
       - page: Old Note
@@ -116,6 +145,7 @@ redirects:
 """,
     )
 
+    assert module.patch_devnotes(patch_args(source_root, published_root)) == 0
     assert module.patch_devnotes(patch_args(source_root, published_root)) == 0
 
     published_docs = (published_root / "fern" / "docs.yml").read_text()
@@ -142,3 +172,18 @@ redirects:
     )
     assert not (published_root / "fern" / "assets" / "published-only-asset.png").exists()
     assert (published_root / "fern" / "versions" / "latest" / "pages" / "devnotes" / "posts" / "new-note.mdx").exists()
+    published_nav = (published_root / "fern" / "versions" / "latest.yml").read_text()
+    assert published_nav.count("section: Image Generation") == 1
+    assert published_nav.index("section: Image Generation") < published_nav.index("section: Code Generation")
+    assert "path: ./latest/pages/recipes/image_generation/new-image-recipe.mdx" in published_nav
+    assert "path: ./v0.6.0/pages/recipes/code_generation/existing.mdx" in published_nav
+    assert (
+        published_root
+        / "fern"
+        / "versions"
+        / "latest"
+        / "pages"
+        / "recipes"
+        / "image_generation"
+        / "new-image-recipe.mdx"
+    ).read_text() == "# New Image Recipe"


### PR DESCRIPTION
## 📋 Summary

The image-generation dev note links to nine recipes that are present on `main` but absent from the release-pinned `docs-website` navigation, so every recipe link returns 404 in production. This PR publishes the companion recipe section and pages with the existing dev-note patch while preserving all frozen release recipe entries.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Copy the image-generation recipe pages into the published latest docs tree.
- Upsert the nested Image Generation recipe section without replacing release-pinned recipe sections.
- Republish when image-generation recipe pages change.
- Cover first-run and repeat-run behavior against a release-pinned navigation fixture.

## 🧪 Testing

- [x] `uv run pytest packages/data-designer/tests/docs/test_fern_published_branch.py -q`
- [x] `uv run ruff check fern/scripts/fern-published-branch.py packages/data-designer/tests/docs/test_fern_published_branch.py`
- [x] Fern check against a patched `docs-website` snapshot: 0 errors
- [x] Workflow YAML parsed successfully
- [x] Unit tests added/updated
- [x] E2E tests: N/A; validated the generated published tree with Fern

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A; no architecture changes)