### PR TITLE
docs: publish recipes with devnotes

### DIFF
--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -21,6 +21,7 @@ on:
       - "fern/styles/trajectory-viewer.css"
       - "fern/versions/latest.yml"
       - "fern/versions/latest/pages/devnotes/**"
+      - "fern/versions/latest/pages/recipes/**"
   workflow_dispatch:
 
 permissions: {}

--- a/fern/scripts/fern-published-branch.py
+++ b/fern/scripts/fern-published-branch.py
@@ -15,6 +15,7 @@ import tempfile
 from pathlib import Path
 
 DEVNOTES_SECTION_RE = re.compile(r"^  - section:\s+Dev Notes\s*$")
+RECIPES_SECTION_RE = re.compile(r"^  - section:\s+Recipes\s*$")
 RETIRED_REFERENCE_SECTION_RE = re.compile(r"^  - section:\s+" + re.escape("Code " + "Reference") + r"\s*$")
 RETIRED_REFERENCE_DIR = "code" + "_reference"
 NAV_PATH_RE = re.compile(r"^(\s*path:\s+)\./([^#\s]+)(.*)$")
@@ -51,6 +52,7 @@ FERN_DEVNOTE_SUPPORT_PATHS = [
     "fern/components/MetricsTable.tsx",
     "fern/components/TrajectoryViewer.tsx",
     "fern/components/devnotes",
+    "fern/versions/latest/pages/recipes",
 ]
 RETIRED_REFERENCE_CLEAN_PAGE_PATHS = [
     "concepts/columns.mdx",
@@ -410,6 +412,8 @@ def patch_devnotes(args: argparse.Namespace) -> int:
 
     source_block = extract_devnotes_block(source_nav)
     replace_devnotes_block(target_nav, rewrite_devnotes_block(source_root, published_root, source_block))
+    recipes_block = extract_navigation_section(source_nav, RECIPES_SECTION_RE)
+    replace_navigation_section(target_nav, RECIPES_SECTION_RE, recipes_block)
     write_publish_metadata(published_root, args, "devnotes-patch")
     return 0
 

--- a/packages/data-designer/tests/docs/test_fern_published_branch.py
+++ b/packages/data-designer/tests/docs/test_fern_published_branch.py
@@ -72,6 +72,10 @@ redirects:
     write_text(
         source_root / "fern" / "versions" / "latest.yml",
         """navigation:
+  - section: Recipes
+    contents:
+      - page: New Recipe
+        path: ./latest/pages/recipes/new-recipe.mdx
   - section: Dev Notes
     contents:
       - page: New Note
@@ -80,6 +84,7 @@ redirects:
     contents: []
 """,
     )
+    write_text(source_root / "fern" / "versions" / "latest" / "pages" / "recipes" / "new-recipe.mdx", "# New")
     write_text(source_root / "fern" / "versions" / "latest" / "pages" / "devnotes" / "posts" / "new-note.mdx", "# New")
 
     write_text(
@@ -107,15 +112,23 @@ redirects:
     write_text(
         published_root / "fern" / "versions" / "latest.yml",
         """navigation:
+  - section: Recipes
+    contents:
+      - page: Released Recipe
+        path: ./v0.6.0/pages/recipes/released-recipe.mdx
   - section: Dev Notes
     contents:
       - page: Old Note
         path: ./latest/pages/devnotes/posts/old-note.mdx
   - section: Concepts
-    contents: []
+    contents:
+      - page: Released Concept
+        path: ./v0.6.0/pages/concepts/released-concept.mdx
 """,
     )
+    write_text(published_root / "fern" / "versions" / "latest" / "pages" / "recipes" / "old-recipe.mdx", "# Old")
 
+    assert module.patch_devnotes(patch_args(source_root, published_root)) == 0
     assert module.patch_devnotes(patch_args(source_root, published_root)) == 0
 
     published_docs = (published_root / "fern" / "docs.yml").read_text()
@@ -142,3 +155,10 @@ redirects:
     )
     assert not (published_root / "fern" / "assets" / "published-only-asset.png").exists()
     assert (published_root / "fern" / "versions" / "latest" / "pages" / "devnotes" / "posts" / "new-note.mdx").exists()
+    published_nav = (published_root / "fern" / "versions" / "latest.yml").read_text()
+    assert published_nav.count("section: Recipes") == 1
+    assert "path: ./latest/pages/recipes/new-recipe.mdx" in published_nav
+    assert "path: ./v0.6.0/pages/recipes/released-recipe.mdx" not in published_nav
+    assert "path: ./v0.6.0/pages/concepts/released-concept.mdx" in published_nav
+    assert (published_root / "fern" / "versions" / "latest" / "pages" / "recipes" / "new-recipe.mdx").exists()
+    assert not (published_root / "fern" / "versions" / "latest" / "pages" / "recipes" / "old-recipe.mdx").exists()


### PR DESCRIPTION
## 📋 Summary

Publish the complete Recipes section from `main` alongside rolling Dev Notes. This prevents published Dev Notes from linking to unreleased recipe pages without making the rest of the documentation rolling.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Copy the complete `fern/versions/latest/pages/recipes` tree into the published `latest` docs.
- Replace the top-level Recipes navigation block while preserving release-pinned sections and archived versions.
- Republish when any recipe page changes.
- Cover replacement, deletion, idempotency, and preservation of the release-pinned Concepts section.

## 🧪 Testing

- [x] `.venv/bin/pytest -q packages/data-designer/tests/docs` - 15 passed
- [x] `.venv/bin/ruff check --fix .`
- [x] `.venv/bin/ruff format .`
- [x] Dry run against the current `docs-website` snapshot - 29 recipe pages and navigation references moved to `latest`; Concepts remained pinned to `v0.6.1`.
- [x] Unit tests added/updated
- [x] E2E tests: N/A; the publisher test and `docs-website` dry run cover the changed path.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A; no architecture changes)
