### PR TITLE
fix: bootstrap Fern docs publishing

### DIFF
--- a/.github/workflows/build-fern-docs.yml
+++ b/.github/workflows/build-fern-docs.yml
@@ -58,7 +58,7 @@ jobs:
             source_ref="${INPUT_SOURCE_REF:-$INPUT_RELEASE_TAG}"
             prepare_release_docs=1
           else
-            release_tag=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // empty')
+            release_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // empty')
             if [ -z "$release_tag" ]; then
               echo "::error::Could not find the latest published release tag."
               exit 1

--- a/.github/workflows/publish-fern-devnotes.yml
+++ b/.github/workflows/publish-fern-devnotes.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Check Fern docs
         working-directory: website
-        run: make check-fern-published-docs
+        run: make -f ../workflow/Makefile check-fern-published-docs
 
       - name: Commit published branch
         env:

--- a/packages/data-designer/tests/docs/test_docs_workflows.py
+++ b/packages/data-designer/tests/docs/test_docs_workflows.py
@@ -37,6 +37,12 @@ def test_fern_publish_excludes_cancelled_notebook_builds() -> None:
     assert "if: needs.build-notebooks.result == 'failure'" in workflow
 
 
+def test_fern_release_resolution_sets_repository() -> None:
+    workflow = (WORKFLOWS_DIR / "build-fern-docs.yml").read_text()
+
+    assert 'gh release list --repo "$GITHUB_REPOSITORY"' in workflow
+
+
 def test_fern_publish_persists_and_restores_notebook_snapshots() -> None:
     workflow = (WORKFLOWS_DIR / "build-fern-docs.yml").read_text()
 

--- a/packages/data-designer/tests/docs/test_docs_workflows.py
+++ b/packages/data-designer/tests/docs/test_docs_workflows.py
@@ -65,5 +65,5 @@ def test_devnotes_publish_does_not_reuse_notebook_artifacts() -> None:
     assert "Run the Build Fern docs workflow successfully once" in workflow
     assert "Restore published notebook snapshot" in workflow
     assert 'gh release download "$release_tag"' in workflow
-    assert "run: make check-fern-published-docs" in workflow
+    assert "run: make -f ../workflow/Makefile check-fern-published-docs" in workflow
     assert "run: make check-fern-docs\n" not in workflow


### PR DESCRIPTION
## 📋 Summary

This PR restores the Fern publishing bootstrap path introduced by [#818](https://github.com/NVIDIA-NeMo/DataDesigner/pull/818). The workflows can now resolve the latest release before checkout and validate devnotes using targets from the current workflow revision.

## 🧭 Context

After #818 merged, the [`Publish Fern devnotes` check on `main`](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30833186014/attempts/1) failed because the `docs-website` branch did not yet contain the new canonical `fern/notebook-snapshot.json`. The intended bootstrap was to run `Build Fern docs` once for the latest release, generating the executed-notebook archive and publishing its metadata for later devnotes runs.

That bootstrap exposed two workflow bugs:

1. The [manual `Build Fern docs` run](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30876242853) failed before checkout. The `resolve-release` job called `gh release list` without `--repo`, so GitHub CLI tried to infer the repository from an empty runner directory and exited with `fatal: not a git repository`.
2. After repository-scoped release lookup allowed [`Build Fern docs` to generate and publish the `v0.8.0` snapshot](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30910633145), [rerunning `Publish Fern devnotes`](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30833186014/attempts/2) reached validation but failed with `No rule to make target 'check-fern-published-docs'`. The command was using the older Makefile from `docs-website`, while the new validation target exists in the current workflow checkout.

This PR fixes both bootstrap bugs. The canonical snapshot is now published, and subsequent devnotes runs can restore and validate it without rebuilding notebooks or relying on short-lived workflow artifacts.

## 🔗 Related Issue

N/A - follow-up to #818 after Fern publishing failures on `main`.

## 🔄 Changes

- Scope release discovery in [`build-fern-docs.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/fix/fern-release-resolution/.github/workflows/build-fern-docs.yml) to `$GITHUB_REPOSITORY`, so the pre-checkout job does not require a local Git repository ([`4726bef3`](https://github.com/NVIDIA-NeMo/DataDesigner/commit/4726bef3744be12681b6506c0ad27d48404bb292)).
- Run published-doc validation in [`publish-fern-devnotes.yml`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/fix/fern-release-resolution/.github/workflows/publish-fern-devnotes.yml) with the workflow checkout's Makefile instead of the older `docs-website` Makefile ([`04e194f4`](https://github.com/NVIDIA-NeMo/DataDesigner/commit/04e194f4032e54c397d22e2ded6c496134f75572)).
- Extend [`test_docs_workflows.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/fix/fern-release-resolution/packages/data-designer/tests/docs/test_docs_workflows.py) with regression assertions for both bootstrap paths.

## 🧪 Testing

- [ ] `make test` passes - not run locally; the full GitHub CI matrix passed.
- [x] Unit tests added/updated - `.venv/bin/pytest packages/data-designer/tests/docs/test_docs_workflows.py` (6 passed).
- [x] E2E tests added/updated (if applicable) - N/A; the workflow-only fix was validated through live end-to-end runs.
- [x] [Full PR CI](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30912901983) passes.
- [x] [`Build Fern docs`](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30910633145) and [`Publish Fern devnotes`](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/30912922736) pass end to end.
- [x] Ruff check, Ruff format, and `git diff --check` pass.
- [x] Published snapshot metadata matches the `v0.8.0` release asset SHA-256 digest.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated - N/A; no architecture changes
