### PR TITLE
fix: harden linked issue validation

### DIFF
--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -9,9 +9,9 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
 
-  # Re-check open PRs when a maintainer adds the "triaged" label to an open issue.
+  # Re-check open PRs when linked-issue validity changes.
   issues:
-    types: [labeled]
+    types: [labeled, unlabeled, closed, reopened]
 
 permissions:
   contents: read
@@ -233,13 +233,20 @@ jobs:
           echo "::error::Linked issue check failed. See the PR comment for details."
           exit 1
 
-  # ── Job 2: re-trigger check when an issue gets triaged ────────────────
+  # ── Job 2: re-trigger check when linked-issue validity changes ───────
   retrigger:
     if: >-
       github.repository_owner == 'NVIDIA-NeMo'
       && github.event_name == 'issues'
-      && github.event.label.name == 'triaged'
-      && github.event.issue.state == 'open'
+      && (
+        github.event.action == 'closed'
+        || github.event.action == 'reopened'
+        || (
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+          && github.event.label.name == 'triaged'
+          && github.event.issue.state == 'open'
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Find PRs referencing this issue
@@ -271,10 +278,30 @@ jobs:
         if: steps.find-prs.outputs.prs != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_ACTION: ${{ github.event.action }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBERS: ${{ steps.find-prs.outputs.prs }}
         run: |
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          case "$ISSUE_ACTION" in
+            labeled)
+              EVENT_DESCRIPTION='received the `triaged` label'
+              ;;
+            unlabeled)
+              EVENT_DESCRIPTION='lost the `triaged` label'
+              ;;
+            closed)
+              EVENT_DESCRIPTION="was closed"
+              ;;
+            reopened)
+              EVENT_DESCRIPTION="was reopened"
+              ;;
+            *)
+              echo "::error::Unsupported issue action: ${ISSUE_ACTION}"
+              exit 1
+              ;;
+          esac
 
           for PR_NUM in $PR_NUMBERS; do
             echo "Re-triggering check for PR #${PR_NUM}..."
@@ -297,5 +324,5 @@ jobs:
 
             # Post a visible comment so the author knows what happened.
             gh pr comment "$PR_NUM" --repo "${{ github.repository }}" --body \
-              "Issue #${ISSUE_NUMBER} has been triaged. The linked issue check is being re-evaluated."
+              "Issue #${ISSUE_NUMBER} ${EVENT_DESCRIPTION}. The linked issue check is being re-evaluated."
           done

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
 
-  # Re-check open PRs when a maintainer adds the "triaged" label to an issue.
+  # Re-check open PRs when a maintainer adds the "triaged" label to an open issue.
   issues:
     types: [labeled]
 
@@ -88,7 +88,7 @@ jobs:
           echo "issue_num=${ISSUE_NUM}" >> "$GITHUB_OUTPUT"
           echo "Parsed issue number: ${ISSUE_NUM:-<none>}"
 
-      - name: Validate issue exists and is triaged
+      - name: Validate issue is open and triaged
         id: validate
         if: steps.author.outputs.is_collaborator != 'true' && steps.parse.outputs.issue_num != ''
         env:
@@ -97,6 +97,7 @@ jobs:
         run: |
           RESPONSE=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUM}" 2>/dev/null) || {
             echo "issue_exists=false" >> "$GITHUB_OUTPUT"
+            echo "is_open=false" >> "$GITHUB_OUTPUT"
             echo "is_triaged=false" >> "$GITHUB_OUTPUT"
             echo "Issue #${ISSUE_NUM} not found"
             exit 0
@@ -106,6 +107,7 @@ jobs:
           IS_PR=$(echo "$RESPONSE" | jq -r 'has("pull_request")')
           if [ "$IS_PR" = "true" ]; then
             echo "issue_exists=false" >> "$GITHUB_OUTPUT"
+            echo "is_open=false" >> "$GITHUB_OUTPUT"
             echo "is_triaged=false" >> "$GITHUB_OUTPUT"
             echo "#${ISSUE_NUM} is a pull request, not an issue"
             exit 0
@@ -113,9 +115,17 @@ jobs:
 
           echo "issue_exists=true" >> "$GITHUB_OUTPUT"
 
+          ISSUE_OPEN=$(echo "$RESPONSE" | jq -r '.state == "open"')
+          echo "is_open=${ISSUE_OPEN}" >> "$GITHUB_OUTPUT"
+          if [ "$ISSUE_OPEN" != "true" ]; then
+            echo "is_triaged=false" >> "$GITHUB_OUTPUT"
+            echo "Issue #${ISSUE_NUM} is closed"
+            exit 0
+          fi
+
           TRIAGED=$(echo "$RESPONSE" | jq -r '[.labels[].name] | any(. == "triaged")')
           echo "is_triaged=${TRIAGED}" >> "$GITHUB_OUTPUT"
