### PR TITLE
docs: fix workflow chaining devnote date

### DIFF
--- a/fern/versions/latest/pages/devnotes/index.mdx
+++ b/fern/versions/latest/pages/devnotes/index.mdx
@@ -10,20 +10,20 @@ Welcome to NeMo Data Designer Dev Notes — in-depth guides, benchmark write-ups
 
 <BlogGrid>
   <BlogCard
+    href="/dev-notes/pause-inspect-resume"
+    title="Pause, Inspect, Resume"
+    description="Workflow chaining turns long generation jobs into resumable stages you can inspect, override, compare, and hand off. Human review is one useful pattern."
+    date="July 13, 2026"
+    authors={["amanoel"]}
+    image={<img src="/assets/document-hitl/workflow-chaining-hero.png" alt="" loading="lazy" />}
+  />
+  <BlogCard
     href="/dev-notes/image-generation-for-multimodal-data-pipelines"
     title="Image Generation for Multimodal Data Pipelines"
     description="From document VQA to autonomous-vehicle scenes, X-rays, drone frames, and funny pet edits — controlled image datasets you can inspect row by row."
     date="July 2, 2026"
     authors={["nmulepati"]}
     image={<img src="/assets/image-generation-for-multimodal-data-pipelines/image-generation-hero.jpg" alt="" loading="lazy" />}
-  />
-  <BlogCard
-    href="/dev-notes/pause-inspect-resume"
-    title="Pause, Inspect, Resume"
-    description="Workflow chaining turns long generation jobs into resumable stages you can inspect, override, compare, and hand off. Human review is one useful pattern."
-    date="Jun 25, 2026"
-    authors={["amanoel"]}
-    image={<img src="/assets/document-hitl/workflow-chaining-hero.png" alt="" loading="lazy" />}
   />
   <BlogCard
     href="/dev-notes/designing-nemotron-personas"


### PR DESCRIPTION
## 📋 Summary

Corrects the publication date for the workflow-chaining devnote to match its July 13, 2026 publication. The card is moved to preserve reverse chronological ordering.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Update the "Pause, Inspect, Resume" devnote date from June 25 to July 13, 2026
- Move the card above the July 2 devnote

## 🧪 Testing

- [x] `make check-fern-docs` passes
- [x] Ruff check and format pass
- [x] Unit tests: N/A - documentation-only change
- [x] E2E tests: N/A - documentation-only change

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A - documentation metadata only)
