### PR TITLE
feat: add Slurm image registry foundation

### DIFF
--- a/packages/data-designer-slurm/pyproject.toml
+++ b/packages/data-designer-slurm/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "data-designer=={{ version }}",
     "packaging>=25,<27",
     "pydantic>=2.9.2,<3",
+    "pyyaml>=6.0.1,<7",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/__init__.py
@@ -1,42 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""SQSH inspection, registry, and resolution for Data Designer Slurm."""
+"""Internal SQSH inspection and registry primitives for Data Designer Slurm."""
 
 from __future__ import annotations
-
-from data_designer.slurm.images.errors import (
-    ImageConflictError,
-    ImageInspectionError,
-    ImageNotFoundError,
-    ImageRegistryError,
-    ImageVerificationError,
-    SlurmImageError,
-)
-from data_designer.slurm.images.inspection import (
-    INSPECTOR_VERSION,
-    ClientImageInspector,
-    InspectionEnvironment,
-    ServingImageInspector,
-    SystemInspectionEnvironment,
-)
-from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
-from data_designer.slurm.images.service import SlurmImageService, compute_file_sha256
-
-__all__ = [
-    "INSPECTOR_VERSION",
-    "ClientImageInspector",
-    "ImageConflictError",
-    "ImageInspectionError",
-    "ImageNotFoundError",
-    "ImageRegistryError",
-    "ImageRegistrySnapshot",
-    "ImageVerificationError",
-    "InspectionEnvironment",
-    "RegisteredImage",
-    "ServingImageInspector",
-    "SlurmImageError",
-    "SlurmImageService",
-    "SystemInspectionEnvironment",
-    "compute_file_sha256",
-]

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQSH inspection, registry, and resolution for Data Designer Slurm."""
+
+from __future__ import annotations
+
+from data_designer.slurm.images.errors import (
+    ImageConflictError,
+    ImageInspectionError,
+    ImageNotFoundError,
+    ImageRegistryError,
+    ImageVerificationError,
+    SlurmImageError,
+)
+from data_designer.slurm.images.inspection import (
+    INSPECTOR_VERSION,
+    ClientImageInspector,
+    InspectionEnvironment,
+    ServingImageInspector,
+    SystemInspectionEnvironment,
+)
+from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
+from data_designer.slurm.images.service import SlurmImageService, compute_file_sha256
+
+__all__ = [
+    "INSPECTOR_VERSION",
+    "ClientImageInspector",
+    "ImageConflictError",
+    "ImageInspectionError",
+    "ImageNotFoundError",
+    "ImageRegistryError",
+    "ImageRegistrySnapshot",
+    "ImageVerificationError",
+    "InspectionEnvironment",
+    "RegisteredImage",
+    "ServingImageInspector",
+    "SlurmImageError",
+    "SlurmImageService",
+    "SystemInspectionEnvironment",
+    "compute_file_sha256",
+]

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/errors.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/errors.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical errors for Slurm image inspection and registry operations."""
+
+from __future__ import annotations
+
+
+class SlurmImageError(RuntimeError):
+    """Base error for package-owned Slurm image operations."""
+
+
+class ImageInspectionError(SlurmImageError):
+    """Raised when an image environment cannot produce valid factual metadata."""
+
+
+class ImageRegistryError(SlurmImageError):
+    """Raised when persisted image registry state cannot be read or written."""
+
+
+class ImageNotFoundError(SlurmImageError):
+    """Raised when an image alias or path is not registered."""
+
+
+class ImageConflictError(SlurmImageError):
+    """Raised when an image registration conflicts with immutable registry state."""
+
+
+class ImageVerificationError(SlurmImageError):
+    """Raised when an image file or inspection record fails verification."""

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/filesystem.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/filesystem.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-bound filesystem operations for package-owned Slurm image state."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import secrets
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from data_designer.slurm.images.errors import ImageRegistryError
+
+_DIRECTORY_MODE = 0o700
+_FILE_MODE = 0o600
+
+
+@contextmanager
+def acquire_file_lock(directory_descriptor: int, name: str, display_path: Path) -> Iterator[None]:
+    """Acquire one exclusive advisory lock without reopening its parent path."""
+    descriptor: int | None = None
+    try:
+        # macOS can report ENOENT to the losing openat(O_CREAT) caller when two
+        # processes create the same lock file concurrently. Retrying then opens
+        # the winner's regular file with the same no-follow boundary.
+        for _ in range(10):
+            try:
+                descriptor = os.open(
+                    name,
+                    os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+                    _FILE_MODE,
+                    dir_fd=directory_descriptor,
+                )
+            except FileNotFoundError:
+                continue
+            break
+        if descriptor is None:
+            raise OSError(f"lock path {display_path} could not be opened")
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"lock path {display_path} is not a regular file")
+        os.fchmod(descriptor, _FILE_MODE)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise ImageRegistryError(f"cannot lock image registry target {display_path}") from error
+
+    try:
+        yield
+    finally:
+        assert descriptor is not None
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+def ensure_private_directory(path: Path, *, parents: bool) -> None:
+    """Create or restrict one real directory to its owning user."""
+    path.mkdir(mode=_DIRECTORY_MODE, parents=parents, exist_ok=True)
+    with open_verified_directory(path) as descriptor:
+        os.fchmod(descriptor, _DIRECTORY_MODE)
+
+
+@contextmanager
+def open_verified_directory(path: Path) -> Iterator[int]:
+    """Open one real directory and reject path replacement during the open."""
+    descriptor: int | None = None
+    try:
+        before_open = path.lstat()
+        if not stat.S_ISDIR(before_open.st_mode):
+            raise OSError(f"registry directory {path} is not a directory")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry directory {path} changed while it was being opened")
+        if not stat.S_ISDIR(after_open.st_mode):
+            raise OSError(f"registry directory {path} is not a directory")
+        yield descriptor
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+@contextmanager
+def open_verified_child_directory(
+    parent_descriptor: int,
+    name: str,
+    display_path: Path,
+) -> Iterator[int]:
+    """Open one real child directory relative to an already verified parent."""
+    descriptor: int | None = None
+    try:
+        before_open = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if not stat.S_ISDIR(before_open.st_mode):
+            raise OSError(f"registry directory {display_path} is not a directory")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry directory {display_path} changed while it was being opened")
+        if not stat.S_ISDIR(after_open.st_mode):
+            raise OSError(f"registry directory {display_path} is not a directory")
+        yield descriptor
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def create_temporary_file(
+    directory_descriptor: int,
+    *,
+    prefix: str,
+    suffix: str,
+) -> tuple[int, str]:
+    """Create one restrictive temporary file beneath an open directory."""
+    for _ in range(100):
+        name = f"{prefix}{secrets.token_hex(8)}{suffix}"
+        try:
+            descriptor = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                _FILE_MODE,
+                dir_fd=directory_descriptor,
+            )
+        except FileExistsError:
+            continue
+        try:
+            os.fchmod(descriptor, _FILE_MODE)
+        except OSError:
+            os.close(descriptor)
+            raise
+        return descriptor, name
+    raise OSError("cannot allocate a unique temporary file name")
+
+
+def read_regular_text(directory_descriptor: int, name: str, display_path: Path) -> str:
+    """Read one non-symlink regular text file beneath an open directory."""
+    descriptor: int | None = None
+    try:
+        before_open = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+        if not stat.S_ISREG(before_open.st_mode):
+            raise OSError(f"registry path {display_path} is not a regular file")
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_descriptor,
+        )
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry path {display_path} changed while it was being opened")
+        registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
+        descriptor = None
+        with registry_file:
+            return registry_file.read()
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
@@ -115,12 +115,15 @@ class ClientImageInspector:
         """Return a digest-bound client inspection for the active image environment."""
         environment = self._environment
         try:
+            distributions = tuple(sorted(environment.list_distributions(), key=lambda item: item.name))
+            if not any(distribution.name == "data-designer" for distribution in distributions):
+                raise ImageInspectionError("required distribution 'data-designer' is not installed")
             inspection = ClientImageInspection(
                 kind="client",
                 python_implementation=environment.get_python_implementation(),
                 python_version=environment.get_python_version(),
                 python_abi=environment.get_python_abi(),
-                distributions=tuple(sorted(environment.list_distributions(), key=lambda item: item.name)),
+                distributions=distributions,
                 installer_path=environment.find_executable("pip"),
                 installer_version=environment.get_distribution_version("pip"),
             )

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
@@ -25,6 +25,13 @@ from data_designer.slurm.contracts import Identifier, Sha256Digest
 from data_designer.slurm.images.errors import ImageInspectionError
 
 INSPECTOR_VERSION: Identifier = "inspector-1"
+_REQUIRED_CLIENT_DISTRIBUTIONS = (
+    "data-designer",
+    "data-designer-config",
+    "data-designer-engine",
+    "data-designer-slurm",
+    "pip",
+)
 
 
 class InspectionEnvironment(Protocol):
@@ -116,8 +123,13 @@ class ClientImageInspector:
         environment = self._environment
         try:
             distributions = tuple(sorted(environment.list_distributions(), key=lambda item: item.name))
-            if not any(distribution.name == "data-designer" for distribution in distributions):
-                raise ImageInspectionError("required distribution 'data-designer' is not installed")
+            versions_by_name = {distribution.name: distribution.version for distribution in distributions}
+            missing_distributions = tuple(
+                name for name in _REQUIRED_CLIENT_DISTRIBUTIONS if name not in versions_by_name
+            )
+            if missing_distributions:
+                missing = ", ".join(repr(name) for name in missing_distributions)
+                raise ImageInspectionError(f"required client distributions are not installed: {missing}")
             inspection = ClientImageInspection(
                 kind="client",
                 python_implementation=environment.get_python_implementation(),
@@ -125,7 +137,7 @@ class ClientImageInspector:
                 python_abi=environment.get_python_abi(),
                 distributions=distributions,
                 installer_path=environment.find_executable("pip"),
-                installer_version=environment.get_distribution_version("pip"),
+                installer_version=versions_by_name["pip"],
             )
             return ImageInspectionRecord(
                 schema_version=1,

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/inspection.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package-owned factual inspectors executed inside target image environments."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import platform
+import shutil
+import sys
+from pathlib import Path
+from typing import Protocol
+
+from packaging.utils import canonicalize_name
+from pydantic import ValidationError
+
+from data_designer.slurm.config import (
+    ClientImageInspection,
+    ImageInspectionRecord,
+    InstalledDistribution,
+    ServingImageInspection,
+)
+from data_designer.slurm.contracts import Identifier, Sha256Digest
+from data_designer.slurm.images.errors import ImageInspectionError
+
+INSPECTOR_VERSION: Identifier = "inspector-1"
+
+
+class InspectionEnvironment(Protocol):
+    """Minimal environment facts required by the package image inspectors."""
+
+    def get_python_implementation(self) -> str:
+        """Return the active Python implementation name."""
+
+    def get_python_version(self) -> str:
+        """Return the active Python semantic version."""
+
+    def get_python_abi(self) -> str:
+        """Return the active Python wheel ABI tag."""
+
+    def list_distributions(self) -> tuple[InstalledDistribution, ...]:
+        """Return the installed Python distribution inventory."""
+
+    def get_distribution_version(self, name: str) -> str:
+        """Return one installed distribution version."""
+
+    def find_executable(self, name: str) -> str:
+        """Return one absolute executable path."""
+
+
+class SystemInspectionEnvironment:
+    """Read factual metadata from the environment in which the inspector runs."""
+
+    def get_python_implementation(self) -> str:
+        """Return the normalized active Python implementation."""
+        return platform.python_implementation().casefold()
+
+    def get_python_version(self) -> str:
+        """Return the active Python version."""
+        return platform.python_version()
+
+    def get_python_abi(self) -> str:
+        """Return the active Python wheel ABI tag."""
+        cache_tag = sys.implementation.cache_tag
+        if cache_tag is None:
+            raise ImageInspectionError("active Python does not expose an ABI cache tag")
+        if cache_tag.startswith("cpython-"):
+            return f"cp{cache_tag.removeprefix('cpython-')}"
+        return cache_tag
+
+    def list_distributions(self) -> tuple[InstalledDistribution, ...]:
+        """Return a normalized, deterministic distribution inventory."""
+        versions_by_name: dict[str, str] = {}
+        for distribution in importlib.metadata.distributions():
+            raw_name = distribution.metadata.get("Name")
+            if not raw_name:
+                raise ImageInspectionError("installed distribution is missing its canonical name")
+            name = canonicalize_name(raw_name)
+            existing_version = versions_by_name.setdefault(name, distribution.version)
+            if existing_version != distribution.version:
+                raise ImageInspectionError(f"installed distribution {name!r} has conflicting versions")
+        try:
+            return tuple(
+                InstalledDistribution(name=name, version=version) for name, version in sorted(versions_by_name.items())
+            )
+        except ValidationError as error:
+            raise ImageInspectionError("installed distribution inventory is invalid") from error
+
+    def get_distribution_version(self, name: str) -> str:
+        """Return one installed distribution version with a canonical missing-package error."""
+        try:
+            return importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError as error:
+            raise ImageInspectionError(f"required distribution {name!r} is not installed") from error
+
+    def find_executable(self, name: str) -> str:
+        """Return one resolved executable path with a canonical missing-tool error."""
+        path = shutil.which(name)
+        if path is None:
+            raise ImageInspectionError(f"required executable {name!r} is not installed")
+        executable = Path(path)
+        if not executable.is_absolute():
+            raise ImageInspectionError(f"required executable {name!r} did not resolve to an absolute path")
+        return executable.as_posix()
+
+
+class ClientImageInspector:
+    """Inspect the Python and dependency-installation facts of a client image."""
+
+    def __init__(self, environment: InspectionEnvironment | None = None) -> None:
+        self._environment = environment if environment is not None else SystemInspectionEnvironment()
+
+    def inspect(self, sqsh_sha256: Sha256Digest) -> ImageInspectionRecord:
+        """Return a digest-bound client inspection for the active image environment."""
+        environment = self._environment
+        try:
+            inspection = ClientImageInspection(
+                kind="client",
+                python_implementation=environment.get_python_implementation(),
+                python_version=environment.get_python_version(),
+                python_abi=environment.get_python_abi(),
+                distributions=tuple(sorted(environment.list_distributions(), key=lambda item: item.name)),
+                installer_path=environment.find_executable("pip"),
+                installer_version=environment.get_distribution_version("pip"),
+            )
+            return ImageInspectionRecord(
+                schema_version=1,
+                inspector_version=INSPECTOR_VERSION,
+                sqsh_sha256=sqsh_sha256,
+                inspection=inspection,
+            )
+        except ImageInspectionError:
+            raise
+        except (OSError, ValueError) as error:
+            raise ImageInspectionError("client image inspection produced invalid facts") from error
+
+
+class ServingImageInspector:
+    """Inspect package-owned vLLM runtime facts in a serving image."""
+
+    def __init__(self, environment: InspectionEnvironment | None = None) -> None:
+        self._environment = environment if environment is not None else SystemInspectionEnvironment()
+
+    def inspect(self, sqsh_sha256: Sha256Digest) -> ImageInspectionRecord:
+        """Return a digest-bound serving inspection for the active image environment."""
+        environment = self._environment
+        try:
+            inspection = ServingImageInspection(
+                kind="serving",
+                server_type="vllm",
+                runtime_version=environment.get_distribution_version("vllm"),
+                executable_path=environment.find_executable("vllm"),
+            )
+            return ImageInspectionRecord(
+                schema_version=1,
+                inspector_version=INSPECTOR_VERSION,
+                sqsh_sha256=sqsh_sha256,
+                inspection=inspection,
+            )
+        except ImageInspectionError:
+            raise
+        except (OSError, ValueError) as error:
+            raise ImageInspectionError("serving image inspection produced invalid facts") from error

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
@@ -32,6 +32,11 @@ class RegisteredImage(ContractRecord):
         """Return the factual role discovered by the package inspector."""
         return self.inspection.inspection.kind
 
+    @property
+    def immutable_facts(self) -> tuple[Sha256Digest, Sha256Digest | None, ImageInspectionRecord]:
+        """Return the facts that every alias for this SQSH path must share."""
+        return (self.sqsh_sha256, self.source_oci_digest, self.inspection)
+
     @field_validator("path")
     @classmethod
     def validate_path(cls, value: str) -> str:
@@ -63,7 +68,7 @@ class ImageRegistryDocument(ContractValue):
 
         facts_by_path: dict[str, tuple[Sha256Digest, Sha256Digest | None, ImageInspectionRecord]] = {}
         for image in self.images:
-            facts = (image.sqsh_sha256, image.source_oci_digest, image.inspection)
+            facts = image.immutable_facts
             existing = facts_by_path.setdefault(image.path, facts)
             if existing != facts:
                 raise ValueError("aliases for one SQSH path must share identical immutable facts")

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable records persisted by the Slurm image registry."""
+
+from __future__ import annotations
+
+from pydantic import field_validator, model_validator
+
+from data_designer.slurm.config import ImageInspectionRecord, ImageKind
+from data_designer.slurm.contracts import (
+    ContractRecord,
+    Identifier,
+    SchemaVersion,
+    Sha256Digest,
+    validate_absolute_path,
+)
+
+
+class RegisteredImage(ContractRecord):
+    """One immutable alias binding for a verified SQSH artifact."""
+
+    name: Identifier
+    path: str
+    sqsh_sha256: Sha256Digest
+    source_oci_digest: Sha256Digest | None = None
+    inspection: ImageInspectionRecord
+
+    @property
+    def kind(self) -> ImageKind:
+        """Return the factual role discovered by the package inspector."""
+        return self.inspection.inspection.kind
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        validate_absolute_path(value)
+        if not value.endswith(".sqsh"):
+            raise ValueError("registered image path must end in .sqsh")
+        return value
+
+    @model_validator(mode="after")
+    def validate_inspection_digest(self) -> RegisteredImage:
+        if self.inspection.sqsh_sha256 != self.sqsh_sha256:
+            raise ValueError("image inspection digest does not match the registered SQSH")
+        return self
+
+
+class ImageRegistrySnapshot(ContractRecord):
+    """Complete deterministic image registry state."""
+
+    schema_version: SchemaVersion = 1
+    images: tuple[RegisteredImage, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_images(self) -> ImageRegistrySnapshot:
+        names = tuple(image.name for image in self.images)
+        if names != tuple(sorted(names)):
+            raise ValueError("registered images must be sorted by alias")
+        if len(names) != len(set(names)):
+            raise ValueError("registered image aliases must be unique")
+
+        facts_by_path: dict[str, tuple[Sha256Digest, Sha256Digest | None, ImageInspectionRecord]] = {}
+        for image in self.images:
+            facts = (image.sqsh_sha256, image.source_oci_digest, image.inspection)
+            existing = facts_by_path.setdefault(image.path, facts)
+            if existing != facts:
+                raise ValueError("aliases for one SQSH path must share identical immutable facts")
+        return self

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/records.py
@@ -10,6 +10,7 @@ from pydantic import field_validator, model_validator
 from data_designer.slurm.config import ImageInspectionRecord, ImageKind
 from data_designer.slurm.contracts import (
     ContractRecord,
+    ContractValue,
     Identifier,
     SchemaVersion,
     Sha256Digest,
@@ -46,14 +47,14 @@ class RegisteredImage(ContractRecord):
         return self
 
 
-class ImageRegistrySnapshot(ContractRecord):
-    """Complete deterministic image registry state."""
+class ImageRegistryDocument(ContractValue):
+    """Versioned contents of the package-owned YAML image registry."""
 
-    schema_version: SchemaVersion = 1
+    schema_version: SchemaVersion
     images: tuple[RegisteredImage, ...] = ()
 
     @model_validator(mode="after")
-    def validate_images(self) -> ImageRegistrySnapshot:
+    def validate_images(self) -> ImageRegistryDocument:
         names = tuple(image.name for image in self.images)
         if names != tuple(sorted(names)):
             raise ValueError("registered images must be sorted by alias")

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atomic workspace-derived persistence for immutable Slurm image facts."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from pydantic import TypeAdapter, ValidationError
+
+from data_designer.slurm.config import ImageRef
+from data_designer.slurm.contracts import Identifier, validate_absolute_path
+from data_designer.slurm.images.errors import ImageConflictError, ImageNotFoundError, ImageRegistryError
+from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
+
+_DIRECTORY_MODE = 0o700
+_FILE_MODE = 0o600
+_IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
+
+
+class ImageRegistry:
+    """Persist image aliases beneath one explicitly selected shared workspace."""
+
+    def __init__(self, workspace_root: str | Path) -> None:
+        try:
+            normalized_root = validate_absolute_path(Path(workspace_root).as_posix())
+        except ValueError as error:
+            raise ImageRegistryError(f"invalid image workspace root {workspace_root!s}") from error
+        self._image_root = Path(normalized_root) / "images"
+        self._registry_path = self._image_root / "registry.json"
+        self._lock_directory = self._image_root / ".locks"
+
+    @property
+    def image_root(self) -> Path:
+        """Return the workspace-derived image root."""
+        return self._image_root
+
+    @property
+    def registry_path(self) -> Path:
+        """Return the workspace-derived registry record path."""
+        return self._registry_path
+
+    def list_images(self) -> tuple[RegisteredImage, ...]:
+        """Return all registered aliases in deterministic order."""
+        return self._load().images
+
+    def get_by_name(self, name: Identifier) -> RegisteredImage:
+        """Return one registered alias."""
+        name = validate_image_alias(name)
+        for image in self._load().images:
+            if image.name == name:
+                return image
+        raise ImageNotFoundError(f"image alias {name!r} is not registered")
+
+    def get_by_path(self, path: str | Path) -> RegisteredImage:
+        """Return immutable facts for one registered absolute SQSH path."""
+        try:
+            normalized_path = ImageRef(path=Path(path).as_posix()).path
+        except ValidationError as error:
+            raise ImageRegistryError(f"invalid registered image path {path!s}") from error
+        assert normalized_path is not None
+        matches = tuple(image for image in self._load().images if image.path == normalized_path)
+        if not matches:
+            raise ImageNotFoundError(f"image path {normalized_path!r} is not registered")
+        return matches[0]
+
+    def register(self, image: RegisteredImage, *, replace: bool = False) -> RegisteredImage:
+        """Atomically add or explicitly replace one image alias."""
+        self._ensure_storage()
+        with (
+            acquire_file_lock(self._get_alias_lock_path(image.name)),
+            acquire_file_lock(self._get_registry_lock_path()),
+        ):
+            snapshot = self._load()
+            existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
+            if existing is not None and not replace:
+                raise ImageConflictError(f"image alias {image.name!r} is already registered")
+            self._validate_path_facts(snapshot, image, replacing=existing)
+            images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
+            updated = ImageRegistrySnapshot(images=tuple(sorted(images, key=lambda entry: entry.name)))
+            self._save(updated)
+        return image
+
+    def unregister(self, name: Identifier) -> RegisteredImage:
+        """Atomically remove an alias without deleting its underlying SQSH artifact."""
+        name = validate_image_alias(name)
+        self._ensure_storage()
+        with acquire_file_lock(self._get_alias_lock_path(name)), acquire_file_lock(self._get_registry_lock_path()):
+            snapshot = self._load()
+            try:
+                removed = next(image for image in snapshot.images if image.name == name)
+            except StopIteration:
+                raise ImageNotFoundError(f"image alias {name!r} is not registered") from None
+            updated = ImageRegistrySnapshot(images=tuple(image for image in snapshot.images if image.name != name))
+            self._save(updated)
+        return removed
+
+    def _load(self) -> ImageRegistrySnapshot:
+        if not self._registry_path.exists():
+            return ImageRegistrySnapshot()
+        try:
+            return ImageRegistrySnapshot.model_validate_json(self._registry_path.read_text())
+        except (OSError, ValidationError) as error:
+            raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
+
+    def _save(self, snapshot: ImageRegistrySnapshot) -> None:
+        temporary_path: Path | None = None
+        descriptor: int | None = None
+        try:
+            descriptor, raw_path = tempfile.mkstemp(
+                dir=self._image_root,
+                prefix=".registry.",
+                suffix=".tmp",
+                text=True,
+            )
+            temporary_path = Path(raw_path)
+            os.fchmod(descriptor, _FILE_MODE)
+            output = os.fdopen(descriptor, "w")
+            descriptor = None
+            with output:
+                output.write(snapshot.serialize_json())
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary_path, self._registry_path)
+            _sync_directory(self._image_root)
+        except OSError as error:
+            raise ImageRegistryError(f"cannot persist image registry {self._registry_path}") from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+    def _ensure_storage(self) -> None:
+        try:
+            self._image_root.mkdir(mode=_DIRECTORY_MODE, parents=True, exist_ok=True)
+            self._lock_directory.mkdir(mode=_DIRECTORY_MODE, parents=True, exist_ok=True)
+        except OSError as error:
+            raise ImageRegistryError(f"cannot initialize image registry beneath {self._image_root}") from error
+
+    def _get_alias_lock_path(self, name: Identifier) -> Path:
+        return self._lock_directory / f"alias-{name}.lock"
+
+    def _get_registry_lock_path(self) -> Path:
+        return self._lock_directory / "registry.lock"
+
+    @staticmethod
+    def _validate_path_facts(
+        snapshot: ImageRegistrySnapshot,
+        image: RegisteredImage,
+        *,
+        replacing: RegisteredImage | None,
+    ) -> None:
+        for existing in snapshot.images:
+            if replacing is not None and existing.name == replacing.name:
+                continue
+            if existing.path != image.path:
+                continue
+            existing_facts = (existing.sqsh_sha256, existing.source_oci_digest, existing.inspection)
+            new_facts = (image.sqsh_sha256, image.source_oci_digest, image.inspection)
+            if existing_facts != new_facts:
+                raise ImageConflictError(f"image path {image.path!r} already has different immutable facts")
+
+
+@contextmanager
+def acquire_file_lock(path: Path) -> Iterator[None]:
+    """Acquire one exclusive advisory file lock for a registry mutation."""
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, os.O_CREAT | os.O_RDWR, _FILE_MODE)
+        os.fchmod(descriptor, _FILE_MODE)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise ImageRegistryError(f"cannot lock image registry target {path}") from error
+
+    try:
+        yield
+    finally:
+        assert descriptor is not None
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+def validate_image_alias(name: str) -> Identifier:
+    """Validate an image alias before deriving any filesystem path from it."""
+    try:
+        return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
+    except ValidationError as error:
+        raise ImageRegistryError(f"invalid image alias {name!r}") from error
+
+
+def _sync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import stat
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -107,9 +108,9 @@ class ImageRegistry:
         if not self._registry_path.exists():
             return ImageRegistrySnapshot()
         try:
