### PR TITLE
chore: Relax validation on NEMO_DEPLOYMENT_TYPE

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/models/telemetry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/telemetry.py
@@ -65,7 +65,11 @@ def _normalize_deployment_type(value: str | None) -> DeploymentTypeEnum:
         return DeploymentTypeEnum.UNDEFINED
 
 
-DEPLOYMENT_TYPE = _normalize_deployment_type(os.getenv("NEMO_DEPLOYMENT_TYPE"))
+def get_nemo_deployment_type() -> DeploymentTypeEnum:
+    return _normalize_deployment_type(os.getenv("NEMO_DEPLOYMENT_TYPE"))
+
+
+DEPLOYMENT_TYPE = get_nemo_deployment_type()
 
 
 class TaskStatusEnum(str, Enum):

--- a/packages/data-designer-engine/src/data_designer/engine/models/telemetry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/telemetry.py
@@ -55,14 +55,17 @@ class DeploymentTypeEnum(str, Enum):
     UNDEFINED = "undefined"
 
 
-_deployment_type_raw = os.getenv("NEMO_DEPLOYMENT_TYPE", "library").lower()
-try:
-    DEPLOYMENT_TYPE = DeploymentTypeEnum(_deployment_type_raw)
-except ValueError:
-    valid_values = [e.value for e in DeploymentTypeEnum]
-    raise ValueError(
-        f"Invalid NEMO_DEPLOYMENT_TYPE: {_deployment_type_raw!r}. Must be one of: {valid_values}"
-    ) from None
+def _normalize_deployment_type(value: str | None) -> DeploymentTypeEnum:
+    if value is None:
+        return DeploymentTypeEnum.LIBRARY
+
+    try:
+        return DeploymentTypeEnum(value.lower())
+    except ValueError:
+        return DeploymentTypeEnum.UNDEFINED
+
+
+DEPLOYMENT_TYPE = _normalize_deployment_type(os.getenv("NEMO_DEPLOYMENT_TYPE"))
 
 
 class TaskStatusEnum(str, Enum):

--- a/packages/data-designer-engine/tests/engine/models/test_telemetry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_telemetry.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import importlib
 from datetime import datetime, timezone
 
+import data_designer.engine.models.telemetry as telemetry
 from data_designer.engine.models.telemetry import (
     DeploymentTypeEnum,
     InferenceEvent,
@@ -30,3 +32,22 @@ def test_nvidia_internal_deployment_type_uses_schema_version_1_9() -> None:
 
     assert payload["eventSchemaVer"] == "1.9"
     assert payload["events"][0]["parameters"]["deploymentType"] == "nvidia-internal"
+
+
+def test_unrecognized_env_deployment_type_defaults_to_undefined(monkeypatch) -> None:
+    monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "unrecognized")
+    reloaded_telemetry = importlib.reload(telemetry)
+
+    try:
+        assert reloaded_telemetry.DEPLOYMENT_TYPE == DeploymentTypeEnum.UNDEFINED
+        event = reloaded_telemetry.InferenceEvent(
+            nemo_source=reloaded_telemetry.NemoSourceEnum.DATADESIGNER,
+            task="batch",
+            task_status=reloaded_telemetry.TaskStatusEnum.SUCCESS,
+            model="test-model",
+        )
+
+        assert event.deployment_type == reloaded_telemetry.DeploymentTypeEnum.UNDEFINED
+    finally:
+        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+        importlib.reload(telemetry)

--- a/packages/data-designer-engine/tests/engine/models/test_telemetry.py
+++ b/packages/data-designer-engine/tests/engine/models/test_telemetry.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-import importlib
 from datetime import datetime, timezone
 
-import data_designer.engine.models.telemetry as telemetry
+import pytest
+
 from data_designer.engine.models.telemetry import (
     DeploymentTypeEnum,
     InferenceEvent,
@@ -14,6 +14,7 @@ from data_designer.engine.models.telemetry import (
     QueuedEvent,
     TaskStatusEnum,
     build_payload,
+    get_nemo_deployment_type,
 )
 
 
@@ -34,20 +35,7 @@ def test_nvidia_internal_deployment_type_uses_schema_version_1_9() -> None:
     assert payload["events"][0]["parameters"]["deploymentType"] == "nvidia-internal"
 
 
-def test_unrecognized_env_deployment_type_defaults_to_undefined(monkeypatch) -> None:
+def test_unrecognized_env_deployment_type_defaults_to_undefined(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "unrecognized")
-    reloaded_telemetry = importlib.reload(telemetry)
 
-    try:
-        assert reloaded_telemetry.DEPLOYMENT_TYPE == DeploymentTypeEnum.UNDEFINED
-        event = reloaded_telemetry.InferenceEvent(
-            nemo_source=reloaded_telemetry.NemoSourceEnum.DATADESIGNER,
-            task="batch",
-            task_status=reloaded_telemetry.TaskStatusEnum.SUCCESS,
-            model="test-model",
-        )
-
-        assert event.deployment_type == reloaded_telemetry.DeploymentTypeEnum.UNDEFINED
-    finally:
-        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
-        importlib.reload(telemetry)
+    assert get_nemo_deployment_type() == DeploymentTypeEnum.UNDEFINED


### PR DESCRIPTION
## 📋 Summary

Relaxes the module-level validation on the `NEMO_DEPLOYMENT_TYPE` in case client applications set it to something unexpected.

## 🔗 Related Issue

N/A

## 🔄 Changes

Tweak the env-var normalization

## 🧪 Testing
Added a unit test

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) N/A
