### PR TITLE
fix: restore NVSkills workflow startup

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,11 +3,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -17,6 +20,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## 📋 Summary

Restores the `Request NVSkills CI` workflow after the shared `NVIDIA/skills` reusable workflow added pull-request status enforcement. DataDesigner's caller was missing the new trigger and permission contract, causing workflow startup failures before any job ran.

The failures were visible on PR #838 in runs [31109567364](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/31109567364) and [31113460876](https://github.com/NVIDIA-NeMo/DataDesigner/actions/runs/31113460876). Both ended with `startup_failure` and created zero jobs.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Trigger the NVSkills reusable workflow for pull-request lifecycle events.
- Route pull-request events through the existing reusable workflow job.
- Grant `statuses: read`, matching the reusable workflow's required permission.
- Preserve the existing issue-comment and trusted signature-push request paths.

## 🧪 Testing

- [ ] `make test` passes - not run; workflow-only change
- [x] `.venv/bin/pytest packages/data-designer/tests/docs/test_docs_workflows.py` - 6 passed
- [x] `.venv/bin/pre-commit run check-yaml --files .github/workflows/request-nvskills-ci.yml`
- [x] `.venv/bin/ruff check --fix .`
- [x] `.venv/bin/ruff format .`
- [ ] Unit tests added/updated - N/A, workflow wiring only
- [ ] E2E tests added/updated - N/A, workflow wiring only

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated - N/A, no architecture change