-            payload = yaml.safe_load(self._registry_path.read_text())
+            payload = yaml.safe_load(_read_regular_text(self._registry_path))
             return ImageRegistrySnapshot.model_validate_json(json.dumps(payload))
-        except (OSError, TypeError, ValidationError, yaml.YAMLError) as error:
+        except (OSError, TypeError, UnicodeError, ValidationError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
     def _save(self, snapshot: ImageRegistrySnapshot) -> None:
@@ -124,7 +125,7 @@ class ImageRegistry:
             )
             temporary_path = Path(raw_path)
             os.fchmod(descriptor, _FILE_MODE)
-            output = os.fdopen(descriptor, "w")
+            output = os.fdopen(descriptor, "w", encoding="utf-8")
             descriptor = None
             with output:
                 yaml.safe_dump(
@@ -184,7 +185,7 @@ def acquire_file_lock(path: Path) -> Iterator[None]:
     """Acquire one exclusive advisory file lock for a registry mutation."""
     descriptor: int | None = None
     try:
-        descriptor = os.open(path, os.O_CREAT | os.O_RDWR, _FILE_MODE)
+        descriptor = os.open(path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), _FILE_MODE)
         os.fchmod(descriptor, _FILE_MODE)
         fcntl.flock(descriptor, fcntl.LOCK_EX)
     except OSError as error:
@@ -216,3 +217,18 @@ def _sync_directory(path: Path) -> None:
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
+
+
+def _read_regular_text(path: Path) -> str:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
+        descriptor = None
+        with registry_file:
+            if not stat.S_ISREG(os.fstat(registry_file.fileno()).st_mode):
+                raise OSError(f"registry path {path} is not a regular file")
+            return registry_file.read()
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -23,7 +23,6 @@ from data_designer.slurm.images.errors import (
     ImageConflictError,
     ImageNotFoundError,
     ImageRegistryError,
-    ImageVerificationError,
 )
 from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
 
@@ -82,14 +81,10 @@ class ImageRegistry:
         self,
         image: RegisteredImage,
         *,
-        verify_persisted: Callable[[RegisteredImage], None],
+        verify_before_publish: Callable[[RegisteredImage], None],
         replace: bool = False,
     ) -> RegisteredImage:
