### PR TITLE
docs: update NeMo Platform badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/NVIDIA-NeMo/DataDesigner/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA-NeMo/DataDesigner/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python 3.10 - 3.14](https://img.shields.io/badge/🐍_Python-3.10_|_3.11_|_3.12_|_3.13_|_3.14-blue.svg)](https://www.python.org/downloads/) [![NeMo Microservices](https://img.shields.io/badge/NeMo-Microservices-76b900)](https://docs.nvidia.com/nemo/microservices/latest/index.html) [![Code](https://img.shields.io/badge/Code-Documentation-8A2BE2.svg)](https://docs.nvidia.com/nemo/datadesigner/) ![Tokens](https://img.shields.io/badge/10T+-Tokens_Processed-76b900.svg?logo=nvidia&logoColor=white)
+[![Python 3.10 - 3.14](https://img.shields.io/badge/🐍_Python-3.10_|_3.11_|_3.12_|_3.13_|_3.14-blue.svg)](https://www.python.org/downloads/) [![NeMo Platform](https://img.shields.io/badge/NeMo-Platform-76b900)](https://docs.nvidia.com/nemo-platform/documentation/design-synthetic-data) [![Code](https://img.shields.io/badge/Code-Documentation-8A2BE2.svg)](https://docs.nvidia.com/nemo/datadesigner/) ![Tokens](https://img.shields.io/badge/10T+-Tokens_Processed-76b900.svg?logo=nvidia&logoColor=white)
 
 **Generate high-quality synthetic datasets from scratch or using your own seed data.**
 

--- a/fern/versions/latest/pages/index.mdx
+++ b/fern/versions/latest/pages/index.mdx
@@ -10,7 +10,7 @@ import { BadgeLinks } from "@/components/BadgeLinks";
   badges={[
     { href: "https://github.com/NVIDIA-NeMo/DataDesigner", src: "https://img.shields.io/badge/github-repo-952fc6?logo=github", alt: "GitHub" },
     { href: "https://opensource.org/licenses/Apache-2.0", src: "https://img.shields.io/badge/License-Apache_2.0-0074df.svg", alt: "License" },
-    { href: "https://docs.nvidia.com/nemo/microservices/latest/index.html", src: "https://img.shields.io/badge/NeMo-Microservices-76b900", alt: "NeMo Microservices" },
+    { href: "https://docs.nvidia.com/nemo-platform/documentation/design-synthetic-data", src: "https://img.shields.io/badge/NeMo-Platform-76b900", alt: "NeMo Platform" },
   ]}
 />
 


### PR DESCRIPTION
## 📋 Summary

Update the repository and Fern landing-page badges to reflect the NeMo Platform naming and direct users to the Data Designer plugin documentation.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Rename the `NeMo Microservices` badges to `NeMo Platform`.
- Point both badges to the NeMo Platform Data Designer plugin page.

## 🧪 Testing

- [x] `npx -y fern-api@5.41.1 check` passes with 0 errors
- [x] Unit tests: N/A — documentation-only change
- [x] E2E tests: N/A — documentation-only change

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs: N/A — no architecture changes