-          echo "Issue #${ISSUE_NUM} exists, triaged=${TRIAGED}"
+          echo "Issue #${ISSUE_NUM} is open, triaged=${TRIAGED}"
 
       - name: Build comment body and post result
         id: comment
@@ -124,6 +134,7 @@ jobs:
           IS_COLLABORATOR: ${{ steps.author.outputs.is_collaborator }}
           ISSUE_NUM: ${{ steps.parse.outputs.issue_num }}
           ISSUE_EXISTS: ${{ steps.validate.outputs.issue_exists }}
+          ISSUE_OPEN: ${{ steps.validate.outputs.is_open }}
           IS_TRIAGED: ${{ steps.validate.outputs.is_triaged }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -131,9 +142,11 @@ jobs:
           MARKER="<!-- linked-issue-check -->"
 
           # Find existing bot comment with our marker.
-          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq "[.[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"${MARKER}\"))] | last | .id // empty" \
+          COMMENT_IDS=$(gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"${MARKER}\")) | .id" \
             2>/dev/null || echo "")
+          COMMENT_ID=$(printf '%s\n' "$COMMENT_IDS" | tail -1)
 
           if [ "$IS_COLLABORATOR" = "true" ]; then
             echo "status=pass" >> "$GITHUB_OUTPUT"
@@ -152,7 +165,7 @@ jobs:
           ### Linked Issue Check
 
           This PR does not reference an issue. External contributions must link to
-          a triaged issue before the PR can be merged.
+          an open, triaged issue for this check to pass.
 
           Add one of the following to your PR description:
           - `Fixes #<issue-number>`
@@ -174,6 +187,15 @@ jobs:
           The referenced issue #${ISSUE_NUM} was not found. Please check the issue
           number in your PR description.
           MSG
+          elif [ "$ISSUE_OPEN" != "true" ]; then
+            STATUS="fail"
+            cat > /tmp/comment-body.md <<MSG
+          <!-- linked-issue-check -->
+          ### Linked Issue Check
+
+          Issue #${ISSUE_NUM} is closed. Please link an open, triaged issue in your
+          PR description.
+          MSG
           elif [ "$IS_TRIAGED" != "true" ]; then
             STATUS="fail"
             cat > /tmp/comment-body.md <<MSG
@@ -181,7 +203,7 @@ jobs:
           ### Linked Issue Check
 
           Issue #${ISSUE_NUM} has not been triaged yet. A maintainer needs to review
-          the issue and add the \`triaged\` label before this PR can be merged.
+          the issue and add the \`triaged\` label for this check to pass.
 
           You can continue working on the PR in the meantime. The check will
           re-run automatically once the issue is triaged.
@@ -217,6 +239,7 @@ jobs:
       github.repository_owner == 'NVIDIA-NeMo'
       && github.event_name == 'issues'
       && github.event.label.name == 'triaged'
+      && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     steps:
       - name: Find PRs referencing this issue
@@ -228,7 +251,13 @@ jobs:
           # List open PRs and find those whose body references this issue.
           PRS=$(gh pr list --repo "${{ github.repository }}" --state open \
             --json number,body --limit 200 \
-            | jq -r "[.[] | select(.body != null) | select(.body | test(\"(?i)(fixes|closes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\")) | .number] | .[]")
+            | jq -r --arg issue "$ISSUE_NUMBER" '
+                .[]
+                | select(.body != null)
+                | (.body | ascii_downcase | capture("(?:fixes|closes|resolves)\\s+#(?<issue>[0-9]+)")?) as $reference
+                | select($reference.issue == $issue)
+                | .number
+              ')
 
           if [ -z "$PRS" ]; then
             echo "No open PRs reference issue #${ISSUE_NUMBER}"

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -14,6 +14,7 @@ on:
     types: [labeled, unlabeled, closed, reopened]
 
 permissions:
+  actions: write
   contents: read
   pull-requests: write
   issues: read
@@ -282,8 +283,6 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBERS: ${{ steps.find-prs.outputs.prs }}
         run: |
-          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
           case "$ISSUE_ACTION" in
             labeled)
               EVENT_DESCRIPTION='received the `triaged` label'
@@ -306,21 +305,22 @@ jobs:
           for PR_NUM in $PR_NUMBERS; do
             echo "Re-triggering check for PR #${PR_NUM}..."
 
-            # Read current PR body to a file to avoid shell expansion issues.
-            gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json body -q '.body' > /tmp/current-body.txt
+            # Find the latest completed run for this PR's current head commit.
+            # Editing the PR with the workflow's GITHUB_TOKEN would not trigger
+            # another workflow run.
+            HEAD_SHA=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+              --json headRefOid --jq '.headRefOid')
+            RUN_ID=$(gh run list --repo "${{ github.repository }}" \
+              --workflow pr-linked-issue.yml --event pull_request_target \
+              --commit "$HEAD_SHA" --status completed --limit 1 \
+              --json databaseId --jq '.[0].databaseId')
 
-            # Append or update hidden timestamp to trigger the 'edited' event,
-            # which re-runs the check job.
-            MARKER="<!-- triaged-recheck"
-            if grep -q "$MARKER" /tmp/current-body.txt; then
-              sed "s|<!-- triaged-recheck[^>]*-->|<!-- triaged-recheck: ${TIMESTAMP} -->|" \
-                /tmp/current-body.txt > /tmp/pr-body.md
-            else
-              cp /tmp/current-body.txt /tmp/pr-body.md
-              printf '\n<!-- triaged-recheck: %s -->' "$TIMESTAMP" >> /tmp/pr-body.md
+            if [ -z "$RUN_ID" ]; then
+              echo "::warning::No completed Linked Issue Check run found for PR #${PR_NUM}"
+              continue
             fi
 
-            gh pr edit "$PR_NUM" --repo "${{ github.repository }}" --body-file /tmp/pr-body.md
+            gh run rerun "$RUN_ID" --repo "${{ github.repository }}"
 
             # Post a visible comment so the author knows what happened.
             gh pr comment "$PR_NUM" --repo "${{ github.repository }}" --body \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ The repository includes skills for common development tasks. These are located i
 
 ## Pull Requests
 
-- PRs must link to the issue they address (`Fixes #NNN` or `Closes #NNN`). For external contributors, this is enforced by a required status check: the linked issue must exist and carry the `triaged` label (added by a maintainer after review). Collaborators are exempt from this check. You can open the PR before the issue is triaged - the check re-runs automatically once a maintainer adds the label.
+- PRs should link to the issue they address (`Fixes #NNN` or `Closes #NNN`). For external contributors, the linked-issue workflow reports whether the issue exists, is open, and carries the `triaged` label (added by a maintainer after review). Collaborators are exempt from this check. Repository rules must separately require `Linked Issue Check / check` for the result to block merging. You can open the PR before the issue is triaged - the check re-runs automatically once a maintainer adds the label.
 - PRs with failing checks that remain inactive are automatically reminded after 7 days and closed after 14 days (collaborators: 14/28 days). Push an update or leave a comment to reset the timer. If you need more time, ask a maintainer to add the `keep-open` label.
 - Use the `create-pr` skill for well-formatted PR descriptions, or follow the PR template
 - Ensure all checks pass before requesting review:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ The repository includes skills for common development tasks. These are located i
 
 ## Pull Requests
 
-- PRs should link to the issue they address (`Fixes #NNN` or `Closes #NNN`). For external contributors, the linked-issue workflow reports whether the issue exists, is open, and carries the `triaged` label (added by a maintainer after review). Collaborators are exempt from this check. Repository rules must separately require `Linked Issue Check / check` for the result to block merging. You can open the PR before the issue is triaged - the check re-runs automatically once a maintainer adds the label.
+- PRs should link to the issue they address (`Fixes #NNN` or `Closes #NNN`). For external contributors, the linked-issue workflow reports whether the issue exists, is open, and carries the `triaged` label (added by a maintainer after review). Collaborators are exempt from this check. Repository rules must separately require `Linked Issue Check / check` for the result to block merging. You can open the PR before the issue is triaged - the check re-runs automatically when the selected issue gains or loses the label, is closed, or is reopened.
 - PRs with failing checks that remain inactive are automatically reminded after 7 days and closed after 14 days (collaborators: 14/28 days). Push an update or leave a comment to reset the timer. If you need more time, ask a maintainer to add the `keep-open` label.
 - Use the `create-pr` skill for well-formatted PR descriptions, or follow the PR template
 - Ensure all checks pass before requesting review:


### PR DESCRIPTION
## Summary

- require linked issues to be open as well as triaged
- re-run validation when the selected issue is closed, reopened, or gains or loses `triaged`
- keep validation and triage-triggered rechecks aligned on the first closing reference
- paginate bot-comment lookup so existing status comments are reliably updated or removed
- clarify that the workflow is advisory unless repository rules require `Linked Issue Check / check`

## Root cause

The workflow validated the `triaged` label without checking issue state, did not re-run when issue validity later changed, used different reference-selection rules between validation and retriggering, and only inspected the first page of PR comments. The contribution guidance also described the check as a required merge gate even though the current `main` protection does not require that status context.

These issues were identified while reviewing and fixing the corresponding workflow in [NVIDIA-NeMo/DataDesignerPlugins#82](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/pull/82).

## Validation

- parsed `.github/workflows/pr-linked-issue.yml` with `yq`
- ran `bash -n` across every embedded workflow shell block
- exercised first-reference and open/closed-state behavior with `jq` fixtures
- `git diff --check`
- `make check-all`
- `make test` — 4,020 passed, 1 skipped
- repository pre-commit hooks