-        """Atomically add or explicitly replace one verified image alias.
-
-        The persisted alias is rolled back while its mutation locks remain held
-        if final artifact verification fails.
-        """
+        """Atomically add or explicitly replace one verified image alias."""
         self._ensure_storage()
         with (
             acquire_file_lock(self._get_alias_lock_path(image.name)),
@@ -102,12 +97,8 @@ class ImageRegistry:
             self._validate_path_facts(snapshot, image, replacing=existing)
             images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
             updated = ImageRegistrySnapshot(images=tuple(sorted(images, key=lambda entry: entry.name)))
+            verify_before_publish(image)
             self._save(updated)
-            try:
-                verify_persisted(image)
-            except ImageVerificationError:
-                self._save(snapshot)
-                raise
         return image
 
     def unregister(self, name: Identifier) -> RegisteredImage:
@@ -130,7 +121,7 @@ class ImageRegistry:
             return ImageRegistrySnapshot.model_validate_json(json.dumps(payload))
         except FileNotFoundError:
             return ImageRegistrySnapshot()
-        except (OSError, TypeError, UnicodeError, ValidationError, yaml.YAMLError) as error:
+        except (OSError, RecursionError, TypeError, UnicodeError, ValueError, ValidationError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
     def _save(self, snapshot: ImageRegistrySnapshot) -> None:
@@ -171,8 +162,8 @@ class ImageRegistry:
 
     def _ensure_storage(self) -> None:
         try:
-            self._image_root.mkdir(mode=_DIRECTORY_MODE, parents=True, exist_ok=True)
-            self._lock_directory.mkdir(mode=_DIRECTORY_MODE, parents=True, exist_ok=True)
+            _ensure_private_directory(self._image_root, parents=True)
+            _ensure_private_directory(self._lock_directory, parents=False)
         except OSError as error:
             raise ImageRegistryError(f"cannot initialize image registry beneath {self._image_root}") from error
 
@@ -239,6 +230,26 @@ def _sync_directory(path: Path) -> None:
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
+
+
+def _ensure_private_directory(path: Path, *, parents: bool) -> None:
+    path.mkdir(mode=_DIRECTORY_MODE, parents=parents, exist_ok=True)
+    descriptor: int | None = None
+    try:
+        before_open = path.lstat()
+        if not stat.S_ISDIR(before_open.st_mode):
+            raise OSError(f"registry directory {path} is not a directory")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry directory {path} changed while it was being opened")
+        if not stat.S_ISDIR(after_open.st_mode):
+            raise OSError(f"registry directory {path} is not a directory")
+        os.fchmod(descriptor, _DIRECTORY_MODE)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
 
 
 def _read_regular_text(path: Path) -> str:

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -5,11 +5,8 @@
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
-import secrets
-import stat
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -27,10 +24,16 @@ from data_designer.slurm.images.errors import (
     ImageNotFoundError,
     ImageRegistryError,
 )
+from data_designer.slurm.images.filesystem import (
+    acquire_file_lock,
+    create_temporary_file,
+    ensure_private_directory,
+    open_verified_child_directory,
+    open_verified_directory,
+    read_regular_text,
+)
 from data_designer.slurm.images.records import ImageRegistryDocument, RegisteredImage
 
-_DIRECTORY_MODE = 0o700
-_FILE_MODE = 0o600
 _LOCK_DIRECTORY_NAME = ".locks"
 _REGISTRY_FILENAME = "registry.yaml"
 _REGISTRY_LOCK_FILENAME = "registry.lock"
@@ -95,12 +98,12 @@ class ImageRegistryStore:
         alias_lock_name = f"alias-{image.name}.lock"
         with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
             with (
-                _acquire_file_lock(
+                acquire_file_lock(
                     lock_directory_descriptor,
                     alias_lock_name,
                     self._lock_directory / alias_lock_name,
                 ),
-                _acquire_file_lock(
+                acquire_file_lock(
                     lock_directory_descriptor,
                     _REGISTRY_LOCK_FILENAME,
                     self._lock_directory / _REGISTRY_LOCK_FILENAME,
@@ -130,12 +133,12 @@ class ImageRegistryStore:
         alias_lock_name = f"alias-{name}.lock"
         with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
             with (
-                _acquire_file_lock(
+                acquire_file_lock(
                     lock_directory_descriptor,
                     alias_lock_name,
                     self._lock_directory / alias_lock_name,
                 ),
-                _acquire_file_lock(
+                acquire_file_lock(
                     lock_directory_descriptor,
                     _REGISTRY_LOCK_FILENAME,
                     self._lock_directory / _REGISTRY_LOCK_FILENAME,
@@ -155,7 +158,7 @@ class ImageRegistryStore:
 
     def _load(self) -> ImageRegistryDocument:
         try:
-            with _open_verified_directory(self._image_root) as image_root_descriptor:
+            with open_verified_directory(self._image_root) as image_root_descriptor:
                 return self._load_from_directory(image_root_descriptor)
         except FileNotFoundError:
             return ImageRegistryDocument(schema_version=1)
@@ -165,7 +168,7 @@ class ImageRegistryStore:
     def _load_from_directory(self, image_root_descriptor: int) -> ImageRegistryDocument:
         try:
             payload = yaml.load(
-                _read_regular_text(image_root_descriptor, _REGISTRY_FILENAME, self._registry_path),
+                read_regular_text(image_root_descriptor, _REGISTRY_FILENAME, self._registry_path),
                 Loader=_UniqueKeySafeLoader,
             )
             return ImageRegistryDocument.model_validate_json(json.dumps(payload))
@@ -184,8 +187,11 @@ class ImageRegistryStore:
         temporary_name: str | None = None
         descriptor: int | None = None
         try:
-            descriptor, temporary_name = _create_temporary_file(image_root_descriptor)
-            os.fchmod(descriptor, _FILE_MODE)
+            descriptor, temporary_name = create_temporary_file(
+                image_root_descriptor,
+                prefix=".registry.",
+                suffix=".tmp",
+            )
             output = os.fdopen(descriptor, "w", encoding="utf-8")
             descriptor = None
             with output:
@@ -219,16 +225,16 @@ class ImageRegistryStore:
 
     def _ensure_storage(self) -> None:
         try:
-            _ensure_private_directory(self._image_root, parents=True)
-            _ensure_private_directory(self._lock_directory, parents=False)
+            ensure_private_directory(self._image_root, parents=True)
+            ensure_private_directory(self._lock_directory, parents=False)
         except OSError as error:
             raise ImageRegistryError(f"cannot initialize image registry beneath {self._image_root}") from error
 
     @contextmanager
     def _open_storage(self) -> Iterator[tuple[int, int]]:
         try:
-            with _open_verified_directory(self._image_root) as image_root_descriptor:
-                with _open_verified_child_directory(
+            with open_verified_directory(self._image_root) as image_root_descriptor:
+                with open_verified_child_directory(
                     image_root_descriptor,
                     _LOCK_DIRECTORY_NAME,
                     self._lock_directory,
@@ -288,138 +294,9 @@ def _construct_unique_mapping(
 _UniqueKeySafeLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping)
 
 
-@contextmanager
-def _acquire_file_lock(directory_descriptor: int, name: str, display_path: Path) -> Iterator[None]:
-    """Acquire one exclusive advisory file lock for a registry mutation."""
-    descriptor: int | None = None
-    try:
-        # macOS can report ENOENT to the losing openat(O_CREAT) caller when two
-        # processes create the same lock file concurrently. Retrying then opens
-        # the winner's regular file with the same no-follow boundary.
-        for _ in range(10):
-            try:
-                descriptor = os.open(
-                    name,
-                    os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
-                    _FILE_MODE,
-                    dir_fd=directory_descriptor,
-                )
-            except FileNotFoundError:
-                continue
-            break
-        if descriptor is None:
-            raise OSError(f"lock path {display_path} could not be opened")
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            raise OSError(f"lock path {display_path} is not a regular file")
-        os.fchmod(descriptor, _FILE_MODE)
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-    except OSError as error:
-        if descriptor is not None:
-            os.close(descriptor)
-        raise ImageRegistryError(f"cannot lock image registry target {display_path}") from error
-
-    try:
-        yield
-    finally:
-        assert descriptor is not None
-        try:
-            fcntl.flock(descriptor, fcntl.LOCK_UN)
-        finally:
-            os.close(descriptor)
-
-
 def _validate_image_alias(name: str) -> Identifier:
     """Validate an image alias before deriving any filesystem path from it."""
     try:
         return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
     except ValidationError as error:
         raise ImageRegistryError(f"invalid image alias {name!r}") from error
-
-
-def _ensure_private_directory(path: Path, *, parents: bool) -> None:
-    path.mkdir(mode=_DIRECTORY_MODE, parents=parents, exist_ok=True)
-    with _open_verified_directory(path) as descriptor:
-        os.fchmod(descriptor, _DIRECTORY_MODE)
-
-
-@contextmanager
-def _open_verified_directory(path: Path) -> Iterator[int]:
-    descriptor: int | None = None
-    try:
-        before_open = path.lstat()
-        if not stat.S_ISDIR(before_open.st_mode):
-            raise OSError(f"registry directory {path} is not a directory")
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(path, flags)
-        after_open = os.fstat(descriptor)
-        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
-            raise OSError(f"registry directory {path} changed while it was being opened")
-        if not stat.S_ISDIR(after_open.st_mode):
-            raise OSError(f"registry directory {path} is not a directory")
-        yield descriptor
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
-
-
-@contextmanager
-def _open_verified_child_directory(
-    parent_descriptor: int,
-    name: str,
-    display_path: Path,
-) -> Iterator[int]:
-    descriptor: int | None = None
-    try:
-        before_open = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
-        if not stat.S_ISDIR(before_open.st_mode):
-            raise OSError(f"registry directory {display_path} is not a directory")
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(name, flags, dir_fd=parent_descriptor)
-        after_open = os.fstat(descriptor)
-        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
-            raise OSError(f"registry directory {display_path} changed while it was being opened")
-        if not stat.S_ISDIR(after_open.st_mode):
-            raise OSError(f"registry directory {display_path} is not a directory")
-        yield descriptor
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
-
-
-def _create_temporary_file(directory_descriptor: int) -> tuple[int, str]:
-    for _ in range(100):
-        name = f".registry.{secrets.token_hex(8)}.tmp"
-        try:
-            descriptor = os.open(
-                name,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-                _FILE_MODE,
-                dir_fd=directory_descriptor,
-            )
-        except FileExistsError:
-            continue
-        return descriptor, name
-    raise OSError("cannot allocate a unique registry snapshot name")
-
-
-def _read_regular_text(directory_descriptor: int, name: str, display_path: Path) -> str:
-    descriptor: int | None = None
-    try:
-        before_open = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
-        if not stat.S_ISREG(before_open.st_mode):
-            raise OSError(f"registry path {display_path} is not a regular file")
-        descriptor = os.open(
-            name,
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
-            dir_fd=directory_descriptor,
-        )
-        after_open = os.fstat(descriptor)
-        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
-            raise OSError(f"registry path {display_path} changed while it was being opened")
-        registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
-        descriptor = None
-        with registry_file:
-            return registry_file.read()
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -16,6 +16,9 @@ from pathlib import Path
 
 import yaml
 from pydantic import TypeAdapter, ValidationError
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+from yaml.resolver import BaseResolver
 
 from data_designer.slurm.config import ImageRef
 from data_designer.slurm.contracts import Identifier, validate_absolute_path
@@ -24,14 +27,14 @@ from data_designer.slurm.images.errors import (
     ImageNotFoundError,
     ImageRegistryError,
 )
-from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
+from data_designer.slurm.images.records import ImageRegistryDocument, RegisteredImage
 
 _DIRECTORY_MODE = 0o700
 _FILE_MODE = 0o600
 _IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 
 
-class ImageRegistry:
+class ImageRegistryStore:
     """Persist image aliases beneath one explicitly selected shared workspace."""
 
     def __init__(self, workspace_root: str | Path) -> None:
@@ -59,7 +62,7 @@ class ImageRegistry:
 
     def get_by_name(self, name: Identifier) -> RegisteredImage:
         """Return one registered alias."""
-        name = validate_image_alias(name)
+        name = _validate_image_alias(name)
         for image in self._load().images:
             if image.name == name:
                 return image
@@ -87,8 +90,8 @@ class ImageRegistry:
         """Atomically add or explicitly replace one verified image alias."""
         self._ensure_storage()
         with (
-            acquire_file_lock(self._get_alias_lock_path(image.name)),
-            acquire_file_lock(self._get_registry_lock_path()),
+            _acquire_file_lock(self._get_alias_lock_path(image.name)),
+            _acquire_file_lock(self._get_registry_lock_path()),
         ):
             snapshot = self._load()
             existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
@@ -96,35 +99,52 @@ class ImageRegistry:
                 raise ImageConflictError(f"image alias {image.name!r} is already registered")
             self._validate_path_facts(snapshot, image, replacing=existing)
             images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
-            updated = ImageRegistrySnapshot(images=tuple(sorted(images, key=lambda entry: entry.name)))
-            verify_before_publish(image)
-            self._save(updated)
+            updated = ImageRegistryDocument(
+                schema_version=1,
+                images=tuple(sorted(images, key=lambda entry: entry.name)),
+            )
+            self._save(updated, verify_before_publish=lambda: verify_before_publish(image))
         return image
 
     def unregister(self, name: Identifier) -> RegisteredImage:
         """Atomically remove an alias without deleting its underlying SQSH artifact."""
-        name = validate_image_alias(name)
+        name = _validate_image_alias(name)
         self._ensure_storage()
-        with acquire_file_lock(self._get_alias_lock_path(name)), acquire_file_lock(self._get_registry_lock_path()):
+        with _acquire_file_lock(self._get_alias_lock_path(name)), _acquire_file_lock(self._get_registry_lock_path()):
             snapshot = self._load()
             try:
                 removed = next(image for image in snapshot.images if image.name == name)
             except StopIteration:
                 raise ImageNotFoundError(f"image alias {name!r} is not registered") from None
-            updated = ImageRegistrySnapshot(images=tuple(image for image in snapshot.images if image.name != name))
+            updated = ImageRegistryDocument(
+                schema_version=1,
+                images=tuple(image for image in snapshot.images if image.name != name),
+            )
             self._save(updated)
         return removed
 
-    def _load(self) -> ImageRegistrySnapshot:
+    def _load(self) -> ImageRegistryDocument:
         try:
-            payload = yaml.safe_load(_read_regular_text(self._registry_path))
-            return ImageRegistrySnapshot.model_validate_json(json.dumps(payload))
+            with _open_verified_directory(self._image_root):
+                pass
         except FileNotFoundError:
-            return ImageRegistrySnapshot()
+            return ImageRegistryDocument(schema_version=1)
+        except OSError as error:
+            raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
+        try:
+            payload = yaml.load(_read_regular_text(self._registry_path), Loader=_UniqueKeySafeLoader)
+            return ImageRegistryDocument.model_validate_json(json.dumps(payload))
+        except FileNotFoundError:
+            return ImageRegistryDocument(schema_version=1)
         except (OSError, RecursionError, TypeError, UnicodeError, ValueError, ValidationError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
-    def _save(self, snapshot: ImageRegistrySnapshot) -> None:
+    def _save(
+        self,
+        snapshot: ImageRegistryDocument,
+        *,
+        verify_before_publish: Callable[[], None] | None = None,
+    ) -> None:
         temporary_path: Path | None = None
         descriptor: int | None = None
         try:
@@ -147,6 +167,8 @@ class ImageRegistry:
                 )
                 output.flush()
                 os.fsync(output.fileno())
+            if verify_before_publish is not None:
+                verify_before_publish()
             os.replace(temporary_path, self._registry_path)
             _sync_directory(self._image_root)
         except (OSError, TypeError, yaml.YAMLError) as error:
@@ -175,7 +197,7 @@ class ImageRegistry:
 
     @staticmethod
     def _validate_path_facts(
-        snapshot: ImageRegistrySnapshot,
+        snapshot: ImageRegistryDocument,
         image: RegisteredImage,
         *,
         replacing: RegisteredImage | None,
@@ -191,8 +213,43 @@ class ImageRegistry:
                 raise ImageConflictError(f"image path {image.path!r} already has different immutable facts")
 
 
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects ambiguous duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader,
+    node: MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as error:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from error
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping)
+
+
 @contextmanager
-def acquire_file_lock(path: Path) -> Iterator[None]:
+def _acquire_file_lock(path: Path) -> Iterator[None]:
     """Acquire one exclusive advisory file lock for a registry mutation."""
     descriptor: int | None = None
     try:
@@ -216,7 +273,7 @@ def acquire_file_lock(path: Path) -> Iterator[None]:
             os.close(descriptor)
 
 
-def validate_image_alias(name: str) -> Identifier:
+def _validate_image_alias(name: str) -> Identifier:
     """Validate an image alias before deriving any filesystem path from it."""
     try:
         return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
@@ -225,15 +282,18 @@ def validate_image_alias(name: str) -> Identifier:
 
 
 def _sync_directory(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY)
-    try:
+    with _open_verified_directory(path) as descriptor:
         os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
 
 
 def _ensure_private_directory(path: Path, *, parents: bool) -> None:
     path.mkdir(mode=_DIRECTORY_MODE, parents=parents, exist_ok=True)
+    with _open_verified_directory(path) as descriptor:
+        os.fchmod(descriptor, _DIRECTORY_MODE)
+
+
+@contextmanager
+def _open_verified_directory(path: Path) -> Iterator[int]:
     descriptor: int | None = None
     try:
         before_open = path.lstat()
@@ -246,7 +306,7 @@ def _ensure_private_directory(path: Path, *, parents: bool) -> None:
             raise OSError(f"registry directory {path} changed while it was being opened")
         if not stat.S_ISDIR(after_open.st_mode):
             raise OSError(f"registry directory {path} is not a directory")
-        os.fchmod(descriptor, _DIRECTORY_MODE)
+        yield descriptor
     finally:
         if descriptor is not None:
             os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -10,7 +10,7 @@ import json
 import os
 import stat
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -19,7 +19,12 @@ from pydantic import TypeAdapter, ValidationError
 
 from data_designer.slurm.config import ImageRef
 from data_designer.slurm.contracts import Identifier, validate_absolute_path
-from data_designer.slurm.images.errors import ImageConflictError, ImageNotFoundError, ImageRegistryError
+from data_designer.slurm.images.errors import (
+    ImageConflictError,
+    ImageNotFoundError,
+    ImageRegistryError,
+    ImageVerificationError,
+)
 from data_designer.slurm.images.records import ImageRegistrySnapshot, RegisteredImage
 
 _DIRECTORY_MODE = 0o700
@@ -73,8 +78,18 @@ class ImageRegistry:
             raise ImageNotFoundError(f"image path {normalized_path!r} is not registered")
         return matches[0]
 
-    def register(self, image: RegisteredImage, *, replace: bool = False) -> RegisteredImage:
-        """Atomically add or explicitly replace one image alias."""
+    def register(
+        self,
+        image: RegisteredImage,
+        *,
+        verify_persisted: Callable[[RegisteredImage], None],
+        replace: bool = False,
+    ) -> RegisteredImage:
+        """Atomically add or explicitly replace one verified image alias.
+
+        The persisted alias is rolled back while its mutation locks remain held
+        if final artifact verification fails.
+        """
         self._ensure_storage()
         with (
             acquire_file_lock(self._get_alias_lock_path(image.name)),
@@ -88,6 +103,11 @@ class ImageRegistry:
             images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
             updated = ImageRegistrySnapshot(images=tuple(sorted(images, key=lambda entry: entry.name)))
             self._save(updated)
+            try:
+                verify_persisted(image)
+            except ImageVerificationError:
+                self._save(snapshot)
+                raise
         return image
 
     def unregister(self, name: Identifier) -> RegisteredImage:

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import fcntl
+import json
 import os
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+import yaml
 from pydantic import TypeAdapter, ValidationError
 
 from data_designer.slurm.config import ImageRef
@@ -33,7 +35,7 @@ class ImageRegistry:
         except ValueError as error:
             raise ImageRegistryError(f"invalid image workspace root {workspace_root!s}") from error
         self._image_root = Path(normalized_root) / "images"
-        self._registry_path = self._image_root / "registry.json"
+        self._registry_path = self._image_root / "registry.yaml"
         self._lock_directory = self._image_root / ".locks"
 
     @property
@@ -105,8 +107,9 @@ class ImageRegistry:
         if not self._registry_path.exists():
             return ImageRegistrySnapshot()
         try:
-            return ImageRegistrySnapshot.model_validate_json(self._registry_path.read_text())
-        except (OSError, ValidationError) as error:
+            payload = yaml.safe_load(self._registry_path.read_text())
+            return ImageRegistrySnapshot.model_validate_json(json.dumps(payload))
+        except (OSError, TypeError, ValidationError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
     def _save(self, snapshot: ImageRegistrySnapshot) -> None:
@@ -124,12 +127,17 @@ class ImageRegistry:
             output = os.fdopen(descriptor, "w")
             descriptor = None
             with output:
-                output.write(snapshot.serialize_json())
+                yaml.safe_dump(
+                    snapshot.model_dump(mode="json"),
+                    output,
+                    default_flow_style=False,
+                    sort_keys=True,
+                )
                 output.flush()
                 os.fsync(output.fileno())
             os.replace(temporary_path, self._registry_path)
             _sync_directory(self._image_root)
-        except OSError as error:
+        except (OSError, TypeError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot persist image registry {self._registry_path}") from error
         finally:
             if descriptor is not None:

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -105,11 +105,11 @@ class ImageRegistry:
         return removed
 
     def _load(self) -> ImageRegistrySnapshot:
-        if not self._registry_path.exists():
-            return ImageRegistrySnapshot()
         try:
             payload = yaml.safe_load(_read_regular_text(self._registry_path))
             return ImageRegistrySnapshot.model_validate_json(json.dumps(payload))
+        except FileNotFoundError:
+            return ImageRegistrySnapshot()
         except (OSError, TypeError, UnicodeError, ValidationError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
@@ -186,6 +186,8 @@ def acquire_file_lock(path: Path) -> Iterator[None]:
     descriptor: int | None = None
     try:
         descriptor = os.open(path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), _FILE_MODE)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"lock path {path} is not a regular file")
         os.fchmod(descriptor, _FILE_MODE)
         fcntl.flock(descriptor, fcntl.LOCK_EX)
     except OSError as error:
@@ -222,12 +224,16 @@ def _sync_directory(path: Path) -> None:
 def _read_regular_text(path: Path) -> str:
     descriptor: int | None = None
     try:
+        before_open = path.lstat()
+        if not stat.S_ISREG(before_open.st_mode):
+            raise OSError(f"registry path {path} is not a regular file")
         descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry path {path} changed while it was being opened")
         registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
         descriptor = None
         with registry_file:
-            if not stat.S_ISREG(os.fstat(registry_file.fileno()).st_mode):
-                raise OSError(f"registry path {path} is not a regular file")
             return registry_file.read()
     finally:
         if descriptor is not None:

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import secrets
 import stat
-import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -31,6 +31,9 @@ from data_designer.slurm.images.records import ImageRegistryDocument, Registered
 
 _DIRECTORY_MODE = 0o700
 _FILE_MODE = 0o600
+_LOCK_DIRECTORY_NAME = ".locks"
+_REGISTRY_FILENAME = "registry.yaml"
+_REGISTRY_LOCK_FILENAME = "registry.lock"
 _IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 
 
@@ -43,8 +46,8 @@ class ImageRegistryStore:
         except ValueError as error:
             raise ImageRegistryError(f"invalid image workspace root {workspace_root!s}") from error
         self._image_root = Path(normalized_root) / "images"
-        self._registry_path = self._image_root / "registry.yaml"
-        self._lock_directory = self._image_root / ".locks"
+        self._registry_path = self._image_root / _REGISTRY_FILENAME
+        self._lock_directory = self._image_root / _LOCK_DIRECTORY_NAME
 
     @property
     def image_root(self) -> Path:
@@ -89,50 +92,82 @@ class ImageRegistryStore:
     ) -> RegisteredImage:
         """Atomically add or explicitly replace one verified image alias."""
         self._ensure_storage()
-        with (
-            _acquire_file_lock(self._get_alias_lock_path(image.name)),
-            _acquire_file_lock(self._get_registry_lock_path()),
-        ):
-            snapshot = self._load()
-            existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
-            if existing is not None and not replace:
-                raise ImageConflictError(f"image alias {image.name!r} is already registered")
-            self._validate_path_facts(snapshot, image, replacing=existing)
-            images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
-            updated = ImageRegistryDocument(
-                schema_version=1,
-                images=tuple(sorted(images, key=lambda entry: entry.name)),
-            )
-            self._save(updated, verify_before_publish=lambda: verify_before_publish(image))
+        alias_lock_name = f"alias-{image.name}.lock"
+        with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
+            with (
+                _acquire_file_lock(
+                    lock_directory_descriptor,
+                    alias_lock_name,
+                    self._lock_directory / alias_lock_name,
+                ),
+                _acquire_file_lock(
+                    lock_directory_descriptor,
+                    _REGISTRY_LOCK_FILENAME,
+                    self._lock_directory / _REGISTRY_LOCK_FILENAME,
+                ),
+            ):
+                snapshot = self._load_from_directory(image_root_descriptor)
+                existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
+                if existing is not None and not replace:
+                    raise ImageConflictError(f"image alias {image.name!r} is already registered")
+                self._validate_path_facts(snapshot, image, replacing=existing)
+                images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
+                updated = ImageRegistryDocument(
+                    schema_version=1,
+                    images=tuple(sorted(images, key=lambda entry: entry.name)),
+                )
+                self._save(
+                    image_root_descriptor,
+                    updated,
+                    verify_before_publish=lambda: verify_before_publish(image),
+                )
         return image
 
     def unregister(self, name: Identifier) -> RegisteredImage:
         """Atomically remove an alias without deleting its underlying SQSH artifact."""
         name = _validate_image_alias(name)
         self._ensure_storage()
-        with _acquire_file_lock(self._get_alias_lock_path(name)), _acquire_file_lock(self._get_registry_lock_path()):
-            snapshot = self._load()
-            try:
-                removed = next(image for image in snapshot.images if image.name == name)
-            except StopIteration:
-                raise ImageNotFoundError(f"image alias {name!r} is not registered") from None
-            updated = ImageRegistryDocument(
-                schema_version=1,
-                images=tuple(image for image in snapshot.images if image.name != name),
-            )
-            self._save(updated)
+        alias_lock_name = f"alias-{name}.lock"
+        with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
+            with (
+                _acquire_file_lock(
+                    lock_directory_descriptor,
+                    alias_lock_name,
+                    self._lock_directory / alias_lock_name,
+                ),
+                _acquire_file_lock(
+                    lock_directory_descriptor,
+                    _REGISTRY_LOCK_FILENAME,
+                    self._lock_directory / _REGISTRY_LOCK_FILENAME,
+                ),
+            ):
+                snapshot = self._load_from_directory(image_root_descriptor)
+                try:
+                    removed = next(image for image in snapshot.images if image.name == name)
+                except StopIteration:
+                    raise ImageNotFoundError(f"image alias {name!r} is not registered") from None
+                updated = ImageRegistryDocument(
+                    schema_version=1,
+                    images=tuple(image for image in snapshot.images if image.name != name),
+                )
+                self._save(image_root_descriptor, updated)
         return removed
 
     def _load(self) -> ImageRegistryDocument:
         try:
-            with _open_verified_directory(self._image_root):
-                pass
+            with _open_verified_directory(self._image_root) as image_root_descriptor:
+                return self._load_from_directory(image_root_descriptor)
         except FileNotFoundError:
             return ImageRegistryDocument(schema_version=1)
         except OSError as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
+
+    def _load_from_directory(self, image_root_descriptor: int) -> ImageRegistryDocument:
         try:
-            payload = yaml.load(_read_regular_text(self._registry_path), Loader=_UniqueKeySafeLoader)
+            payload = yaml.load(
+                _read_regular_text(image_root_descriptor, _REGISTRY_FILENAME, self._registry_path),
+                Loader=_UniqueKeySafeLoader,
+            )
             return ImageRegistryDocument.model_validate_json(json.dumps(payload))
         except FileNotFoundError:
             return ImageRegistryDocument(schema_version=1)
@@ -141,20 +176,15 @@ class ImageRegistryStore:
 
     def _save(
         self,
+        image_root_descriptor: int,
         snapshot: ImageRegistryDocument,
         *,
         verify_before_publish: Callable[[], None] | None = None,
     ) -> None:
-        temporary_path: Path | None = None
+        temporary_name: str | None = None
         descriptor: int | None = None
         try:
-            descriptor, raw_path = tempfile.mkstemp(
-                dir=self._image_root,
-                prefix=".registry.",
-                suffix=".tmp",
-                text=True,
-            )
-            temporary_path = Path(raw_path)
+            descriptor, temporary_name = _create_temporary_file(image_root_descriptor)
             os.fchmod(descriptor, _FILE_MODE)
             output = os.fdopen(descriptor, "w", encoding="utf-8")
             descriptor = None
@@ -169,16 +199,21 @@ class ImageRegistryStore:
                 os.fsync(output.fileno())
             if verify_before_publish is not None:
                 verify_before_publish()
-            os.replace(temporary_path, self._registry_path)
-            _sync_directory(self._image_root)
+            os.replace(
+                temporary_name,
+                _REGISTRY_FILENAME,
+                src_dir_fd=image_root_descriptor,
+                dst_dir_fd=image_root_descriptor,
+            )
+            os.fsync(image_root_descriptor)
         except (OSError, TypeError, yaml.YAMLError) as error:
             raise ImageRegistryError(f"cannot persist image registry {self._registry_path}") from error
         finally:
             if descriptor is not None:
                 os.close(descriptor)
-            if temporary_path is not None:
+            if temporary_name is not None:
                 try:
-                    temporary_path.unlink(missing_ok=True)
+                    os.unlink(temporary_name, dir_fd=image_root_descriptor)
                 except OSError:
                     pass
 
@@ -189,11 +224,18 @@ class ImageRegistryStore:
         except OSError as error:
             raise ImageRegistryError(f"cannot initialize image registry beneath {self._image_root}") from error
 
-    def _get_alias_lock_path(self, name: Identifier) -> Path:
-        return self._lock_directory / f"alias-{name}.lock"
-
-    def _get_registry_lock_path(self) -> Path:
-        return self._lock_directory / "registry.lock"
+    @contextmanager
+    def _open_storage(self) -> Iterator[tuple[int, int]]:
+        try:
+            with _open_verified_directory(self._image_root) as image_root_descriptor:
+                with _open_verified_child_directory(
+                    image_root_descriptor,
+                    _LOCK_DIRECTORY_NAME,
+                    self._lock_directory,
+                ) as lock_directory_descriptor:
+                    yield image_root_descriptor, lock_directory_descriptor
+        except OSError as error:
+            raise ImageRegistryError(f"cannot access image registry beneath {self._image_root}") from error
 
     @staticmethod
     def _validate_path_facts(
@@ -207,9 +249,7 @@ class ImageRegistryStore:
                 continue
             if existing.path != image.path:
                 continue
-            existing_facts = (existing.sqsh_sha256, existing.source_oci_digest, existing.inspection)
-            new_facts = (image.sqsh_sha256, image.source_oci_digest, image.inspection)
-            if existing_facts != new_facts:
+            if existing.immutable_facts != image.immutable_facts:
                 raise ImageConflictError(f"image path {image.path!r} already has different immutable facts")
 
 
@@ -249,19 +289,34 @@ _UniqueKeySafeLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, _construc
 
 
 @contextmanager
-def _acquire_file_lock(path: Path) -> Iterator[None]:
+def _acquire_file_lock(directory_descriptor: int, name: str, display_path: Path) -> Iterator[None]:
     """Acquire one exclusive advisory file lock for a registry mutation."""
     descriptor: int | None = None
     try:
-        descriptor = os.open(path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), _FILE_MODE)
+        # macOS can report ENOENT to the losing openat(O_CREAT) caller when two
+        # processes create the same lock file concurrently. Retrying then opens
+        # the winner's regular file with the same no-follow boundary.
+        for _ in range(10):
+            try:
+                descriptor = os.open(
+                    name,
+                    os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+                    _FILE_MODE,
+                    dir_fd=directory_descriptor,
+                )
+            except FileNotFoundError:
+                continue
+            break
+        if descriptor is None:
+            raise OSError(f"lock path {display_path} could not be opened")
         if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            raise OSError(f"lock path {path} is not a regular file")
+            raise OSError(f"lock path {display_path} is not a regular file")
         os.fchmod(descriptor, _FILE_MODE)
         fcntl.flock(descriptor, fcntl.LOCK_EX)
     except OSError as error:
         if descriptor is not None:
             os.close(descriptor)
-        raise ImageRegistryError(f"cannot lock image registry target {path}") from error
+        raise ImageRegistryError(f"cannot lock image registry target {display_path}") from error
 
     try:
         yield
@@ -279,11 +334,6 @@ def _validate_image_alias(name: str) -> Identifier:
         return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
     except ValidationError as error:
         raise ImageRegistryError(f"invalid image alias {name!r}") from error
-
-
-def _sync_directory(path: Path) -> None:
-    with _open_verified_directory(path) as descriptor:
-        os.fsync(descriptor)
 
 
 def _ensure_private_directory(path: Path, *, parents: bool) -> None:
@@ -312,16 +362,60 @@ def _open_verified_directory(path: Path) -> Iterator[int]:
             os.close(descriptor)
 
 
-def _read_regular_text(path: Path) -> str:
+@contextmanager
+def _open_verified_child_directory(
+    parent_descriptor: int,
+    name: str,
+    display_path: Path,
+) -> Iterator[int]:
     descriptor: int | None = None
     try:
-        before_open = path.lstat()
-        if not stat.S_ISREG(before_open.st_mode):
-            raise OSError(f"registry path {path} is not a regular file")
-        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        before_open = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if not stat.S_ISDIR(before_open.st_mode):
+            raise OSError(f"registry directory {display_path} is not a directory")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(name, flags, dir_fd=parent_descriptor)
         after_open = os.fstat(descriptor)
         if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
-            raise OSError(f"registry path {path} changed while it was being opened")
+            raise OSError(f"registry directory {display_path} changed while it was being opened")
+        if not stat.S_ISDIR(after_open.st_mode):
+            raise OSError(f"registry directory {display_path} is not a directory")
+        yield descriptor
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _create_temporary_file(directory_descriptor: int) -> tuple[int, str]:
+    for _ in range(100):
+        name = f".registry.{secrets.token_hex(8)}.tmp"
+        try:
+            descriptor = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                _FILE_MODE,
+                dir_fd=directory_descriptor,
+            )
+        except FileExistsError:
+            continue
+        return descriptor, name
+    raise OSError("cannot allocate a unique registry snapshot name")
+
+
+def _read_regular_text(directory_descriptor: int, name: str, display_path: Path) -> str:
+    descriptor: int | None = None
+    try:
+        before_open = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+        if not stat.S_ISREG(before_open.st_mode):
+            raise OSError(f"registry path {display_path} is not a regular file")
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_descriptor,
+        )
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise OSError(f"registry path {display_path} changed while it was being opened")
         registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
         descriptor = None
         with registry_file:

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -51,7 +51,7 @@ class SlurmImageService:
             sqsh_sha256=sqsh_sha256,
             inspection=inspection,
         )
-        return self._registry.register(image, replace=replace)
+        return self._registry.register(image, verify_persisted=_verify_registered_image, replace=replace)
 
     def list_images(self) -> tuple[RegisteredImage, ...]:
         """Return all registered aliases in deterministic order."""
@@ -64,9 +64,7 @@ class SlurmImageService:
         else:
             assert reference.path is not None
             image = self._registry.get_by_path(reference.path)
-        actual_sha256 = compute_file_sha256(Path(image.path))
-        if actual_sha256 != image.sqsh_sha256:
-            raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")
+        _verify_registered_image(image)
         _validate_inspection(
             image.inspection,
             expected_kind=expected_kind,
@@ -128,3 +126,9 @@ def _validate_inspection(
         raise ImageVerificationError(
             f"image inspection kind {inspection.inspection.kind.value!r} does not match {expected_kind.value!r}"
         )
+
+
+def _verify_registered_image(image: RegisteredImage) -> None:
+    actual_sha256 = compute_file_sha256(Path(image.path))
+    if actual_sha256 != image.sqsh_sha256:
+        raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verified image registration and resolution services for Slurm planning."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+
+from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, ImageKind, ImageRef
+from data_designer.slurm.contracts import Sha256Digest
+from data_designer.slurm.images.errors import ImageVerificationError
+from data_designer.slurm.images.records import RegisteredImage
+from data_designer.slurm.images.registry import ImageRegistry
+from data_designer.slurm.planning import ResolvedImage
+
+_HASH_BLOCK_SIZE = 1024 * 1024
+
+
+class SlurmImageService:
+    """Manage verified existing SQSH files without copying or deleting artifacts."""
+
+    def __init__(self, workspace_root: str | Path) -> None:
+        self._registry = ImageRegistry(workspace_root)
+
+    @property
+    def registry_path(self) -> Path:
+        """Return the workspace-derived registry path."""
+        return self._registry.registry_path
+
+    def register_existing(
+        self,
+        request: ImageBuildRequest,
+        inspection: ImageInspectionRecord,
+        *,
+        replace: bool = False,
+    ) -> RegisteredImage:
+        """Verify and register an existing compute-visible SQSH in place."""
+        if not request.source.endswith(".sqsh"):
+            raise ImageVerificationError("OCI image sources require the CPU Slurm image lifecycle")
+        path = Path(request.source)
+        sqsh_sha256 = compute_file_sha256(path)
+        _validate_inspection(inspection, expected_kind=ImageKind(request.kind), expected_sha256=sqsh_sha256)
+        image = RegisteredImage(
+            schema_version=1,
+            name=request.name,
+            path=path.as_posix(),
+            sqsh_sha256=sqsh_sha256,
+            inspection=inspection,
+        )
+        return self._registry.register(image, replace=replace)
+
+    def list_images(self) -> tuple[RegisteredImage, ...]:
+        """Return all registered aliases in deterministic order."""
+        return self._registry.list_images()
+
+    def resolve(self, reference: ImageRef, *, expected_kind: ImageKind) -> ResolvedImage:
+        """Resolve and reverify one registered alias or path for plan compilation."""
+        if reference.name is not None:
+            image = self._registry.get_by_name(reference.name)
+        else:
+            assert reference.path is not None
+            image = self._registry.get_by_path(reference.path)
+        actual_sha256 = compute_file_sha256(Path(image.path))
+        if actual_sha256 != image.sqsh_sha256:
+            raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")
+        _validate_inspection(
+            image.inspection,
+            expected_kind=expected_kind,
+            expected_sha256=image.sqsh_sha256,
+        )
+        return ResolvedImage(
+            authored_ref=reference,
+            path=image.path,
+            sha256=image.sqsh_sha256,
+            inspection=image.inspection,
+        )
+
+    def unregister(self, name: str) -> RegisteredImage:
+        """Remove an alias while leaving its underlying artifact untouched."""
+        return self._registry.unregister(name)
+
+
+def compute_file_sha256(path: Path) -> Sha256Digest:
+    """Compute the SHA-256 of one regular, non-symlink SQSH file."""
+    descriptor: int | None = None
+    try:
+        before_open = path.lstat()
+        if not stat.S_ISREG(before_open.st_mode):
+            raise ImageVerificationError(f"image path {path} must be a regular non-symlink file")
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        image_file = os.fdopen(descriptor, "rb")
+        descriptor = None
+        digest = hashlib.sha256()
+        with image_file:
+            before_read = os.fstat(image_file.fileno())
+            if (before_open.st_dev, before_open.st_ino) != (before_read.st_dev, before_read.st_ino):
+                raise ImageVerificationError(f"image path {path} changed while it was being opened")
+            while block := image_file.read(_HASH_BLOCK_SIZE):
+                digest.update(block)
+            after_read = os.fstat(image_file.fileno())
+        before_facts = (before_read.st_dev, before_read.st_ino, before_read.st_size, before_read.st_mtime_ns)
+        after_facts = (after_read.st_dev, after_read.st_ino, after_read.st_size, after_read.st_mtime_ns)
+        if before_facts != after_facts:
+            raise ImageVerificationError(f"image path {path} changed while it was being verified")
+        return digest.hexdigest()
+    except FileNotFoundError as error:
+        raise ImageVerificationError(f"image path {path} does not exist") from error
+    except OSError as error:
+        raise ImageVerificationError(f"cannot read image path {path}") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _validate_inspection(
+    inspection: ImageInspectionRecord,
+    *,
+    expected_kind: ImageKind,
+    expected_sha256: Sha256Digest,
+) -> None:
+    if inspection.sqsh_sha256 != expected_sha256:
+        raise ImageVerificationError("image inspection does not match the SQSH digest")
+    if inspection.inspection.kind is not expected_kind:
+        raise ImageVerificationError(
+            f"image inspection kind {inspection.inspection.kind.value!r} does not match {expected_kind.value!r}"
+        )

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -51,7 +51,7 @@ class SlurmImageService:
             sqsh_sha256=sqsh_sha256,
             inspection=inspection,
         )
-        return self._registry.register(image, verify_persisted=_verify_registered_image, replace=replace)
+        return self._registry.register(image, verify_before_publish=_verify_registered_image, replace=replace)
 
     def list_images(self) -> tuple[RegisteredImage, ...]:
         """Return all registered aliases in deterministic order."""

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verified image registration and resolution services for Slurm planning."""
+"""Verified existing-image registry operations for Slurm planning."""
 
 from __future__ import annotations
 
@@ -13,23 +13,19 @@ from pathlib import Path
 from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, ImageKind, ImageRef
 from data_designer.slurm.contracts import Sha256Digest
 from data_designer.slurm.images.errors import ImageVerificationError
+from data_designer.slurm.images.inspection import INSPECTOR_VERSION
 from data_designer.slurm.images.records import RegisteredImage
-from data_designer.slurm.images.registry import ImageRegistry
+from data_designer.slurm.images.registry import ImageRegistryStore
 from data_designer.slurm.planning import ResolvedImage
 
 _HASH_BLOCK_SIZE = 1024 * 1024
 
 
-class SlurmImageService:
-    """Manage verified existing SQSH files without copying or deleting artifacts."""
+class VerifiedImageRegistry:
+    """Provide verified existing-SQSH operations for the public image facade."""
 
     def __init__(self, workspace_root: str | Path) -> None:
-        self._registry = ImageRegistry(workspace_root)
-
-    @property
-    def registry_path(self) -> Path:
-        """Return the workspace-derived registry path."""
-        return self._registry.registry_path
+        self._registry = ImageRegistryStore(workspace_root)
 
     def register_existing(
         self,
@@ -42,13 +38,12 @@ class SlurmImageService:
         if not request.source.endswith(".sqsh"):
             raise ImageVerificationError("OCI image sources require the CPU Slurm image lifecycle")
         path = Path(request.source)
-        sqsh_sha256 = compute_file_sha256(path)
-        _validate_inspection(inspection, expected_kind=ImageKind(request.kind), expected_sha256=sqsh_sha256)
+        _validate_inspection(inspection, expected_kind=ImageKind(request.kind))
         image = RegisteredImage(
             schema_version=1,
             name=request.name,
             path=path.as_posix(),
-            sqsh_sha256=sqsh_sha256,
+            sqsh_sha256=inspection.sqsh_sha256,
             inspection=inspection,
         )
         return self._registry.register(image, verify_before_publish=_verify_registered_image, replace=replace)
@@ -57,7 +52,7 @@ class SlurmImageService:
         """Return all registered aliases in deterministic order."""
         return self._registry.list_images()
 
-    def resolve(self, reference: ImageRef, *, expected_kind: ImageKind) -> ResolvedImage:
+    def resolve_for_planning(self, reference: ImageRef, *, expected_kind: ImageKind) -> ResolvedImage:
         """Resolve and reverify one registered alias or path for plan compilation."""
         if reference.name is not None:
             image = self._registry.get_by_name(reference.name)
@@ -82,7 +77,7 @@ class SlurmImageService:
         return self._registry.unregister(name)
 
 
-def compute_file_sha256(path: Path) -> Sha256Digest:
+def compute_sqsh_file_sha256(path: Path) -> Sha256Digest:
     """Compute the SHA-256 of one regular, non-symlink SQSH file."""
     descriptor: int | None = None
     try:
@@ -100,9 +95,31 @@ def compute_file_sha256(path: Path) -> Sha256Digest:
             while block := image_file.read(_HASH_BLOCK_SIZE):
                 digest.update(block)
             after_read = os.fstat(image_file.fileno())
-        before_facts = (before_read.st_dev, before_read.st_ino, before_read.st_size, before_read.st_mtime_ns)
-        after_facts = (after_read.st_dev, after_read.st_ino, after_read.st_size, after_read.st_mtime_ns)
+            after_path = path.lstat()
+        before_facts = (
+            before_read.st_dev,
+            before_read.st_ino,
+            before_read.st_size,
+            before_read.st_mtime_ns,
+            before_read.st_ctime_ns,
+        )
+        after_facts = (
+            after_read.st_dev,
+            after_read.st_ino,
+            after_read.st_size,
+            after_read.st_mtime_ns,
+            after_read.st_ctime_ns,
+        )
         if before_facts != after_facts:
+            raise ImageVerificationError(f"image path {path} changed while it was being verified")
+        path_facts = (
+            after_path.st_dev,
+            after_path.st_ino,
+            after_path.st_size,
+            after_path.st_mtime_ns,
+            after_path.st_ctime_ns,
+        )
+        if not stat.S_ISREG(after_path.st_mode) or path_facts != after_facts:
             raise ImageVerificationError(f"image path {path} changed while it was being verified")
         return digest.hexdigest()
     except FileNotFoundError as error:
@@ -118,9 +135,11 @@ def _validate_inspection(
     inspection: ImageInspectionRecord,
     *,
     expected_kind: ImageKind,
-    expected_sha256: Sha256Digest,
+    expected_sha256: Sha256Digest | None = None,
 ) -> None:
-    if inspection.sqsh_sha256 != expected_sha256:
+    if inspection.inspector_version != INSPECTOR_VERSION:
+        raise ImageVerificationError(f"unsupported image inspector version {inspection.inspector_version!r}")
+    if expected_sha256 is not None and inspection.sqsh_sha256 != expected_sha256:
         raise ImageVerificationError("image inspection does not match the SQSH digest")
     if inspection.inspection.kind is not expected_kind:
         raise ImageVerificationError(
@@ -129,6 +148,6 @@ def _validate_inspection(
 
 
 def _verify_registered_image(image: RegisteredImage) -> None:
-    actual_sha256 = compute_file_sha256(Path(image.path))
+    actual_sha256 = compute_sqsh_file_sha256(Path(image.path))
     if actual_sha256 != image.sqsh_sha256:
         raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")

--- a/packages/data-designer-slurm/tests/contracts/golden/client_image_inspection.json
+++ b/packages/data-designer-slurm/tests/contracts/golden/client_image_inspection.json
@@ -6,6 +6,18 @@
         "version": "0.9.2"
       },
       {
+        "name": "data-designer-config",
+        "version": "0.9.2"
+      },
+      {
+        "name": "data-designer-engine",
+        "version": "0.9.2"
+      },
+      {
+        "name": "data-designer-slurm",
+        "version": "0.9.2"
+      },
+      {
         "name": "pip",
         "version": "26.1"
       }

--- a/packages/data-designer-slurm/tests/contracts/golden/dependency_lock.json
+++ b/packages/data-designer-slurm/tests/contracts/golden/dependency_lock.json
@@ -10,6 +10,18 @@
       "version": "0.9.2"
     },
     {
+      "name": "data-designer-config",
+      "version": "0.9.2"
+    },
+    {
+      "name": "data-designer-engine",
+      "version": "0.9.2"
+    },
+    {
+      "name": "data-designer-slurm",
+      "version": "0.9.2"
+    },
+    {
       "name": "pip",
       "version": "26.1"
     }

--- a/packages/data-designer-slurm/tests/contracts/golden/dependency_lock_single.json
+++ b/packages/data-designer-slurm/tests/contracts/golden/dependency_lock_single.json
@@ -6,6 +6,22 @@
     {
       "name": "data-designer",
       "version": "0.9.2"
+    },
+    {
+      "name": "data-designer-config",
+      "version": "0.9.2"
+    },
+    {
+      "name": "data-designer-engine",
+      "version": "0.9.2"
+    },
+    {
+      "name": "data-designer-slurm",
+      "version": "0.9.2"
+    },
+    {
+      "name": "pip",
+      "version": "26.1"
     }
   ],
   "overlay_packages": [],

--- a/packages/data-designer-slurm/tests/contracts/golden/multi_node_plan.json
+++ b/packages/data-designer-slurm/tests/contracts/golden/multi_node_plan.json
@@ -56,7 +56,7 @@
     },
     "dependency_lock": {
       "path": "/workspace/primary/runs/run-001/dependency-lock.json",
-      "sha256": "a86032b310aa6bdb95fc7f35ef606fec2e56b977ba60e36b8b9293341ac43e00"
+      "sha256": "fb536259ea0c206eca90ee8a4ad0a95345f97eb869e349732d1d19db857ecbc3"
     },
     "gpu_count": 0,
     "host_node_index": 0,
@@ -70,6 +70,18 @@
           "distributions": [
             {
               "name": "data-designer",
+              "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-config",
+              "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-engine",
+              "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-slurm",
               "version": "0.9.2"
             },
             {

--- a/packages/data-designer-slurm/tests/contracts/golden/single_node_plan.json
+++ b/packages/data-designer-slurm/tests/contracts/golden/single_node_plan.json
@@ -43,7 +43,7 @@
     },
     "dependency_lock": {
       "path": "/workspace/primary/runs/run-single/dependency-lock.json",
-      "sha256": "2600c1944897a8e3c9a9410fe912bdee0e169e09769e58180cadebe94f3da52c"
+      "sha256": "ce671fcd812110bc09bd39a21c2c294754c8255d42030c1b90e250a1b513a311"
     },
     "gpu_count": 0,
     "host_node_index": 0,
@@ -58,6 +58,22 @@
             {
               "name": "data-designer",
               "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-config",
+              "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-engine",
+              "version": "0.9.2"
+            },
+            {
+              "name": "data-designer-slurm",
+              "version": "0.9.2"
+            },
+            {
+              "name": "pip",
+              "version": "26.1"
             }
           ],
           "installer_path": "/usr/bin/pip",

--- a/packages/data-designer-slurm/tests/images/test_image_registry_records.py
+++ b/packages/data-designer-slurm/tests/images/test_image_registry_records.py
@@ -13,6 +13,7 @@ def test_registered_image_exposes_inspected_kind() -> None:
     image = _registered_image("alpha")
 
     assert image.kind is ImageKind.CLIENT
+    assert image.immutable_facts == (_SQSH_SHA256, None, image.inspection)
 
 
 def test_registry_document_accepts_aliases_with_identical_facts() -> None:

--- a/packages/data-designer-slurm/tests/images/test_image_registry_records.py
+++ b/packages/data-designer-slurm/tests/images/test_image_registry_records.py
@@ -10,14 +10,14 @@ _SQSH_SHA256 = "a" * 64
 
 
 def test_registered_image_exposes_inspected_kind() -> None:
-    image = _registered_image("alpha")
+    image = _get_registered_image("alpha")
 
     assert image.kind is ImageKind.CLIENT
     assert image.immutable_facts == (_SQSH_SHA256, None, image.inspection)
 
 
 def test_registry_document_accepts_aliases_with_identical_facts() -> None:
-    alpha = _registered_image("alpha")
+    alpha = _get_registered_image("alpha")
     beta = alpha.model_copy(update={"name": "beta"})
 
     document = ImageRegistryDocument(schema_version=1, images=(alpha, beta))
@@ -25,7 +25,7 @@ def test_registry_document_accepts_aliases_with_identical_facts() -> None:
     assert document.images == (alpha, beta)
 
 
-def _registered_image(name: str) -> RegisteredImage:
+def _get_registered_image(name: str) -> RegisteredImage:
     inspection = ImageInspectionRecord(
         schema_version=1,
         inspector_version="inspector-1",

--- a/packages/data-designer-slurm/tests/images/test_image_registry_records.py
+++ b/packages/data-designer-slurm/tests/images/test_image_registry_records.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.slurm.config import ClientImageInspection, ImageInspectionRecord, ImageKind, InstalledDistribution
+from data_designer.slurm.images.records import ImageRegistryDocument, RegisteredImage
+
+_SQSH_SHA256 = "a" * 64
+
+
+def test_registered_image_exposes_inspected_kind() -> None:
+    image = _registered_image("alpha")
+
+    assert image.kind is ImageKind.CLIENT
+
+
+def test_registry_document_accepts_aliases_with_identical_facts() -> None:
+    alpha = _registered_image("alpha")
+    beta = alpha.model_copy(update={"name": "beta"})
+
+    document = ImageRegistryDocument(schema_version=1, images=(alpha, beta))
+
+    assert document.images == (alpha, beta)
+
+
+def _registered_image(name: str) -> RegisteredImage:
+    inspection = ImageInspectionRecord(
+        schema_version=1,
+        inspector_version="inspector-1",
+        sqsh_sha256=_SQSH_SHA256,
+        inspection=ClientImageInspection(
+            kind="client",
+            python_implementation="cpython",
+            python_version="3.13.3",
+            python_abi="cp313",
+            distributions=(InstalledDistribution(name="data-designer", version="0.9.2"),),
+            installer_path="/usr/bin/pip",
+            installer_version="26.1",
+        ),
+    )
+    return RegisteredImage(
+        schema_version=1,
+        name=name,
+        path="/workspace/images/shared.sqsh",
+        sqsh_sha256=_SQSH_SHA256,
+        inspection=inspection,
+    )

--- a/packages/data-designer-slurm/tests/images/test_inspection.py
+++ b/packages/data-designer-slurm/tests/images/test_inspection.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from slurm_test_fakes import FakeInspectionEnvironment
+
+from data_designer.slurm.config import ImageInspectionRecord, InstalledDistribution
+from data_designer.slurm.images import ClientImageInspector, ImageInspectionError, ServingImageInspector
+
+
+def test_client_inspector_produces_digest_bound_golden_facts(
+    client_image_inspection: ImageInspectionRecord,
+) -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=(
+            InstalledDistribution(name="data-designer", version="0.9.2"),
+            InstalledDistribution(name="pip", version="26.1"),
+        ),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    inspected = ClientImageInspector(environment).inspect(client_image_inspection.sqsh_sha256)
+
+    assert inspected == client_image_inspection
+
+
+def test_serving_inspector_produces_digest_bound_golden_facts(
+    serving_image_inspection: ImageInspectionRecord,
+) -> None:
+    environment = FakeInspectionEnvironment(
+        distribution_versions={"vllm": "0.21.0"},
+        executables={"vllm": "/usr/local/bin/vllm"},
+    )
+
+    inspected = ServingImageInspector(environment).inspect(serving_image_inspection.sqsh_sha256)
+
+    assert inspected == serving_image_inspection
+
+
+@pytest.mark.parametrize(
+    "environment",
+    (
+        FakeInspectionEnvironment(distribution_versions={"pip": "26.1"}),
+        FakeInspectionEnvironment(executables={"pip": "/usr/bin/pip"}),
+    ),
+    ids=("missing-installer", "missing-installer-distribution"),
+)
+def test_client_inspector_rejects_missing_installer_capabilities(
+    environment: FakeInspectionEnvironment,
+) -> None:
+    with pytest.raises(ImageInspectionError, match="required"):
+        ClientImageInspector(environment).inspect("a" * 64)
+
+
+@pytest.mark.parametrize(
+    "environment",
+    (
+        FakeInspectionEnvironment(distribution_versions={"vllm": "0.21.0"}),
+        FakeInspectionEnvironment(executables={"vllm": "/usr/local/bin/vllm"}),
+    ),
+    ids=("missing-executable", "missing-runtime-distribution"),
+)
+def test_serving_inspector_rejects_missing_runtime_capabilities(
+    environment: FakeInspectionEnvironment,
+) -> None:
+    with pytest.raises(ImageInspectionError, match="required"):
+        ServingImageInspector(environment).inspect("a" * 64)
+
+
+def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=(
+            InstalledDistribution(name="plugin", version="1"),
+            InstalledDistribution(name="plugin", version="2"),
+        ),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    with pytest.raises(ImageInspectionError, match="invalid facts"):
+        ClientImageInspector(environment).inspect("a" * 64)
+
+
+def test_client_inspector_sorts_distribution_inventory() -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=(
+            InstalledDistribution(name="pip", version="26.1"),
+            InstalledDistribution(name="data-designer", version="0.9.2"),
+        ),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    inspection = ClientImageInspector(environment).inspect("a" * 64).inspection
+
+    assert tuple(distribution.name for distribution in inspection.distributions) == ("data-designer", "pip")

--- a/packages/data-designer-slurm/tests/images/test_inspection.py
+++ b/packages/data-designer-slurm/tests/images/test_inspection.py
@@ -21,7 +21,7 @@ from data_designer.slurm.images.inspection import (
 )
 
 
-def _client_distributions() -> tuple[InstalledDistribution, ...]:
+def _get_client_distributions() -> tuple[InstalledDistribution, ...]:
     return (
         InstalledDistribution(name="data-designer", version="0.9.2"),
         InstalledDistribution(name="data-designer-config", version="0.9.2"),
@@ -35,7 +35,7 @@ def test_client_inspector_produces_digest_bound_golden_facts(
     client_image_inspection: ImageInspectionRecord,
 ) -> None:
     environment = FakeInspectionEnvironment(
-        distributions=_client_distributions(),
+        distributions=_get_client_distributions(),
         distribution_versions={"pip": "26.1"},
         executables={"pip": "/usr/bin/pip"},
     )
@@ -62,10 +62,12 @@ def test_serving_inspector_produces_digest_bound_golden_facts(
     "environment",
     (
         FakeInspectionEnvironment(
-            distributions=_client_distributions(),
+            distributions=_get_client_distributions(),
         ),
         FakeInspectionEnvironment(
-            distributions=tuple(distribution for distribution in _client_distributions() if distribution.name != "pip"),
+            distributions=tuple(
+                distribution for distribution in _get_client_distributions() if distribution.name != "pip"
+            ),
             executables={"pip": "/usr/bin/pip"},
         ),
     ),
@@ -96,7 +98,7 @@ def test_client_inspector_rejects_generic_python_image_without_data_designer() -
 def test_client_inspector_rejects_incomplete_data_designer_package_set(missing_name: str) -> None:
     environment = FakeInspectionEnvironment(
         distributions=tuple(
-            distribution for distribution in _client_distributions() if distribution.name != missing_name
+            distribution for distribution in _get_client_distributions() if distribution.name != missing_name
         ),
         executables={"pip": "/usr/bin/pip"},
     )
@@ -122,7 +124,7 @@ def test_serving_inspector_rejects_missing_runtime_capabilities(
 
 def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
     environment = FakeInspectionEnvironment(
-        distributions=_client_distributions()
+        distributions=_get_client_distributions()
         + (
             InstalledDistribution(name="plugin", version="1"),
             InstalledDistribution(name="plugin", version="2"),
@@ -137,7 +139,7 @@ def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
 
 def test_client_inspector_sorts_distribution_inventory() -> None:
     environment = FakeInspectionEnvironment(
-        distributions=tuple(reversed(_client_distributions())),
+        distributions=tuple(reversed(_get_client_distributions())),
         distribution_versions={"pip": "26.1"},
         executables={"pip": "/usr/bin/pip"},
     )
@@ -145,13 +147,13 @@ def test_client_inspector_sorts_distribution_inventory() -> None:
     inspection = ClientImageInspector(environment).inspect("a" * 64).inspection
 
     assert tuple(distribution.name for distribution in inspection.distributions) == tuple(
-        distribution.name for distribution in _client_distributions()
+        distribution.name for distribution in _get_client_distributions()
     )
 
 
 def test_client_inspector_uses_installer_version_from_distribution_inventory() -> None:
     environment = FakeInspectionEnvironment(
-        distributions=_client_distributions(),
+        distributions=_get_client_distributions(),
         distribution_versions={"pip": "unexpected"},
         executables={"pip": "/usr/bin/pip"},
     )

--- a/packages/data-designer-slurm/tests/images/test_inspection.py
+++ b/packages/data-designer-slurm/tests/images/test_inspection.py
@@ -13,22 +13,29 @@ import pytest
 from slurm_test_fakes import FakeInspectionEnvironment
 
 from data_designer.slurm.config import ImageInspectionRecord, InstalledDistribution
-from data_designer.slurm.images import (
+from data_designer.slurm.images.errors import ImageInspectionError
+from data_designer.slurm.images.inspection import (
     ClientImageInspector,
-    ImageInspectionError,
     ServingImageInspector,
     SystemInspectionEnvironment,
 )
+
+
+def _client_distributions() -> tuple[InstalledDistribution, ...]:
+    return (
+        InstalledDistribution(name="data-designer", version="0.9.2"),
+        InstalledDistribution(name="data-designer-config", version="0.9.2"),
+        InstalledDistribution(name="data-designer-engine", version="0.9.2"),
+        InstalledDistribution(name="data-designer-slurm", version="0.9.2"),
+        InstalledDistribution(name="pip", version="26.1"),
+    )
 
 
 def test_client_inspector_produces_digest_bound_golden_facts(
     client_image_inspection: ImageInspectionRecord,
 ) -> None:
     environment = FakeInspectionEnvironment(
-        distributions=(
-            InstalledDistribution(name="data-designer", version="0.9.2"),
-            InstalledDistribution(name="pip", version="26.1"),
-        ),
+        distributions=_client_distributions(),
         distribution_versions={"pip": "26.1"},
         executables={"pip": "/usr/bin/pip"},
     )
@@ -54,8 +61,13 @@ def test_serving_inspector_produces_digest_bound_golden_facts(
 @pytest.mark.parametrize(
     "environment",
     (
-        FakeInspectionEnvironment(distribution_versions={"pip": "26.1"}),
-        FakeInspectionEnvironment(executables={"pip": "/usr/bin/pip"}),
+        FakeInspectionEnvironment(
+            distributions=_client_distributions(),
+        ),
+        FakeInspectionEnvironment(
+            distributions=tuple(distribution for distribution in _client_distributions() if distribution.name != "pip"),
+            executables={"pip": "/usr/bin/pip"},
+        ),
     ),
     ids=("missing-installer", "missing-installer-distribution"),
 )
@@ -78,6 +90,22 @@ def test_client_inspector_rejects_generic_python_image_without_data_designer() -
 
 
 @pytest.mark.parametrize(
+    "missing_name",
+    ("data-designer", "data-designer-config", "data-designer-engine", "data-designer-slurm"),
+)
+def test_client_inspector_rejects_incomplete_data_designer_package_set(missing_name: str) -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=tuple(
+            distribution for distribution in _client_distributions() if distribution.name != missing_name
+        ),
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    with pytest.raises(ImageInspectionError, match=missing_name):
+        ClientImageInspector(environment).inspect("a" * 64)
+
+
+@pytest.mark.parametrize(
     "environment",
     (
         FakeInspectionEnvironment(distribution_versions={"vllm": "0.21.0"}),
@@ -94,8 +122,8 @@ def test_serving_inspector_rejects_missing_runtime_capabilities(
 
 def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
     environment = FakeInspectionEnvironment(
-        distributions=(
-            InstalledDistribution(name="data-designer", version="0.9.2"),
+        distributions=_client_distributions()
+        + (
             InstalledDistribution(name="plugin", version="1"),
             InstalledDistribution(name="plugin", version="2"),
         ),
@@ -109,17 +137,28 @@ def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
 
 def test_client_inspector_sorts_distribution_inventory() -> None:
     environment = FakeInspectionEnvironment(
-        distributions=(
-            InstalledDistribution(name="pip", version="26.1"),
-            InstalledDistribution(name="data-designer", version="0.9.2"),
-        ),
+        distributions=tuple(reversed(_client_distributions())),
         distribution_versions={"pip": "26.1"},
         executables={"pip": "/usr/bin/pip"},
     )
 
     inspection = ClientImageInspector(environment).inspect("a" * 64).inspection
 
-    assert tuple(distribution.name for distribution in inspection.distributions) == ("data-designer", "pip")
+    assert tuple(distribution.name for distribution in inspection.distributions) == tuple(
+        distribution.name for distribution in _client_distributions()
+    )
+
+
+def test_client_inspector_uses_installer_version_from_distribution_inventory() -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=_client_distributions(),
+        distribution_versions={"pip": "unexpected"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    inspection = ClientImageInspector(environment).inspect("a" * 64).inspection
+
+    assert inspection.installer_version == "26.1"
 
 
 def test_system_inspection_environment_normalizes_distribution_inventory(

--- a/packages/data-designer-slurm/tests/images/test_inspection.py
+++ b/packages/data-designer-slurm/tests/images/test_inspection.py
@@ -3,11 +3,22 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import re
+import shutil
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 from slurm_test_fakes import FakeInspectionEnvironment
 
 from data_designer.slurm.config import ImageInspectionRecord, InstalledDistribution
-from data_designer.slurm.images import ClientImageInspector, ImageInspectionError, ServingImageInspector
+from data_designer.slurm.images import (
+    ClientImageInspector,
+    ImageInspectionError,
+    ServingImageInspector,
+    SystemInspectionEnvironment,
+)
 
 
 def test_client_inspector_produces_digest_bound_golden_facts(
@@ -97,3 +108,74 @@ def test_client_inspector_sorts_distribution_inventory() -> None:
     inspection = ClientImageInspector(environment).inspect("a" * 64).inspection
 
     assert tuple(distribution.name for distribution in inspection.distributions) == ("data-designer", "pip")
+
+
+def test_system_inspection_environment_normalizes_distribution_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    distributions = (
+        SimpleNamespace(metadata={"Name": "My_Package"}, version="1.2.3"),
+        SimpleNamespace(metadata={"Name": "another.package"}, version="2"),
+        SimpleNamespace(metadata={"Name": "my-package"}, version="1.2.3"),
+    )
+    monkeypatch.setattr(importlib.metadata, "distributions", Mock(return_value=distributions))
+
+    inspected = SystemInspectionEnvironment().list_distributions()
+
+    assert tuple((distribution.name, distribution.version) for distribution in inspected) == (
+        ("another-package", "2"),
+        ("my-package", "1.2.3"),
+    )
+
+
+@pytest.mark.parametrize(
+    "distributions",
+    (
+        (
+            SimpleNamespace(metadata={"Name": "plugin"}, version="1"),
+            SimpleNamespace(metadata={"Name": "plugin"}, version="2"),
+        ),
+        (SimpleNamespace(metadata={}, version="1"),),
+    ),
+    ids=("conflicting-versions", "missing-name"),
+)
+def test_system_inspection_environment_rejects_invalid_distribution_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    distributions: tuple[SimpleNamespace, ...],
+) -> None:
+    monkeypatch.setattr(importlib.metadata, "distributions", Mock(return_value=distributions))
+
+    with pytest.raises(ImageInspectionError):
+        SystemInspectionEnvironment().list_distributions()
+
+
+def test_system_inspection_environment_normalizes_missing_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        Mock(side_effect=importlib.metadata.PackageNotFoundError("missing")),
+    )
+
+    with pytest.raises(ImageInspectionError, match="not installed"):
+        SystemInspectionEnvironment().get_distribution_version("missing")
+
+
+@pytest.mark.parametrize("path", (None, "relative/pip"), ids=("missing", "relative"))
+def test_system_inspection_environment_requires_absolute_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str | None,
+) -> None:
+    monkeypatch.setattr(shutil, "which", Mock(return_value=path))
+
+    with pytest.raises(ImageInspectionError):
+        SystemInspectionEnvironment().find_executable("pip")
+
+
+def test_system_inspection_environment_reports_current_python_facts() -> None:
+    environment = SystemInspectionEnvironment()
+
+    assert environment.get_python_implementation()
+    assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", environment.get_python_version())
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", environment.get_python_abi())

--- a/packages/data-designer-slurm/tests/images/test_inspection.py
+++ b/packages/data-designer-slurm/tests/images/test_inspection.py
@@ -66,6 +66,17 @@ def test_client_inspector_rejects_missing_installer_capabilities(
         ClientImageInspector(environment).inspect("a" * 64)
 
 
+def test_client_inspector_rejects_generic_python_image_without_data_designer() -> None:
+    environment = FakeInspectionEnvironment(
+        distributions=(InstalledDistribution(name="pip", version="26.1"),),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+    with pytest.raises(ImageInspectionError, match="data-designer"):
+        ClientImageInspector(environment).inspect("a" * 64)
+
+
 @pytest.mark.parametrize(
     "environment",
     (
@@ -84,6 +95,7 @@ def test_serving_inspector_rejects_missing_runtime_capabilities(
 def test_client_inspector_normalizes_invalid_facts_to_canonical_error() -> None:
     environment = FakeInspectionEnvironment(
         distributions=(
+            InstalledDistribution(name="data-designer", version="0.9.2"),
             InstalledDistribution(name="plugin", version="1"),
             InstalledDistribution(name="plugin", version="2"),
         ),

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -131,7 +131,7 @@ def test_failed_replacement_keeps_previous_alias(tmp_path: Path) -> None:
 
     with (
         patch(
-            "data_designer.slurm.images.registry.secrets.token_hex",
+            "data_designer.slurm.images.filesystem.secrets.token_hex",
             side_effect=mutate_replacement_before_registry_write,
         ),
         pytest.raises(ImageVerificationError, match="no longer matches"),
@@ -162,7 +162,7 @@ def test_registration_does_not_publish_alias_when_sqsh_changes_before_atomic_pub
 
     with (
         patch(
-            "data_designer.slurm.images.registry.secrets.token_hex",
+            "data_designer.slurm.images.filesystem.secrets.token_hex",
             side_effect=mutate_image_before_registry_write,
         ),
         pytest.raises(ImageVerificationError, match="no longer matches"),

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier, Event
@@ -22,43 +23,55 @@ from data_designer.slurm.config import (
     ImageRef,
     InstalledDistribution,
 )
-from data_designer.slurm.images import (
-    ClientImageInspector,
+from data_designer.slurm.images.errors import (
     ImageConflictError,
     ImageNotFoundError,
     ImageRegistryError,
-    ImageRegistrySnapshot,
     ImageVerificationError,
-    ServingImageInspector,
-    SlurmImageService,
-    compute_file_sha256,
 )
+from data_designer.slurm.images.inspection import ClientImageInspector, ServingImageInspector
+from data_designer.slurm.images.records import ImageRegistryDocument, RegisteredImage
+from data_designer.slurm.images.registry import ImageRegistryStore
+from data_designer.slurm.images.service import (
+    VerifiedImageRegistry,
+    compute_sqsh_file_sha256,
+)
+
+
+def _create_registry(workspace: Path) -> VerifiedImageRegistry:
+    return VerifiedImageRegistry(workspace)
+
+
+def _registry_path(workspace: Path) -> Path:
+    return workspace / "images" / "registry.yaml"
 
 
 def test_register_and_resolve_existing_sqsh_by_alias_and_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image_path = _write_sqsh(tmp_path / "artifacts" / "client.sqsh", b"client-image")
     inspection = _inspect_client(image_path)
-    service = SlurmImageService(workspace)
+    service = _create_registry(workspace)
 
     registered = service.register_existing(
         ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
         inspection,
     )
 
-    by_alias = service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
-    by_path = service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
-    persisted = ImageRegistrySnapshot.model_validate_json(json.dumps(yaml.safe_load(service.registry_path.read_text())))
+    by_alias = service.resolve_for_planning(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+    by_path = service.resolve_for_planning(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
+    persisted = ImageRegistryDocument.model_validate_json(
+        json.dumps(yaml.safe_load(_registry_path(workspace).read_text()))
+    )
     assert by_alias.path == by_path.path
     assert by_alias.sha256 == by_path.sha256
     assert by_alias.inspection == by_path.inspection
     assert by_alias.path == image_path.as_posix()
     assert registered == persisted.images[0]
-    assert service.registry_path == workspace / "images" / "registry.yaml"
+    assert _registry_path(workspace) == workspace / "images" / "registry.yaml"
 
 
 def test_registry_lists_aliases_deterministically(tmp_path: Path) -> None:
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     for name in ("zeta", "alpha"):
         image_path = _write_sqsh(tmp_path / f"{name}.sqsh", name.encode())
         service.register_existing(
@@ -71,7 +84,7 @@ def test_registry_lists_aliases_deterministically(tmp_path: Path) -> None:
 
 def test_unregister_removes_only_alias(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client-image")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     service.register_existing(
         ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
         _inspect_client(image_path),
@@ -82,13 +95,13 @@ def test_unregister_removes_only_alias(tmp_path: Path) -> None:
     assert removed.path == image_path.as_posix()
     assert image_path.read_bytes() == b"client-image"
     with pytest.raises(ImageNotFoundError, match="not registered"):
-        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+        service.resolve_for_planning(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
 
 
 def test_registration_requires_explicit_replace_for_alias_updates(tmp_path: Path) -> None:
     first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
     second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     request = ImageBuildRequest(name="serving", kind="serving", source=first_path.as_posix())
     service.register_existing(request, _inspect_serving(first_path))
 
@@ -98,44 +111,32 @@ def test_registration_requires_explicit_replace_for_alias_updates(tmp_path: Path
 
     service.register_existing(replacement, _inspect_serving(second_path), replace=True)
 
-    assert service.resolve(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path == second_path.as_posix()
+    assert (
+        service.resolve_for_planning(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path
+        == second_path.as_posix()
+    )
     assert first_path.exists()
-
-
-def test_registration_does_not_publish_alias_when_sqsh_changes_before_commit(tmp_path: Path) -> None:
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    inspection = _inspect_client(image_path)
-    service = SlurmImageService(tmp_path / "workspace")
-
-    with (
-        patch(
-            "data_designer.slurm.images.service.compute_file_sha256",
-            side_effect=(inspection.sqsh_sha256, "f" * 64),
-        ),
-        pytest.raises(ImageVerificationError, match="no longer matches"),
-    ):
-        service.register_existing(
-            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-            inspection,
-        )
-
-    assert service.list_images() == ()
 
 
 def test_failed_replacement_keeps_previous_alias(tmp_path: Path) -> None:
     first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
     second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     service.register_existing(
         ImageBuildRequest(name="serving", kind="serving", source=first_path.as_posix()),
         _inspect_serving(first_path),
     )
     second_inspection = _inspect_serving(second_path)
+    original_mkstemp = tempfile.mkstemp
+
+    def mutate_replacement_before_registry_write(*args: object, **kwargs: object) -> tuple[int, str]:
+        second_path.write_bytes(b"modified")
+        return original_mkstemp(*args, **kwargs)
 
     with (
         patch(
-            "data_designer.slurm.images.service.compute_file_sha256",
-            side_effect=(second_inspection.sqsh_sha256, "f" * 64),
+            "data_designer.slurm.images.registry.tempfile.mkstemp",
+            side_effect=mutate_replacement_before_registry_write,
         ),
         pytest.raises(ImageVerificationError, match="no longer matches"),
     ):
@@ -145,13 +146,60 @@ def test_failed_replacement_keeps_previous_alias(tmp_path: Path) -> None:
             replace=True,
         )
 
-    assert service.resolve(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path == first_path.as_posix()
+    reloaded = _create_registry(tmp_path / "workspace")
+    assert (
+        reloaded.resolve_for_planning(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path
+        == first_path.as_posix()
+    )
+
+
+def test_registration_does_not_publish_alias_when_sqsh_changes_before_atomic_publish(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    inspection = _inspect_client(image_path)
+    service = _create_registry(workspace)
+    original_mkstemp = tempfile.mkstemp
+
+    def mutate_image_before_registry_write(*args: object, **kwargs: object) -> tuple[int, str]:
+        image_path.write_bytes(b"modified")
+        return original_mkstemp(*args, **kwargs)
+
+    with (
+        patch("data_designer.slurm.images.registry.tempfile.mkstemp", side_effect=mutate_image_before_registry_write),
+        pytest.raises(ImageVerificationError, match="no longer matches"),
+    ):
+        service.register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            inspection,
+        )
+
+    assert _create_registry(workspace).list_images() == ()
+
+
+def test_hash_rejects_path_replaced_while_reading(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    replacement = _write_sqsh(tmp_path / "replacement.sqsh", b"replacement")
+    original_lstat = Path.lstat
+    lstat_calls = 0
+
+    def replace_before_final_path_check(path: Path) -> os.stat_result:
+        nonlocal lstat_calls
+        lstat_calls += 1
+        if lstat_calls == 2:
+            replacement.replace(image_path)
+        return original_lstat(path)
+
+    with (
+        patch.object(Path, "lstat", replace_before_final_path_check),
+        pytest.raises(ImageVerificationError, match="changed while it was being verified"),
+    ):
+        compute_sqsh_file_sha256(image_path)
 
 
 @pytest.mark.parametrize("mutation", (b"modified", b""), ids=("modified", "truncated"))
 def test_resolution_rejects_modified_registered_sqsh(tmp_path: Path, mutation: bytes) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"original")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     service.register_existing(
         ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
         _inspect_client(image_path),
@@ -159,26 +207,26 @@ def test_resolution_rejects_modified_registered_sqsh(tmp_path: Path, mutation: b
     image_path.write_bytes(mutation)
 
     with pytest.raises(ImageVerificationError, match="no longer matches"):
-        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+        service.resolve_for_planning(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
 
 
 def test_resolution_rejects_kind_mismatch(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     service.register_existing(
         ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
         _inspect_client(image_path),
     )
 
     with pytest.raises(ImageVerificationError, match="does not match"):
-        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.SERVING)
+        service.resolve_for_planning(ImageRef(name="client"), expected_kind=ImageKind.SERVING)
 
 
 def test_registration_rejects_missing_symlink_and_wrong_inspection(tmp_path: Path) -> None:
     target = _write_sqsh(tmp_path / "target.sqsh", b"target")
     symlink = tmp_path / "link.sqsh"
     symlink.symlink_to(target)
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
 
     with pytest.raises(ImageVerificationError, match="does not exist"):
         service.register_existing(
@@ -200,7 +248,7 @@ def test_registration_rejects_missing_symlink_and_wrong_inspection(tmp_path: Pat
 
 def test_registration_rejects_kind_mismatched_inspection(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "image.sqsh", b"image")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
 
     with pytest.raises(ImageVerificationError, match="kind"):
         service.register_existing(
@@ -210,8 +258,22 @@ def test_registration_rejects_kind_mismatched_inspection(tmp_path: Path) -> None
     assert service.list_images() == ()
 
 
+def test_registration_rejects_unsupported_inspector_version(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    inspection = _inspect_client(image_path).model_copy(update={"inspector_version": "inspector-2"})
+    service = _create_registry(tmp_path / "workspace")
+
+    with pytest.raises(ImageVerificationError, match="unsupported image inspector version"):
+        service.register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            inspection,
+        )
+
+    assert service.list_images() == ()
+
+
 def test_existing_registration_rejects_oci_source(tmp_path: Path) -> None:
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
     request = ImageBuildRequest(
         name="serving",
         kind="serving",
@@ -224,10 +286,10 @@ def test_existing_registration_rejects_oci_source(tmp_path: Path) -> None:
 
 def test_direct_path_must_be_registered(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "unregistered.sqsh", b"unregistered")
-    service = SlurmImageService(tmp_path / "workspace")
+    service = _create_registry(tmp_path / "workspace")
 
     with pytest.raises(ImageNotFoundError, match="not registered"):
-        service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
+        service.resolve_for_planning(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
 
 
 @pytest.mark.parametrize(
@@ -236,33 +298,62 @@ def test_direct_path_must_be_registered(tmp_path: Path) -> None:
         b"not-yaml: [\n",
         b"\xff",
         b"schema_version: 1\nimages: &recursive\n  - *recursive\n",
+        b"images: []\n",
+        b"schema_version: 2\nimages: []\n",
+        b"schema_version: 1\nschema_version: 1\nimages: []\n",
     ),
-    ids=("invalid-yaml", "invalid-utf8", "recursive-alias"),
+    ids=(
+        "invalid-yaml",
+        "invalid-utf8",
+        "recursive-alias",
+        "missing-version",
+        "unsupported-version",
+        "duplicate-key",
+    ),
 )
 def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: bytes) -> None:
-    service = SlurmImageService(tmp_path / "workspace")
-    service.registry_path.parent.mkdir(parents=True)
-    service.registry_path.write_bytes(content)
+    service = _create_registry(tmp_path / "workspace")
+    registry_path = _registry_path(tmp_path / "workspace")
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_bytes(content)
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
         service.list_images()
 
 
 def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
-    service = SlurmImageService(tmp_path / "workspace")
-    service.registry_path.parent.mkdir(parents=True)
+    service = _create_registry(tmp_path / "workspace")
+    registry_path = _registry_path(tmp_path / "workspace")
+    registry_path.parent.mkdir(parents=True)
     target = tmp_path / "outside.yaml"
     target.write_text("schema_version: 1\nimages: []\n")
-    service.registry_path.symlink_to(target)
+    registry_path.symlink_to(target)
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
         service.list_images()
 
 
+def test_registry_rejects_reads_through_symlinked_image_root(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    outside_workspace = tmp_path / "outside-workspace"
+    outside_registry = _create_registry(outside_workspace)
+    outside_registry.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "images").symlink_to(outside_workspace / "images", target_is_directory=True)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        _create_registry(workspace).list_images()
+
+
 def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path) -> None:
-    service = SlurmImageService(tmp_path / "workspace")
-    service.registry_path.parent.mkdir(parents=True)
-    os.mkfifo(service.registry_path)
+    service = _create_registry(tmp_path / "workspace")
+    registry_path = _registry_path(tmp_path / "workspace")
+    registry_path.parent.mkdir(parents=True)
+    os.mkfifo(registry_path)
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
         service.list_images()
@@ -279,7 +370,7 @@ def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: 
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
 
     with pytest.raises(ImageRegistryError, match="cannot lock"):
-        SlurmImageService(workspace).register_existing(
+        _create_registry(workspace).register_existing(
             ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
             _inspect_client(image_path),
         )
@@ -295,7 +386,7 @@ def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
 
     with pytest.raises(ImageRegistryError, match="cannot lock"):
-        SlurmImageService(workspace).register_existing(
+        _create_registry(workspace).register_existing(
             ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
             _inspect_client(image_path),
         )
@@ -316,7 +407,7 @@ def test_registry_rejects_symlinked_storage_directories(tmp_path: Path, director
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
 
     with pytest.raises(ImageRegistryError, match="cannot initialize"):
-        SlurmImageService(workspace).register_existing(
+        _create_registry(workspace).register_existing(
             ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
             _inspect_client(image_path),
         )
@@ -332,45 +423,51 @@ def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> N
     image_root.chmod(0o775)
     lock_directory.chmod(0o775)
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    service = SlurmImageService(workspace)
+    service = _create_registry(workspace)
 
     service.register_existing(
         ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
         _inspect_client(image_path),
     )
 
-    assert stat.S_IMODE(service.registry_path.stat().st_mode) == 0o600
+    registry_path = _registry_path(workspace)
+    assert stat.S_IMODE(registry_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
-    assert not tuple(service.registry_path.parent.glob(".registry.*.tmp"))
+    assert not tuple(registry_path.parent.glob(".registry.*.tmp"))
 
 
 def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    service = SlurmImageService(workspace)
+    inspection = _inspect_client(image_path)
+    image = RegisteredImage(
+        schema_version=1,
+        name="client",
+        path=image_path.as_posix(),
+        sqsh_sha256=inspection.sqsh_sha256,
+        inspection=inspection,
+    )
+    store = ImageRegistryStore(workspace)
     verification_started = Event()
     finish_verification = Event()
 
-    def verify_before_publish(_image: object) -> None:
+    def verify_before_publish(_image: RegisteredImage) -> None:
         verification_started.set()
         assert finish_verification.wait(timeout=5)
 
-    with (
-        patch("data_designer.slurm.images.service._verify_registered_image", side_effect=verify_before_publish),
-        ThreadPoolExecutor(max_workers=1) as executor,
-    ):
+    with ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(
-            service.register_existing,
-            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-            _inspect_client(image_path),
+            store.register,
+            image,
+            verify_before_publish=verify_before_publish,
         )
         assert verification_started.wait(timeout=5)
-        assert service.list_images() == ()
+        assert ImageRegistryStore(workspace).list_images() == ()
         finish_verification.set()
         assert future.result().name == "client"
 
-    assert tuple(image.name for image in service.list_images()) == ("client",)
+    assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
 
 
 def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:
@@ -380,7 +477,7 @@ def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) ->
     def register(name: str) -> str:
         image_path = _write_sqsh(tmp_path / f"{name}.sqsh", name.encode())
         barrier.wait()
-        image = SlurmImageService(workspace).register_existing(
+        image = _create_registry(workspace).register_existing(
             ImageBuildRequest(name=name, kind="serving", source=image_path.as_posix()),
             _inspect_serving(image_path),
         )
@@ -390,7 +487,7 @@ def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) ->
         names = tuple(executor.map(register, ("first", "second")))
 
     assert names == ("first", "second")
-    assert tuple(image.name for image in SlurmImageService(workspace).list_images()) == ("first", "second")
+    assert tuple(image.name for image in _create_registry(workspace).list_images()) == ("first", "second")
 
 
 def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -> None:
@@ -400,7 +497,7 @@ def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -
     def register(content: bytes) -> str:
         image_path = _write_sqsh(tmp_path / f"{content.decode()}.sqsh", content)
         barrier.wait()
-        image = SlurmImageService(workspace).register_existing(
+        image = _create_registry(workspace).register_existing(
             ImageBuildRequest(name="shared", kind="serving", source=image_path.as_posix()),
             _inspect_serving(image_path),
         )
@@ -414,7 +511,7 @@ def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -
     assert len(outcomes) == 1
     assert len(failures) == 1
     assert isinstance(failures[0], ImageConflictError)
-    assert SlurmImageService(workspace).list_images()[0].path == outcomes[0]
+    assert _create_registry(workspace).list_images()[0].path == outcomes[0]
 
 
 def _write_sqsh(path: Path, content: bytes) -> Path:
@@ -425,18 +522,24 @@ def _write_sqsh(path: Path, content: bytes) -> Path:
 
 def _client_environment() -> FakeInspectionEnvironment:
     return FakeInspectionEnvironment(
-        distributions=(InstalledDistribution(name="data-designer", version="0.9.2"),),
+        distributions=(
+            InstalledDistribution(name="data-designer", version="0.9.2"),
+            InstalledDistribution(name="data-designer-config", version="0.9.2"),
+            InstalledDistribution(name="data-designer-engine", version="0.9.2"),
+            InstalledDistribution(name="data-designer-slurm", version="0.9.2"),
+            InstalledDistribution(name="pip", version="26.1"),
+        ),
         distribution_versions={"pip": "26.1"},
         executables={"pip": "/usr/bin/pip"},
     )
 
 
 def _inspect_client(path: Path) -> ImageInspectionRecord:
-    return ClientImageInspector(_client_environment()).inspect(compute_file_sha256(path))
+    return ClientImageInspector(_client_environment()).inspect(compute_sqsh_file_sha256(path))
 
 
 def _inspect_serving(path: Path) -> ImageInspectionRecord:
-    return ServingImageInspector(_serving_environment()).inspect(compute_file_sha256(path))
+    return ServingImageInspector(_serving_environment()).inspect(compute_sqsh_file_sha256(path))
 
 
 def _serving_environment() -> FakeInspectionEnvironment:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -182,13 +182,44 @@ def test_direct_path_must_be_registered(tmp_path: Path) -> None:
         service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
 
 
-def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path) -> None:
+@pytest.mark.parametrize("content", (b"not-yaml: [\n", b"\xff"), ids=("invalid-yaml", "invalid-utf8"))
+def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: bytes) -> None:
     service = SlurmImageService(tmp_path / "workspace")
     service.registry_path.parent.mkdir(parents=True)
-    service.registry_path.write_text("not-json\n")
+    service.registry_path.write_bytes(content)
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
         service.list_images()
+
+
+def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
+    service = SlurmImageService(tmp_path / "workspace")
+    service.registry_path.parent.mkdir(parents=True)
+    target = tmp_path / "outside.yaml"
+    target.write_text("schema_version: 1\nimages: []\n")
+    service.registry_path.symlink_to(target)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        service.list_images()
+
+
+def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    lock_directory = workspace / "images" / ".locks"
+    lock_directory.mkdir(parents=True)
+    target = tmp_path / "outside.lock"
+    target.write_text("outside")
+    target.chmod(0o640)
+    (lock_directory / "alias-client.lock").symlink_to(target)
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+
+    with pytest.raises(ImageRegistryError, match="cannot lock"):
+        SlurmImageService(workspace).register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            _inspect_client(image_path),
+        )
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
 
 
 def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -8,7 +8,7 @@ import os
 import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Barrier
+from threading import Barrier, Event
 from unittest.mock import patch
 
 import pytest
@@ -102,7 +102,7 @@ def test_registration_requires_explicit_replace_for_alias_updates(tmp_path: Path
     assert first_path.exists()
 
 
-def test_registration_rolls_back_alias_when_sqsh_changes_before_commit(tmp_path: Path) -> None:
+def test_registration_does_not_publish_alias_when_sqsh_changes_before_commit(tmp_path: Path) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
     inspection = _inspect_client(image_path)
     service = SlurmImageService(tmp_path / "workspace")
@@ -122,7 +122,7 @@ def test_registration_rolls_back_alias_when_sqsh_changes_before_commit(tmp_path:
     assert service.list_images() == ()
 
 
-def test_failed_replacement_restores_previous_alias(tmp_path: Path) -> None:
+def test_failed_replacement_keeps_previous_alias(tmp_path: Path) -> None:
     first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
     second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
     service = SlurmImageService(tmp_path / "workspace")
@@ -230,7 +230,15 @@ def test_direct_path_must_be_registered(tmp_path: Path) -> None:
         service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
 
 
-@pytest.mark.parametrize("content", (b"not-yaml: [\n", b"\xff"), ids=("invalid-yaml", "invalid-utf8"))
+@pytest.mark.parametrize(
+    "content",
+    (
+        b"not-yaml: [\n",
+        b"\xff",
+        b"schema_version: 1\nimages: &recursive\n  - *recursive\n",
+    ),
+    ids=("invalid-yaml", "invalid-utf8", "recursive-alias"),
+)
 def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: bytes) -> None:
     service = SlurmImageService(tmp_path / "workspace")
     service.registry_path.parent.mkdir(parents=True)
@@ -293,8 +301,36 @@ def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.parametrize("directory", ("images", "locks"))
+def test_registry_rejects_symlinked_storage_directories(tmp_path: Path, directory: str) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image_root = workspace / "images"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    if directory == "images":
+        image_root.symlink_to(outside, target_is_directory=True)
+    else:
+        image_root.mkdir()
+        (image_root / ".locks").symlink_to(outside, target_is_directory=True)
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+
+    with pytest.raises(ImageRegistryError, match="cannot initialize"):
+        SlurmImageService(workspace).register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            _inspect_client(image_path),
+        )
+
+    assert tuple(outside.iterdir()) == ()
+
+
 def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
+    image_root = workspace / "images"
+    lock_directory = image_root / ".locks"
+    lock_directory.mkdir(parents=True)
+    image_root.chmod(0o775)
+    lock_directory.chmod(0o775)
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
     service = SlurmImageService(workspace)
 
@@ -304,7 +340,37 @@ def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> N
     )
 
     assert stat.S_IMODE(service.registry_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
     assert not tuple(service.registry_path.parent.glob(".registry.*.tmp"))
+
+
+def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    service = SlurmImageService(workspace)
+    verification_started = Event()
+    finish_verification = Event()
+
+    def verify_before_publish(_image: object) -> None:
+        verification_started.set()
+        assert finish_verification.wait(timeout=5)
+
+    with (
+        patch("data_designer.slurm.images.service._verify_registered_image", side_effect=verify_before_publish),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        future = executor.submit(
+            service.register_existing,
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            _inspect_client(image_path),
+        )
+        assert verification_started.wait(timeout=5)
+        assert service.list_images() == ()
+        finish_verification.set()
+        assert future.result().name == "client"
+
+    assert tuple(image.name for image in service.list_images()) == ("client",)
 
 
 def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -9,6 +9,7 @@ import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -99,6 +100,52 @@ def test_registration_requires_explicit_replace_for_alias_updates(tmp_path: Path
 
     assert service.resolve(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path == second_path.as_posix()
     assert first_path.exists()
+
+
+def test_registration_rolls_back_alias_when_sqsh_changes_before_commit(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    inspection = _inspect_client(image_path)
+    service = SlurmImageService(tmp_path / "workspace")
+
+    with (
+        patch(
+            "data_designer.slurm.images.service.compute_file_sha256",
+            side_effect=(inspection.sqsh_sha256, "f" * 64),
+        ),
+        pytest.raises(ImageVerificationError, match="no longer matches"),
+    ):
+        service.register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            inspection,
+        )
+
+    assert service.list_images() == ()
+
+
+def test_failed_replacement_restores_previous_alias(tmp_path: Path) -> None:
+    first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
+    second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
+    service = SlurmImageService(tmp_path / "workspace")
+    service.register_existing(
+        ImageBuildRequest(name="serving", kind="serving", source=first_path.as_posix()),
+        _inspect_serving(first_path),
+    )
+    second_inspection = _inspect_serving(second_path)
+
+    with (
+        patch(
+            "data_designer.slurm.images.service.compute_file_sha256",
+            side_effect=(second_inspection.sqsh_sha256, "f" * 64),
+        ),
+        pytest.raises(ImageVerificationError, match="no longer matches"),
+    ):
+        service.register_existing(
+            ImageBuildRequest(name="serving", kind="serving", source=second_path.as_posix()),
+            second_inspection,
+            replace=True,
+        )
+
+    assert service.resolve(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path == first_path.as_posix()
 
 
 @pytest.mark.parametrize("mutation", (b"modified", b""), ids=("modified", "truncated"))

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
-import stat
 import tempfile
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Barrier, Event
 from unittest.mock import patch
 
 import pytest
@@ -26,12 +24,10 @@ from data_designer.slurm.config import (
 from data_designer.slurm.images.errors import (
     ImageConflictError,
     ImageNotFoundError,
-    ImageRegistryError,
     ImageVerificationError,
 )
 from data_designer.slurm.images.inspection import ClientImageInspector, ServingImageInspector
-from data_designer.slurm.images.records import ImageRegistryDocument, RegisteredImage
-from data_designer.slurm.images.registry import ImageRegistryStore
+from data_designer.slurm.images.records import ImageRegistryDocument
 from data_designer.slurm.images.service import (
     VerifiedImageRegistry,
     compute_sqsh_file_sha256,
@@ -196,6 +192,13 @@ def test_hash_rejects_path_replaced_while_reading(tmp_path: Path) -> None:
         compute_sqsh_file_sha256(image_path)
 
 
+def test_hash_uses_exact_sqsh_bytes(tmp_path: Path) -> None:
+    content = b"exact SQSH bytes\x00\xff"
+    image_path = _write_sqsh(tmp_path / "client.sqsh", content)
+
+    assert compute_sqsh_file_sha256(image_path) == hashlib.sha256(content).hexdigest()
+
+
 @pytest.mark.parametrize("mutation", (b"modified", b""), ids=("modified", "truncated"))
 def test_resolution_rejects_modified_registered_sqsh(tmp_path: Path, mutation: bytes) -> None:
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"original")
@@ -290,228 +293,6 @@ def test_direct_path_must_be_registered(tmp_path: Path) -> None:
 
     with pytest.raises(ImageNotFoundError, match="not registered"):
         service.resolve_for_planning(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
-
-
-@pytest.mark.parametrize(
-    "content",
-    (
-        b"not-yaml: [\n",
-        b"\xff",
-        b"schema_version: 1\nimages: &recursive\n  - *recursive\n",
-        b"images: []\n",
-        b"schema_version: 2\nimages: []\n",
-        b"schema_version: 1\nschema_version: 1\nimages: []\n",
-    ),
-    ids=(
-        "invalid-yaml",
-        "invalid-utf8",
-        "recursive-alias",
-        "missing-version",
-        "unsupported-version",
-        "duplicate-key",
-    ),
-)
-def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: bytes) -> None:
-    service = _create_registry(tmp_path / "workspace")
-    registry_path = _registry_path(tmp_path / "workspace")
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_bytes(content)
-
-    with pytest.raises(ImageRegistryError, match="cannot load"):
-        service.list_images()
-
-
-def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
-    service = _create_registry(tmp_path / "workspace")
-    registry_path = _registry_path(tmp_path / "workspace")
-    registry_path.parent.mkdir(parents=True)
-    target = tmp_path / "outside.yaml"
-    target.write_text("schema_version: 1\nimages: []\n")
-    registry_path.symlink_to(target)
-
-    with pytest.raises(ImageRegistryError, match="cannot load"):
-        service.list_images()
-
-
-def test_registry_rejects_reads_through_symlinked_image_root(tmp_path: Path) -> None:
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    outside_workspace = tmp_path / "outside-workspace"
-    outside_registry = _create_registry(outside_workspace)
-    outside_registry.register_existing(
-        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-        _inspect_client(image_path),
-    )
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    (workspace / "images").symlink_to(outside_workspace / "images", target_is_directory=True)
-
-    with pytest.raises(ImageRegistryError, match="cannot load"):
-        _create_registry(workspace).list_images()
-
-
-def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path) -> None:
-    service = _create_registry(tmp_path / "workspace")
-    registry_path = _registry_path(tmp_path / "workspace")
-    registry_path.parent.mkdir(parents=True)
-    os.mkfifo(registry_path)
-
-    with pytest.raises(ImageRegistryError, match="cannot load"):
-        service.list_images()
-
-
-def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    lock_directory = workspace / "images" / ".locks"
-    lock_directory.mkdir(parents=True)
-    target = tmp_path / "outside.lock"
-    target.write_text("outside")
-    target.chmod(0o640)
-    (lock_directory / "alias-client.lock").symlink_to(target)
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-
-    with pytest.raises(ImageRegistryError, match="cannot lock"):
-        _create_registry(workspace).register_existing(
-            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-            _inspect_client(image_path),
-        )
-
-    assert stat.S_IMODE(target.stat().st_mode) == 0o640
-
-
-def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    lock_directory = workspace / "images" / ".locks"
-    lock_directory.mkdir(parents=True)
-    os.mkfifo(lock_directory / "alias-client.lock")
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-
-    with pytest.raises(ImageRegistryError, match="cannot lock"):
-        _create_registry(workspace).register_existing(
-            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-            _inspect_client(image_path),
-        )
-
-
-@pytest.mark.parametrize("directory", ("images", "locks"))
-def test_registry_rejects_symlinked_storage_directories(tmp_path: Path, directory: str) -> None:
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    image_root = workspace / "images"
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    if directory == "images":
-        image_root.symlink_to(outside, target_is_directory=True)
-    else:
-        image_root.mkdir()
-        (image_root / ".locks").symlink_to(outside, target_is_directory=True)
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-
-    with pytest.raises(ImageRegistryError, match="cannot initialize"):
-        _create_registry(workspace).register_existing(
-            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-            _inspect_client(image_path),
-        )
-
-    assert tuple(outside.iterdir()) == ()
-
-
-def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    image_root = workspace / "images"
-    lock_directory = image_root / ".locks"
-    lock_directory.mkdir(parents=True)
-    image_root.chmod(0o775)
-    lock_directory.chmod(0o775)
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    service = _create_registry(workspace)
-
-    service.register_existing(
-        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
-        _inspect_client(image_path),
-    )
-
-    registry_path = _registry_path(workspace)
-    assert stat.S_IMODE(registry_path.stat().st_mode) == 0o600
-    assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
-    assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
-    assert not tuple(registry_path.parent.glob(".registry.*.tmp"))
-
-
-def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
-    inspection = _inspect_client(image_path)
-    image = RegisteredImage(
-        schema_version=1,
-        name="client",
-        path=image_path.as_posix(),
-        sqsh_sha256=inspection.sqsh_sha256,
-        inspection=inspection,
-    )
-    store = ImageRegistryStore(workspace)
-    verification_started = Event()
-    finish_verification = Event()
-
-    def verify_before_publish(_image: RegisteredImage) -> None:
-        verification_started.set()
-        assert finish_verification.wait(timeout=5)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(
-            store.register,
-            image,
-            verify_before_publish=verify_before_publish,
-        )
-        assert verification_started.wait(timeout=5)
-        assert ImageRegistryStore(workspace).list_images() == ()
-        finish_verification.set()
-        assert future.result().name == "client"
-
-    assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
-
-
-def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    barrier = Barrier(2)
-
-    def register(name: str) -> str:
-        image_path = _write_sqsh(tmp_path / f"{name}.sqsh", name.encode())
-        barrier.wait()
-        image = _create_registry(workspace).register_existing(
-            ImageBuildRequest(name=name, kind="serving", source=image_path.as_posix()),
-            _inspect_serving(image_path),
-        )
-        return image.name
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        names = tuple(executor.map(register, ("first", "second")))
-
-    assert names == ("first", "second")
-    assert tuple(image.name for image in _create_registry(workspace).list_images()) == ("first", "second")
-
-
-def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
-    barrier = Barrier(2)
-
-    def register(content: bytes) -> str:
-        image_path = _write_sqsh(tmp_path / f"{content.decode()}.sqsh", content)
-        barrier.wait()
-        image = _create_registry(workspace).register_existing(
-            ImageBuildRequest(name="shared", kind="serving", source=image_path.as_posix()),
-            _inspect_serving(image_path),
-        )
-        return image.path
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = tuple(executor.submit(register, content) for content in (b"first", b"second"))
-
-    failures = tuple(future.exception() for future in futures if future.exception() is not None)
-    outcomes = tuple(future.result() for future in futures if future.exception() is None)
-    assert len(outcomes) == 1
-    assert len(failures) == 1
-    assert isinstance(failures[0], ImageConflictError)
-    assert _create_registry(workspace).list_images()[0].path == outcomes[0]
 
 
 def _write_sqsh(path: Path, content: bytes) -> Path:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -203,6 +204,15 @@ def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
         service.list_images()
 
 
+def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path) -> None:
+    service = SlurmImageService(tmp_path / "workspace")
+    service.registry_path.parent.mkdir(parents=True)
+    os.mkfifo(service.registry_path)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        service.list_images()
+
+
 def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     lock_directory = workspace / "images" / ".locks"
@@ -220,6 +230,20 @@ def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: 
         )
 
     assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    lock_directory = workspace / "images" / ".locks"
+    lock_directory.mkdir(parents=True)
+    os.mkfifo(lock_directory / "alias-client.lock")
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+
+    with pytest.raises(ImageRegistryError, match="cannot lock"):
+        SlurmImageService(workspace).register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            _inspect_client(image_path),
+        )
 
 
 def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
@@ -186,6 +187,20 @@ def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path) -> None:
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
         service.list_images()
+
+
+def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    service = SlurmImageService(workspace)
+
+    service.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+
+    assert stat.S_IMODE(service.registry_path.stat().st_mode) == 0o600
+    assert not tuple(service.registry_path.parent.glob(".registry.*.tmp"))
 
 
 def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+import pytest
+from slurm_test_fakes import FakeInspectionEnvironment
+
+from data_designer.slurm.config import (
+    ImageBuildRequest,
+    ImageInspectionRecord,
+    ImageKind,
+    ImageRef,
+    InstalledDistribution,
+)
+from data_designer.slurm.images import (
+    ClientImageInspector,
+    ImageConflictError,
+    ImageNotFoundError,
+    ImageRegistryError,
+    ImageRegistrySnapshot,
+    ImageVerificationError,
+    ServingImageInspector,
+    SlurmImageService,
+    compute_file_sha256,
+)
+
+
+def test_register_and_resolve_existing_sqsh_by_alias_and_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "artifacts" / "client.sqsh", b"client-image")
+    inspection = _inspect_client(image_path)
+    service = SlurmImageService(workspace)
+
+    registered = service.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        inspection,
+    )
+
+    by_alias = service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+    by_path = service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
+    persisted = ImageRegistrySnapshot.model_validate_json(service.registry_path.read_text())
+    assert by_alias.path == by_path.path
+    assert by_alias.sha256 == by_path.sha256
+    assert by_alias.inspection == by_path.inspection
+    assert by_alias.path == image_path.as_posix()
+    assert registered == persisted.images[0]
+    assert service.registry_path == workspace / "images" / "registry.json"
+
+
+def test_registry_lists_aliases_deterministically(tmp_path: Path) -> None:
+    service = SlurmImageService(tmp_path / "workspace")
+    for name in ("zeta", "alpha"):
+        image_path = _write_sqsh(tmp_path / f"{name}.sqsh", name.encode())
+        service.register_existing(
+            ImageBuildRequest(name=name, kind="serving", source=image_path.as_posix()),
+            _inspect_serving(image_path),
+        )
+
+    assert tuple(image.name for image in service.list_images()) == ("alpha", "zeta")
+
+
+def test_unregister_removes_only_alias(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client-image")
+    service = SlurmImageService(tmp_path / "workspace")
+    service.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+
+    removed = service.unregister("client")
+
+    assert removed.path == image_path.as_posix()
+    assert image_path.read_bytes() == b"client-image"
+    with pytest.raises(ImageNotFoundError, match="not registered"):
+        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+
+
+def test_registration_requires_explicit_replace_for_alias_updates(tmp_path: Path) -> None:
+    first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
+    second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
+    service = SlurmImageService(tmp_path / "workspace")
+    request = ImageBuildRequest(name="serving", kind="serving", source=first_path.as_posix())
+    service.register_existing(request, _inspect_serving(first_path))
+
+    replacement = ImageBuildRequest(name="serving", kind="serving", source=second_path.as_posix())
+    with pytest.raises(ImageConflictError, match="already registered"):
+        service.register_existing(replacement, _inspect_serving(second_path))
+
+    service.register_existing(replacement, _inspect_serving(second_path), replace=True)
+
+    assert service.resolve(ImageRef(name="serving"), expected_kind=ImageKind.SERVING).path == second_path.as_posix()
+    assert first_path.exists()
+
+
+@pytest.mark.parametrize("mutation", (b"modified", b""), ids=("modified", "truncated"))
+def test_resolution_rejects_modified_registered_sqsh(tmp_path: Path, mutation: bytes) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"original")
+    service = SlurmImageService(tmp_path / "workspace")
+    service.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+    image_path.write_bytes(mutation)
+
+    with pytest.raises(ImageVerificationError, match="no longer matches"):
+        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
+
+
+def test_resolution_rejects_kind_mismatch(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    service = SlurmImageService(tmp_path / "workspace")
+    service.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+
+    with pytest.raises(ImageVerificationError, match="does not match"):
+        service.resolve(ImageRef(name="client"), expected_kind=ImageKind.SERVING)
+
+
+def test_registration_rejects_missing_symlink_and_wrong_inspection(tmp_path: Path) -> None:
+    target = _write_sqsh(tmp_path / "target.sqsh", b"target")
+    symlink = tmp_path / "link.sqsh"
+    symlink.symlink_to(target)
+    service = SlurmImageService(tmp_path / "workspace")
+
+    with pytest.raises(ImageVerificationError, match="does not exist"):
+        service.register_existing(
+            ImageBuildRequest(name="missing", kind="client", source=(tmp_path / "missing.sqsh").as_posix()),
+            _inspect_client(target),
+        )
+    with pytest.raises(ImageVerificationError, match="regular non-symlink"):
+        service.register_existing(
+            ImageBuildRequest(name="symlink", kind="client", source=symlink.as_posix()),
+            _inspect_client(target),
+        )
+    with pytest.raises(ImageVerificationError, match="digest"):
+        service.register_existing(
+            ImageBuildRequest(name="mismatch", kind="client", source=target.as_posix()),
+            ClientImageInspector(_client_environment()).inspect("f" * 64),
+        )
+    assert service.list_images() == ()
+
+
+def test_registration_rejects_kind_mismatched_inspection(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "image.sqsh", b"image")
+    service = SlurmImageService(tmp_path / "workspace")
+
+    with pytest.raises(ImageVerificationError, match="kind"):
+        service.register_existing(
+            ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+            _inspect_serving(image_path),
+        )
+    assert service.list_images() == ()
+
+
+def test_existing_registration_rejects_oci_source(tmp_path: Path) -> None:
+    service = SlurmImageService(tmp_path / "workspace")
+    request = ImageBuildRequest(
+        name="serving",
+        kind="serving",
+        source=f"registry.example.test/serving@sha256:{'a' * 64}",
+    )
+
+    with pytest.raises(ImageVerificationError, match="CPU Slurm image lifecycle"):
+        service.register_existing(request, ServingImageInspector(_serving_environment()).inspect("a" * 64))
+
+
+def test_direct_path_must_be_registered(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "unregistered.sqsh", b"unregistered")
+    service = SlurmImageService(tmp_path / "workspace")
+
+    with pytest.raises(ImageNotFoundError, match="not registered"):
+        service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
+
+
+def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path) -> None:
+    service = SlurmImageService(tmp_path / "workspace")
+    service.registry_path.parent.mkdir(parents=True)
+    service.registry_path.write_text("not-json\n")
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        service.list_images()
+
+
+def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    barrier = Barrier(2)
+
+    def register(name: str) -> str:
+        image_path = _write_sqsh(tmp_path / f"{name}.sqsh", name.encode())
+        barrier.wait()
+        image = SlurmImageService(workspace).register_existing(
+            ImageBuildRequest(name=name, kind="serving", source=image_path.as_posix()),
+            _inspect_serving(image_path),
+        )
+        return image.name
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        names = tuple(executor.map(register, ("first", "second")))
+
+    assert names == ("first", "second")
+    assert tuple(image.name for image in SlurmImageService(workspace).list_images()) == ("first", "second")
+
+
+def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    barrier = Barrier(2)
+
+    def register(content: bytes) -> str:
+        image_path = _write_sqsh(tmp_path / f"{content.decode()}.sqsh", content)
+        barrier.wait()
+        image = SlurmImageService(workspace).register_existing(
+            ImageBuildRequest(name="shared", kind="serving", source=image_path.as_posix()),
+            _inspect_serving(image_path),
+        )
+        return image.path
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(register, content) for content in (b"first", b"second"))
+
+    failures = tuple(future.exception() for future in futures if future.exception() is not None)
+    outcomes = tuple(future.result() for future in futures if future.exception() is None)
+    assert len(outcomes) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], ImageConflictError)
+    assert SlurmImageService(workspace).list_images()[0].path == outcomes[0]
+
+
+def _write_sqsh(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _client_environment() -> FakeInspectionEnvironment:
+    return FakeInspectionEnvironment(
+        distributions=(InstalledDistribution(name="data-designer", version="0.9.2"),),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+
+
+def _inspect_client(path: Path) -> ImageInspectionRecord:
+    return ClientImageInspector(_client_environment()).inspect(compute_file_sha256(path))
+
+
+def _inspect_serving(path: Path) -> ImageInspectionRecord:
+    return ServingImageInspector(_serving_environment()).inspect(compute_file_sha256(path))
+
+
+def _serving_environment() -> FakeInspectionEnvironment:
+    return FakeInspectionEnvironment(
+        distribution_versions={"vllm": "0.21.0"},
+        executables={"vllm": "/usr/local/bin/vllm"},
+    )

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import json
 import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
 
 import pytest
+import yaml
 from slurm_test_fakes import FakeInspectionEnvironment
 
 from data_designer.slurm.config import (
@@ -44,13 +46,13 @@ def test_register_and_resolve_existing_sqsh_by_alias_and_path(tmp_path: Path) ->
 
     by_alias = service.resolve(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
     by_path = service.resolve(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
-    persisted = ImageRegistrySnapshot.model_validate_json(service.registry_path.read_text())
+    persisted = ImageRegistrySnapshot.model_validate_json(json.dumps(yaml.safe_load(service.registry_path.read_text())))
     assert by_alias.path == by_path.path
     assert by_alias.sha256 == by_path.sha256
     assert by_alias.inspection == by_path.inspection
     assert by_alias.path == image_path.as_posix()
     assert registered == persisted.images[0]
-    assert service.registry_path == workspace / "images" / "registry.json"
+    assert service.registry_path == workspace / "images" / "registry.yaml"
 
 
 def test_registry_lists_aliases_deterministically(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -38,7 +38,7 @@ def _create_registry(workspace: Path) -> VerifiedImageRegistry:
     return VerifiedImageRegistry(workspace)
 
 
-def _registry_path(workspace: Path) -> Path:
+def _get_registry_path(workspace: Path) -> Path:
     return workspace / "images" / "registry.yaml"
 
 
@@ -56,14 +56,14 @@ def test_register_and_resolve_existing_sqsh_by_alias_and_path(tmp_path: Path) ->
     by_alias = service.resolve_for_planning(ImageRef(name="client"), expected_kind=ImageKind.CLIENT)
     by_path = service.resolve_for_planning(ImageRef(path=image_path.as_posix()), expected_kind=ImageKind.CLIENT)
     persisted = ImageRegistryDocument.model_validate_json(
-        json.dumps(yaml.safe_load(_registry_path(workspace).read_text()))
+        json.dumps(yaml.safe_load(_get_registry_path(workspace).read_text()))
     )
     assert by_alias.path == by_path.path
     assert by_alias.sha256 == by_path.sha256
     assert by_alias.inspection == by_path.inspection
     assert by_alias.path == image_path.as_posix()
     assert registered == persisted.images[0]
-    assert _registry_path(workspace) == workspace / "images" / "registry.yaml"
+    assert _get_registry_path(workspace) == workspace / "images" / "registry.yaml"
 
 
 def test_registry_lists_aliases_deterministically(tmp_path: Path) -> None:
@@ -247,7 +247,7 @@ def test_registration_rejects_missing_symlink_and_wrong_inspection(tmp_path: Pat
     with pytest.raises(ImageVerificationError, match="digest"):
         service.register_existing(
             ImageBuildRequest(name="mismatch", kind="client", source=target.as_posix()),
-            ClientImageInspector(_client_environment()).inspect("f" * 64),
+            ClientImageInspector(_get_client_environment()).inspect("f" * 64),
         )
     assert service.list_images() == ()
 
@@ -287,7 +287,7 @@ def test_existing_registration_rejects_oci_source(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ImageVerificationError, match="CPU Slurm image lifecycle"):
-        service.register_existing(request, ServingImageInspector(_serving_environment()).inspect("a" * 64))
+        service.register_existing(request, ServingImageInspector(_get_serving_environment()).inspect("a" * 64))
 
 
 def test_direct_path_must_be_registered(tmp_path: Path) -> None:
@@ -304,7 +304,7 @@ def _write_sqsh(path: Path, content: bytes) -> Path:
     return path
 
 
-def _client_environment() -> FakeInspectionEnvironment:
+def _get_client_environment() -> FakeInspectionEnvironment:
     return FakeInspectionEnvironment(
         distributions=(
             InstalledDistribution(name="data-designer", version="0.9.2"),
@@ -319,14 +319,14 @@ def _client_environment() -> FakeInspectionEnvironment:
 
 
 def _inspect_client(path: Path) -> ImageInspectionRecord:
-    return ClientImageInspector(_client_environment()).inspect(compute_sqsh_file_sha256(path))
+    return ClientImageInspector(_get_client_environment()).inspect(compute_sqsh_file_sha256(path))
 
 
 def _inspect_serving(path: Path) -> ImageInspectionRecord:
-    return ServingImageInspector(_serving_environment()).inspect(compute_sqsh_file_sha256(path))
+    return ServingImageInspector(_get_serving_environment()).inspect(compute_sqsh_file_sha256(path))
 
 
-def _serving_environment() -> FakeInspectionEnvironment:
+def _get_serving_environment() -> FakeInspectionEnvironment:
     return FakeInspectionEnvironment(
         distribution_versions={"vllm": "0.21.0"},
         executables={"vllm": "/usr/local/bin/vllm"},

--- a/packages/data-designer-slurm/tests/images/test_registry.py
+++ b/packages/data-designer-slurm/tests/images/test_registry.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import tempfile
+import secrets
 from pathlib import Path
 from unittest.mock import patch
 
@@ -123,15 +123,15 @@ def test_failed_replacement_keeps_previous_alias(tmp_path: Path) -> None:
         _inspect_serving(first_path),
     )
     second_inspection = _inspect_serving(second_path)
-    original_mkstemp = tempfile.mkstemp
+    original_token_hex = secrets.token_hex
 
-    def mutate_replacement_before_registry_write(*args: object, **kwargs: object) -> tuple[int, str]:
+    def mutate_replacement_before_registry_write(nbytes: int | None = None) -> str:
         second_path.write_bytes(b"modified")
-        return original_mkstemp(*args, **kwargs)
+        return original_token_hex(nbytes)
 
     with (
         patch(
-            "data_designer.slurm.images.registry.tempfile.mkstemp",
+            "data_designer.slurm.images.registry.secrets.token_hex",
             side_effect=mutate_replacement_before_registry_write,
         ),
         pytest.raises(ImageVerificationError, match="no longer matches"),
@@ -154,14 +154,17 @@ def test_registration_does_not_publish_alias_when_sqsh_changes_before_atomic_pub
     image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
     inspection = _inspect_client(image_path)
     service = _create_registry(workspace)
-    original_mkstemp = tempfile.mkstemp
+    original_token_hex = secrets.token_hex
 
-    def mutate_image_before_registry_write(*args: object, **kwargs: object) -> tuple[int, str]:
+    def mutate_image_before_registry_write(nbytes: int | None = None) -> str:
         image_path.write_bytes(b"modified")
-        return original_mkstemp(*args, **kwargs)
+        return original_token_hex(nbytes)
 
     with (
-        patch("data_designer.slurm.images.registry.tempfile.mkstemp", side_effect=mutate_image_before_registry_write),
+        patch(
+            "data_designer.slurm.images.registry.secrets.token_hex",
+            side_effect=mutate_image_before_registry_write,
+        ),
         pytest.raises(ImageVerificationError, match="no longer matches"),
     ):
         service.register_existing(

--- a/packages/data-designer-slurm/tests/images/test_registry_store.py
+++ b/packages/data-designer-slurm/tests/images/test_registry_store.py
@@ -50,7 +50,7 @@ def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: by
 
 def test_registry_rejects_persisted_non_sqsh_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     payload = image.model_dump(mode="json")
     payload["path"] = (tmp_path / "client.bin").as_posix()
     _write_registry_images(workspace, (payload,))
@@ -61,7 +61,7 @@ def test_registry_rejects_persisted_non_sqsh_path(tmp_path: Path) -> None:
 
 def test_registry_rejects_persisted_inspection_digest_mismatch(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     payload = image.model_dump(mode="json")
     payload["sqsh_sha256"] = "f" * 64
     _write_registry_images(workspace, (payload,))
@@ -72,8 +72,8 @@ def test_registry_rejects_persisted_inspection_digest_mismatch(tmp_path: Path) -
 
 def test_registry_rejects_persisted_unsorted_aliases(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    zeta = _registered_client(_write_sqsh(tmp_path / "zeta.sqsh", b"zeta"), name="zeta")
-    alpha = _registered_client(_write_sqsh(tmp_path / "alpha.sqsh", b"alpha"), name="alpha")
+    zeta = _get_registered_client_image(_write_sqsh(tmp_path / "zeta.sqsh", b"zeta"), name="zeta")
+    alpha = _get_registered_client_image(_write_sqsh(tmp_path / "alpha.sqsh", b"alpha"), name="alpha")
     _write_registry_images(workspace, (zeta.model_dump(mode="json"), alpha.model_dump(mode="json")))
 
     with pytest.raises(ImageRegistryError, match="cannot load"):
@@ -82,7 +82,7 @@ def test_registry_rejects_persisted_unsorted_aliases(tmp_path: Path) -> None:
 
 def test_registry_rejects_persisted_duplicate_aliases(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     payload = image.model_dump(mode="json")
     _write_registry_images(workspace, (payload, payload))
 
@@ -93,7 +93,7 @@ def test_registry_rejects_persisted_duplicate_aliases(tmp_path: Path) -> None:
 def test_registry_rejects_persisted_conflicting_facts_for_one_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image_path = _write_sqsh(tmp_path / "shared.sqsh", b"shared")
-    client = _registered_client(image_path, name="client")
+    client = _get_registered_client_image(image_path, name="client")
     serving_inspection = _inspect_serving(image_path)
     serving = RegisteredImage(
         schema_version=1,
@@ -113,7 +113,7 @@ def test_registry_rejects_persisted_conflicting_facts_for_one_path(tmp_path: Pat
 
 def test_registry_allows_aliases_with_identical_facts_for_one_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    image = _registered_client(_write_sqsh(tmp_path / "shared.sqsh", b"shared"), name="alpha")
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "shared.sqsh", b"shared"), name="alpha")
     alias = image.model_copy(update={"name": "beta"})
     store = ImageRegistryStore(workspace)
 
@@ -126,7 +126,7 @@ def test_registry_allows_aliases_with_identical_facts_for_one_path(tmp_path: Pat
 def test_registry_rejects_new_alias_with_conflicting_facts_for_one_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image_path = _write_sqsh(tmp_path / "shared.sqsh", b"shared")
-    client = _registered_client(image_path, name="client")
+    client = _get_registered_client_image(image_path, name="client")
     serving_inspection = _inspect_serving(image_path)
     serving = RegisteredImage(
         schema_version=1,
@@ -144,7 +144,7 @@ def test_registry_rejects_new_alias_with_conflicting_facts_for_one_path(tmp_path
 
 def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    registry_path = _registry_path(workspace)
+    registry_path = _get_registry_path(workspace)
     registry_path.parent.mkdir(parents=True)
     target = tmp_path / "outside.yaml"
     target.write_text("schema_version: 1\nimages: []\n")
@@ -172,7 +172,7 @@ def test_registry_rejects_reads_through_symlinked_image_root(tmp_path: Path) -> 
 
 def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    registry_path = _registry_path(workspace)
+    registry_path = _get_registry_path(workspace)
     registry_path.parent.mkdir(parents=True)
     os.mkfifo(registry_path)
 
@@ -188,7 +188,7 @@ def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: 
     target.write_text("outside")
     target.chmod(0o640)
     (lock_directory / "alias-client.lock").symlink_to(target)
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
 
     with pytest.raises(ImageRegistryError, match="cannot lock"):
         ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
@@ -201,7 +201,7 @@ def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
     lock_directory = workspace / "images" / ".locks"
     lock_directory.mkdir(parents=True)
     os.mkfifo(lock_directory / "alias-client.lock")
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
 
     with pytest.raises(ImageRegistryError, match="cannot lock"):
         ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
@@ -219,7 +219,7 @@ def test_registry_rejects_symlinked_storage_directories(tmp_path: Path, director
     else:
         image_root.mkdir()
         (image_root / ".locks").symlink_to(outside, target_is_directory=True)
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
 
     with pytest.raises(ImageRegistryError, match="cannot initialize"):
         ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
@@ -234,11 +234,11 @@ def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> N
     lock_directory.mkdir(parents=True)
     image_root.chmod(0o775)
     lock_directory.chmod(0o775)
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
 
     ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
 
-    registry_path = _registry_path(workspace)
+    registry_path = _get_registry_path(workspace)
     assert stat.S_IMODE(registry_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
@@ -247,7 +247,7 @@ def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> N
 
 def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     store = ImageRegistryStore(workspace)
     verification_started = Event()
     finish_verification = Event()
@@ -276,7 +276,7 @@ def test_registry_transaction_stays_bound_when_image_root_path_is_replaced(tmp_p
     detached_image_root = workspace / "detached-images"
     replacement_image_root = workspace / "replacement-images"
     replacement_image_root.mkdir(parents=True)
-    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
 
     def replace_image_root(_image: RegisteredImage) -> None:
         image_root.rename(detached_image_root)
@@ -294,7 +294,7 @@ def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) ->
     barrier = Barrier(2)
 
     def register(name: str) -> str:
-        image = _registered_client(_write_sqsh(tmp_path / f"{name}.sqsh", name.encode()), name=name)
+        image = _get_registered_client_image(_write_sqsh(tmp_path / f"{name}.sqsh", name.encode()), name=name)
         barrier.wait()
         return ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None).name
 
@@ -310,7 +310,7 @@ def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -
     barrier = Barrier(2)
 
     def register(content: bytes) -> str:
-        image = _registered_client(_write_sqsh(tmp_path / f"{content.decode()}.sqsh", content), name="shared")
+        image = _get_registered_client_image(_write_sqsh(tmp_path / f"{content.decode()}.sqsh", content), name="shared")
         barrier.wait()
         return ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None).path
 
@@ -326,7 +326,7 @@ def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -
 
 
 def _write_registry_content(workspace: Path, content: bytes) -> None:
-    registry_path = _registry_path(workspace)
+    registry_path = _get_registry_path(workspace)
     registry_path.parent.mkdir(parents=True)
     registry_path.write_bytes(content)
 
@@ -336,7 +336,7 @@ def _write_registry_images(workspace: Path, images: tuple[dict[str, object], ...
     _write_registry_content(workspace, content)
 
 
-def _registry_path(workspace: Path) -> Path:
+def _get_registry_path(workspace: Path) -> Path:
     return workspace / "images" / "registry.yaml"
 
 
@@ -346,7 +346,7 @@ def _write_sqsh(path: Path, content: bytes) -> Path:
     return path
 
 
-def _registered_client(path: Path, *, name: str = "client") -> RegisteredImage:
+def _get_registered_client_image(path: Path, *, name: str = "client") -> RegisteredImage:
     inspection = _inspect_client(path)
     return RegisteredImage(
         schema_version=1,

--- a/packages/data-designer-slurm/tests/images/test_registry_store.py
+++ b/packages/data-designer-slurm/tests/images/test_registry_store.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import stat
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, Event
+
+import pytest
+import yaml
+from slurm_test_fakes import FakeInspectionEnvironment
+
+from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, InstalledDistribution
+from data_designer.slurm.images.errors import ImageConflictError, ImageRegistryError
+from data_designer.slurm.images.inspection import ClientImageInspector, ServingImageInspector
+from data_designer.slurm.images.records import RegisteredImage
+from data_designer.slurm.images.registry import ImageRegistryStore
+from data_designer.slurm.images.service import VerifiedImageRegistry, compute_sqsh_file_sha256
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        b"not-yaml: [\n",
+        b"\xff",
+        b"schema_version: 1\nimages: &recursive\n  - *recursive\n",
+        b"images: []\n",
+        b"schema_version: 2\nimages: []\n",
+        b"schema_version: 1\nschema_version: 1\nimages: []\n",
+    ),
+    ids=(
+        "invalid-yaml",
+        "invalid-utf8",
+        "recursive-alias",
+        "missing-version",
+        "unsupported-version",
+        "duplicate-key",
+    ),
+)
+def test_registry_normalizes_corrupt_persisted_state(tmp_path: Path, content: bytes) -> None:
+    workspace = tmp_path / "workspace"
+    _write_registry_content(workspace, content)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_persisted_non_sqsh_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    payload = image.model_dump(mode="json")
+    payload["path"] = (tmp_path / "client.bin").as_posix()
+    _write_registry_images(workspace, (payload,))
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_persisted_inspection_digest_mismatch(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    payload = image.model_dump(mode="json")
+    payload["sqsh_sha256"] = "f" * 64
+    _write_registry_images(workspace, (payload,))
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_persisted_unsorted_aliases(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    zeta = _registered_client(_write_sqsh(tmp_path / "zeta.sqsh", b"zeta"), name="zeta")
+    alpha = _registered_client(_write_sqsh(tmp_path / "alpha.sqsh", b"alpha"), name="alpha")
+    _write_registry_images(workspace, (zeta.model_dump(mode="json"), alpha.model_dump(mode="json")))
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_persisted_duplicate_aliases(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    payload = image.model_dump(mode="json")
+    _write_registry_images(workspace, (payload, payload))
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_persisted_conflicting_facts_for_one_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "shared.sqsh", b"shared")
+    client = _registered_client(image_path, name="client")
+    serving_inspection = _inspect_serving(image_path)
+    serving = RegisteredImage(
+        schema_version=1,
+        name="serving",
+        path=image_path.as_posix(),
+        sqsh_sha256=serving_inspection.sqsh_sha256,
+        inspection=serving_inspection,
+    )
+    _write_registry_images(
+        workspace,
+        (client.model_dump(mode="json"), serving.model_dump(mode="json")),
+    )
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_allows_aliases_with_identical_facts_for_one_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _registered_client(_write_sqsh(tmp_path / "shared.sqsh", b"shared"), name="alpha")
+    alias = image.model_copy(update={"name": "beta"})
+    store = ImageRegistryStore(workspace)
+
+    store.register(image, verify_before_publish=lambda _image: None)
+    store.register(alias, verify_before_publish=lambda _image: None)
+
+    assert store.list_images() == (image, alias)
+
+
+def test_registry_rejects_new_alias_with_conflicting_facts_for_one_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = _write_sqsh(tmp_path / "shared.sqsh", b"shared")
+    client = _registered_client(image_path, name="client")
+    serving_inspection = _inspect_serving(image_path)
+    serving = RegisteredImage(
+        schema_version=1,
+        name="serving",
+        path=image_path.as_posix(),
+        sqsh_sha256=serving_inspection.sqsh_sha256,
+        inspection=serving_inspection,
+    )
+    store = ImageRegistryStore(workspace)
+    store.register(client, verify_before_publish=lambda _image: None)
+
+    with pytest.raises(ImageConflictError, match="different immutable facts"):
+        store.register(serving, verify_before_publish=lambda _image: None)
+
+
+def test_registry_rejects_symlinked_state_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    registry_path = _registry_path(workspace)
+    registry_path.parent.mkdir(parents=True)
+    target = tmp_path / "outside.yaml"
+    target.write_text("schema_version: 1\nimages: []\n")
+    registry_path.symlink_to(target)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_reads_through_symlinked_image_root(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    outside_workspace = tmp_path / "outside-workspace"
+    outside_registry = VerifiedImageRegistry(outside_workspace)
+    outside_registry.register_existing(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _inspect_client(image_path),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "images").symlink_to(outside_workspace / "images", target_is_directory=True)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    registry_path = _registry_path(workspace)
+    registry_path.parent.mkdir(parents=True)
+    os.mkfifo(registry_path)
+
+    with pytest.raises(ImageRegistryError, match="cannot load"):
+        ImageRegistryStore(workspace).list_images()
+
+
+def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    lock_directory = workspace / "images" / ".locks"
+    lock_directory.mkdir(parents=True)
+    target = tmp_path / "outside.lock"
+    target.write_text("outside")
+    target.chmod(0o640)
+    (lock_directory / "alias-client.lock").symlink_to(target)
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+
+    with pytest.raises(ImageRegistryError, match="cannot lock"):
+        ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_registry_rejects_nonregular_lock_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    lock_directory = workspace / "images" / ".locks"
+    lock_directory.mkdir(parents=True)
+    os.mkfifo(lock_directory / "alias-client.lock")
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+
+    with pytest.raises(ImageRegistryError, match="cannot lock"):
+        ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
+
+
+@pytest.mark.parametrize("directory", ("images", "locks"))
+def test_registry_rejects_symlinked_storage_directories(tmp_path: Path, directory: str) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image_root = workspace / "images"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    if directory == "images":
+        image_root.symlink_to(outside, target_is_directory=True)
+    else:
+        image_root.mkdir()
+        (image_root / ".locks").symlink_to(outside, target_is_directory=True)
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+
+    with pytest.raises(ImageRegistryError, match="cannot initialize"):
+        ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
+
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_root = workspace / "images"
+    lock_directory = image_root / ".locks"
+    lock_directory.mkdir(parents=True)
+    image_root.chmod(0o775)
+    lock_directory.chmod(0o775)
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+
+    ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None)
+
+    registry_path = _registry_path(workspace)
+    assert stat.S_IMODE(registry_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
+    assert not tuple(registry_path.parent.glob(".registry.*.tmp"))
+
+
+def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    store = ImageRegistryStore(workspace)
+    verification_started = Event()
+    finish_verification = Event()
+
+    def verify_before_publish(_image: RegisteredImage) -> None:
+        verification_started.set()
+        assert finish_verification.wait(timeout=5)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            store.register,
+            image,
+            verify_before_publish=verify_before_publish,
+        )
+        assert verification_started.wait(timeout=5)
+        assert ImageRegistryStore(workspace).list_images() == ()
+        finish_verification.set()
+        assert future.result().name == "client"
+
+    assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
+
+
+def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    barrier = Barrier(2)
+
+    def register(name: str) -> str:
+        image = _registered_client(_write_sqsh(tmp_path / f"{name}.sqsh", name.encode()), name=name)
+        barrier.wait()
+        return ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None).name
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        names = tuple(executor.map(register, ("first", "second")))
+
+    assert names == ("first", "second")
+    assert tuple(image.name for image in ImageRegistryStore(workspace).list_images()) == ("first", "second")
+
+
+def test_concurrent_writers_cannot_publish_conflicting_aliases(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    barrier = Barrier(2)
+
+    def register(content: bytes) -> str:
+        image = _registered_client(_write_sqsh(tmp_path / f"{content.decode()}.sqsh", content), name="shared")
+        barrier.wait()
+        return ImageRegistryStore(workspace).register(image, verify_before_publish=lambda _image: None).path
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(register, content) for content in (b"first", b"second"))
+
+    failures = tuple(future.exception() for future in futures if future.exception() is not None)
+    outcomes = tuple(future.result() for future in futures if future.exception() is None)
+    assert len(outcomes) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], ImageConflictError)
+    assert ImageRegistryStore(workspace).list_images()[0].path == outcomes[0]
+
+
+def _write_registry_content(workspace: Path, content: bytes) -> None:
+    registry_path = _registry_path(workspace)
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_bytes(content)
+
+
+def _write_registry_images(workspace: Path, images: tuple[dict[str, object], ...]) -> None:
+    content = yaml.safe_dump({"schema_version": 1, "images": list(images)}, sort_keys=True).encode()
+    _write_registry_content(workspace, content)
+
+
+def _registry_path(workspace: Path) -> Path:
+    return workspace / "images" / "registry.yaml"
+
+
+def _write_sqsh(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _registered_client(path: Path, *, name: str = "client") -> RegisteredImage:
+    inspection = _inspect_client(path)
+    return RegisteredImage(
+        schema_version=1,
+        name=name,
+        path=path.as_posix(),
+        sqsh_sha256=inspection.sqsh_sha256,
+        inspection=inspection,
+    )
+
+
+def _inspect_client(path: Path) -> ImageInspectionRecord:
+    environment = FakeInspectionEnvironment(
+        distributions=(
+            InstalledDistribution(name="data-designer", version="0.9.2"),
+            InstalledDistribution(name="data-designer-config", version="0.9.2"),
+            InstalledDistribution(name="data-designer-engine", version="0.9.2"),
+            InstalledDistribution(name="data-designer-slurm", version="0.9.2"),
+            InstalledDistribution(name="pip", version="26.1"),
+        ),
+        distribution_versions={"pip": "26.1"},
+        executables={"pip": "/usr/bin/pip"},
+    )
+    return ClientImageInspector(environment).inspect(compute_sqsh_file_sha256(path))
+
+
+def _inspect_serving(path: Path) -> ImageInspectionRecord:
+    environment = FakeInspectionEnvironment(
+        distribution_versions={"vllm": "0.21.0"},
+        executables={"vllm": "/usr/local/bin/vllm"},
+    )
+    return ServingImageInspector(environment).inspect(compute_sqsh_file_sha256(path))

--- a/packages/data-designer-slurm/tests/images/test_registry_store.py
+++ b/packages/data-designer-slurm/tests/images/test_registry_store.py
@@ -270,6 +270,25 @@ def test_registration_remains_unpublished_until_final_verification(tmp_path: Pat
     assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
 
 
+def test_registry_transaction_stays_bound_when_image_root_path_is_replaced(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_root = workspace / "images"
+    detached_image_root = workspace / "detached-images"
+    replacement_image_root = workspace / "replacement-images"
+    replacement_image_root.mkdir(parents=True)
+    image = _registered_client(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+
+    def replace_image_root(_image: RegisteredImage) -> None:
+        image_root.rename(detached_image_root)
+        replacement_image_root.rename(image_root)
+
+    ImageRegistryStore(workspace).register(image, verify_before_publish=replace_image_root)
+
+    assert not (image_root / "registry.yaml").exists()
+    relocated_registry = yaml.safe_load((detached_image_root / "registry.yaml").read_text())
+    assert relocated_registry["images"][0]["name"] == "client"
+
+
 def test_concurrent_alias_writers_preserve_both_registrations(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     barrier = Barrier(2)

--- a/packages/data-designer-slurm/tests/integration/golden/finalization_chain.json
+++ b/packages/data-designer-slurm/tests/integration/golden/finalization_chain.json
@@ -9,7 +9,7 @@
     "created_at": "2026-08-19T12:00:02Z",
     "resolved_plan": {
       "path": "/workspace/primary/runs/run-single/resolved-plan.json",
-      "sha256": "d9155dd04ad439b4cd091eaec9b7b4d938bbdf133a03b4a751defb8ea9329425"
+      "sha256": "8cf7c2ec3eb398bcddd75e200094fffa8ce4403a655e3340b35e5098d2f308a0"
     },
     "run_id": "run-single",
     "scheduler": {
@@ -90,7 +90,7 @@
     "created_at": "2026-08-19T12:00:00Z",
     "resolved_plan": {
       "path": "/workspace/primary/runs/run-single/resolved-plan.json",
-      "sha256": "d9155dd04ad439b4cd091eaec9b7b4d938bbdf133a03b4a751defb8ea9329425"
+      "sha256": "8cf7c2ec3eb398bcddd75e200094fffa8ce4403a655e3340b35e5098d2f308a0"
     },
     "run_id": "run-single",
     "schema_version": 1,

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/__init__.py
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from slurm_test_fakes.clock import FakeClock
 from slurm_test_fakes.dependencies import FakeDependencyInstaller, FakeDependencyResolver
+from slurm_test_fakes.images import FakeInspectionEnvironment
 from slurm_test_fakes.serving import FakeLogicalEndpoint, FakeServingState, FakeVllmBackend
 from slurm_test_fakes.slurm import (
     FakeCommandResponse,
@@ -20,6 +21,7 @@ __all__ = [
     "FakeCommandResponse",
     "FakeDependencyInstaller",
     "FakeDependencyResolver",
+    "FakeInspectionEnvironment",
     "FakeLogicalEndpoint",
     "FakeServingState",
     "FakeSlurmArray",

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/golden/rendered/multi_node.sbatch
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/golden/rendered/multi_node.sbatch
@@ -11,7 +11,7 @@ set -Eeuo pipefail
 readonly DD_RUNTIME_ARCHIVE="/workspace/primary/runtime/runtime.tar.gz"
 readonly DD_RUNTIME_SHA256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 readonly DD_PLAN="/workspace/primary/runs/run-001/resolved-plan.json"
-readonly DD_PLAN_SHA256="dbcae1da6ce8ef6799faf2add8e08b1b093390ae08a37dd13e336da522b9a3fd"
+readonly DD_PLAN_SHA256="fff7573a8b6eb2f71ae12f27900a85e1e121debfe58b0e94fefc3fb9362970ce"
 readonly DD_RUN_ROOT="/workspace/primary/runs/run-001"
 readonly DD_ATTEMPT_ORDINAL="0001"
 

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/golden/rendered/single_node.sbatch
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/golden/rendered/single_node.sbatch
@@ -11,7 +11,7 @@ set -Eeuo pipefail
 readonly DD_RUNTIME_ARCHIVE="/workspace/primary/runtime/runtime.tar.gz"
 readonly DD_RUNTIME_SHA256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 readonly DD_PLAN="/workspace/primary/runs/run-single/resolved-plan.json"
-readonly DD_PLAN_SHA256="d9155dd04ad439b4cd091eaec9b7b4d938bbdf133a03b4a751defb8ea9329425"
+readonly DD_PLAN_SHA256="8cf7c2ec3eb398bcddd75e200094fffa8ce4403a655e3340b35e5098d2f308a0"
 readonly DD_RUN_ROOT="/workspace/primary/runs/run-single"
 readonly DD_ATTEMPT_ORDINAL="0001"
 

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/images.py
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/images.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic image-environment facts for package inspector tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from data_designer.slurm.config import InstalledDistribution
+from data_designer.slurm.images import ImageInspectionError
+
+
+@dataclass(frozen=True, slots=True)
+class FakeInspectionEnvironment:
+    """Expose explicit client and serving facts without entering a container."""
+
+    python_implementation: str = "cpython"
+    python_version: str = "3.12.12"
+    python_abi: str = "cp312"
+    distributions: tuple[InstalledDistribution, ...] = ()
+    distribution_versions: Mapping[str, str] = field(default_factory=dict)
+    executables: Mapping[str, str] = field(default_factory=dict)
+
+    def get_python_implementation(self) -> str:
+        """Return the configured Python implementation."""
+        return self.python_implementation
+
+    def get_python_version(self) -> str:
+        """Return the configured Python version."""
+        return self.python_version
+
+    def get_python_abi(self) -> str:
+        """Return the configured Python ABI."""
+        return self.python_abi
+
+    def list_distributions(self) -> tuple[InstalledDistribution, ...]:
+        """Return the configured distribution inventory."""
+        return self.distributions
+
+    def get_distribution_version(self, name: str) -> str:
+        """Return one configured distribution version."""
+        try:
+            return self.distribution_versions[name]
+        except KeyError:
+            raise ImageInspectionError(f"required distribution {name!r} is not installed") from None
+
+    def find_executable(self, name: str) -> str:
+        """Return one configured executable path."""
+        try:
+            return self.executables[name]
+        except KeyError:
+            raise ImageInspectionError(f"required executable {name!r} is not installed") from None

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/images.py
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/images.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from data_designer.slurm.config import InstalledDistribution
-from data_designer.slurm.images import ImageInspectionError
+from data_designer.slurm.images.errors import ImageInspectionError
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/test_rendered_scripts.py
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/test_rendered_scripts.py
@@ -19,12 +19,12 @@ def test_rendered_script_fixtures_are_pinned_and_bound_to_canonical_plans(
     _assert_script_matches_plan(
         single_node_plan,
         "single_node.sbatch",
-        expected_fixture_sha256="faa1dac9b9b0423423c9d06a13d71bee339932ffa45d1e02a8a95012a7934520",
+        expected_fixture_sha256="cdb5204e8ce7a7affda99ea9c121c6b60a16bf42c510c8eb6bc57661969620b9",
     )
     _assert_script_matches_plan(
         multi_node_plan,
         "multi_node.sbatch",
-        expected_fixture_sha256="a4542e56b124c2346d0a92ebadc4e89b45d94c9355d7b86a4a1b05180d331a48",
+        expected_fixture_sha256="c6708cdbc0a03e095062c0642cfd141f066153b958b7ad3dec779afd6414fa34",
     )
 
 

--- a/scripts/test_slurm_package_install.py
+++ b/scripts/test_slurm_package_install.py
@@ -128,6 +128,7 @@ assert version("data-designer-slurm") == {version!r}
 from data_designer.slurm.contracts import ArtifactReference as ContractArtifactReference
 from data_designer.slurm.contracts import RecordRange as ContractRecordRange
 from data_designer.slurm.contracts import ResumeWorkspace as ContractResumeWorkspace
+from data_designer.slurm.images import SlurmImageService
 from data_designer.slurm.integration import PlanStateValidator
 from data_designer.slurm.planning import ArtifactReference as PlanningArtifactReference
 from data_designer.slurm.planning import RecordRange as PlanningRecordRange
@@ -137,6 +138,7 @@ from data_designer.slurm.state import RecordRange as StateRecordRange
 from data_designer.slurm.state import ResumeWorkspace as StateResumeWorkspace
 from data_designer.slurm.state import RunManifest
 assert RunManifest.__name__ == "RunManifest"
+assert SlurmImageService.__name__ == "SlurmImageService"
 assert PlanningArtifactReference is ContractArtifactReference
 assert PlanningRecordRange is ContractRecordRange
 assert PlanningResumeWorkspace is ContractResumeWorkspace
@@ -190,10 +192,12 @@ def main() -> None:
         leaf_base_requirement = requirement(leaf_metadata, "data-designer")
         leaf_packaging_requirement = requirement(leaf_metadata, "packaging")
         leaf_pydantic_requirement = requirement(leaf_metadata, "pydantic")
+        leaf_pyyaml_requirement = requirement(leaf_metadata, "pyyaml")
         assert str(base_leaf_requirement.specifier) == f"=={version}"
         assert str(leaf_base_requirement.specifier) == f"=={version}"
         assert leaf_packaging_requirement.specifier == Requirement("packaging>=25,<27").specifier
         assert leaf_pydantic_requirement.specifier == Requirement("pydantic>=2.9.2,<3").specifier
+        assert leaf_pyyaml_requirement.specifier == Requirement("pyyaml>=6.0.1,<7").specifier
         assert base_leaf_requirement.marker is not None
         assert base_leaf_requirement.marker.evaluate({"extra": "slurm"})
         assert not base_leaf_requirement.marker.evaluate({"extra": ""})

--- a/scripts/test_slurm_package_install.py
+++ b/scripts/test_slurm_package_install.py
@@ -129,6 +129,7 @@ from data_designer.slurm.contracts import ArtifactReference as ContractArtifactR
 from data_designer.slurm.contracts import RecordRange as ContractRecordRange
 from data_designer.slurm.contracts import ResumeWorkspace as ContractResumeWorkspace
 from data_designer.slurm.integration import PlanStateValidator
+from data_designer.slurm.images.registry import ImageRegistryStore
 from data_designer.slurm.planning import ArtifactReference as PlanningArtifactReference
 from data_designer.slurm.planning import RecordRange as PlanningRecordRange
 from data_designer.slurm.planning import ResumeWorkspace as PlanningResumeWorkspace
@@ -137,6 +138,7 @@ from data_designer.slurm.state import RecordRange as StateRecordRange
 from data_designer.slurm.state import ResumeWorkspace as StateResumeWorkspace
 from data_designer.slurm.state import RunManifest
 assert RunManifest.__name__ == "RunManifest"
+assert ImageRegistryStore.__name__ == "ImageRegistryStore"
 assert PlanningArtifactReference is ContractArtifactReference
 assert PlanningRecordRange is ContractRecordRange
 assert PlanningResumeWorkspace is ContractResumeWorkspace

--- a/scripts/test_slurm_package_install.py
+++ b/scripts/test_slurm_package_install.py
@@ -128,7 +128,6 @@ assert version("data-designer-slurm") == {version!r}
 from data_designer.slurm.contracts import ArtifactReference as ContractArtifactReference
 from data_designer.slurm.contracts import RecordRange as ContractRecordRange
 from data_designer.slurm.contracts import ResumeWorkspace as ContractResumeWorkspace
-from data_designer.slurm.images import SlurmImageService
 from data_designer.slurm.integration import PlanStateValidator
 from data_designer.slurm.planning import ArtifactReference as PlanningArtifactReference
 from data_designer.slurm.planning import RecordRange as PlanningRecordRange
@@ -138,7 +137,6 @@ from data_designer.slurm.state import RecordRange as StateRecordRange
 from data_designer.slurm.state import ResumeWorkspace as StateResumeWorkspace
 from data_designer.slurm.state import RunManifest
 assert RunManifest.__name__ == "RunManifest"
-assert SlurmImageService.__name__ == "SlurmImageService"
 assert PlanningArtifactReference is ContractArtifactReference
 assert PlanningRecordRange is ContractRecordRange
 assert PlanningResumeWorkspace is ContractResumeWorkspace

--- a/uv.lock
+++ b/uv.lock
@@ -975,6 +975,7 @@ dependencies = [
     { name = "data-designer" },
     { name = "packaging" },
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -982,6 +983,7 @@ requires-dist = [
     { name = "data-designer", editable = "packages/data-designer" },
     { name = "packaging", specifier = ">=25,<27" },
     { name = "pydantic", specifier = ">=2.9.2,<3" },
+    { name = "pyyaml", specifier = ">=6.0.1,<7" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📋 Summary
Adds the first independently reviewable slice of #867: package-owned digest-bound client and serving inspection, immutable registry records, atomic workspace-derived YAML persistence, and verified alias/path resolution. OCI import, artifact publication, and compatibility hardening remain in the later scoped slices.

## 🔗 Related Issue
Part of #867

## 🔄 Changes
- Add injectable client and vLLM serving inspectors with normalized package errors.
- Add immutable registered-image and registry-snapshot records.
- Add locked, atomic, restrictive `registry.yaml` persistence under the selected workspace.
- Register existing absolute SQSH files in place and resolve aliases or registered paths with digest/kind re-verification.
- Add deterministic inspection fakes, concurrency and filesystem-boundary coverage, and isolated wheel checks.
- Declare and lock the direct PyYAML runtime dependency.

## 🧪 Testing
- [x] All package test suites pass (4,514 passed, 1 skipped)
- [x] Slurm unit tests added/updated (434 passed)
- [x] Repository-wide Ruff lint and format checks pass
- [x] Isolated Slurm wheel installation and import-budget check passes
- [x] E2E tests not applicable to this foundation slice

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs not applicable to this internal foundation slice
