### PR TITLE
chore: strengthen code review design pass

### DIFF
--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -177,7 +177,7 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 - If one module owns distinct phases such as authored config, resolution, compilation, and validation, would splitting those responsibilities make ownership and future changes clearer?
 - Are new dependencies flowing in the right direction?
 - Could this introduce circular imports or unnecessary coupling?
-- Does every symbol live in the module that owns it? A leading-underscore helper imported by sibling modules is a misplaced shared API, not truly private.
+- Does every symbol live in the module that owns it? Treat a leading-underscore helper imported by sibling modules as a signal to inspect ownership and package-export intent. Package-private sharing can be legitimate when the defining module owns the helper and it remains intentionally unexported.
 - Are helpers scoped to their actual consumers? Logic used only to validate or construct one class usually belongs on that class instead of in module-level generic machinery.
 - Are re-exports intentional and sourced from the defining module rather than incidental import chains?
 - Is there one canonical public entry point per operation, or do class methods plus module-level wrappers expose redundant APIs?
@@ -203,13 +203,13 @@ Review every item in the Step 3 inventory individually, using the invariant map 
 - Does the API vocabulary match neighboring builders and established cardinality? For example, repeatable collection operations should follow the existing `add_*` convention, while `with_*` should retain its established singleton/configuration meaning.
 - Is every exported symbol meant to become a compatibility commitment? Keep implementation bases, compiler internals, and shared utilities private unless external callers need them.
 - Are exceptions named and located at the right subsystem boundary? Avoid generic names that become ambiguous when imported, and prefer the project's canonical error hierarchy over parallel local taxonomies.
-- Can callers determine parameter semantics, accepted representations, return values, lifecycle transitions, and raised project errors from the public contract itself? Flag ambiguous or incomplete API design, not missing comments or docstrings.
+- Can callers determine parameter semantics, accepted representations, return values, lifecycle transitions, and raised project errors from the public contract itself? Flag ambiguous or incomplete API design separately from project-standard docstring coverage.
 
 **Boundary and representation checks:**
 
 - Treat plugin-owned or opaque payloads as opaque. Core code may validate a stable envelope it owns, but should not infer extension semantics from familiar-looking keys or current built-in payload shapes.
 - Test the boundary with an unfamiliar future extension value. If valid unknown fields or plugin payloads are rejected, stripped, or reinterpreted, the abstraction is not actually extensible.
-- At exception boundaries, inspect both the public exception and its chained cause. The wrapper should give stable project context without hiding the actionable third-party validation detail.
+- At exception boundaries, inspect the public error and how actionable detail is preserved. Use a safe chained cause when it will not expose sensitive provider data; otherwise put sanitized detail on the public error and suppress the raw cause with `raise ... from None` according to boundary policy.
 
 **Documentation alignment (same pass — scoped, not a full docs audit):**
 
@@ -235,7 +235,7 @@ Final pass focused on **project conventions and test quality for new/modified co
 - Are mocks/stubs used appropriately (at boundaries, not deep internals)?
 - Do new test names clearly describe what they verify?
 - For new public contracts, do tests exercise direct supported construction as well as builder/factory paths, lifecycle transitions, malformed boundary input, and an unfamiliar extension/plugin case where applicable?
-- For normalized exceptions, do tests assert the stable public error and verify that the chained cause preserves useful underlying detail?
+- For normalized exceptions, do tests assert the stable public error and verify that actionable detail is preserved through either a safe chained cause or sanitized public-error detail without leaking provider secrets?
 
 **Project Standards (from AGENTS.md and STYLEGUIDE.md) — apply to new/modified code only:**
 
@@ -248,6 +248,7 @@ Verify the items below on lines introduced or changed by this branch. Refer to `
 - Absolute imports only (no relative imports)
 - Lazy loading for heavy third-party imports via `lazy_heavy_imports` + `TYPE_CHECKING`
 - Naming: snake_case functions starting with a verb, PascalCase classes, UPPER_SNAKE_CASE constants
+- Public API classes and functions have Google-style docstrings; private helpers need them only when their logic is non-obvious
 - No vacuous comments — comments only for non-obvious intent
 - Public before private ordering in new classes
 - Design principles: DRY (extract on third occurrence), KISS (flat over clever), YAGNI (no speculative abstractions)
@@ -289,7 +290,7 @@ Write as a supportive teammate, not a gatekeeper. The goal is to help the author
 
 Write the review as **GitHub-flavored Markdown** ready to post as a PR comment. Save it to a temporary file outside the repository (e.g. `/tmp/review-<pr-or-branch>.md`) so it doesn't pollute `git status`. Do not commit this file; treat it as ephemeral.
 
-Use the template below exactly — omit a severity section if it has no findings and omit the optional Residual Risk section when empty, but keep all other sections.
+Use the template below exactly — omit a severity section if it has no findings, include Open Questions only with **Needs discussion**, and omit Residual Risk when empty, but keep all other sections.
 
 ---
 
@@ -324,6 +325,10 @@ Separate each finding with a blank line. Use bold file-and-title as a heading li
 ### What Looks Good
 
 Call out 2-3 things done well (good abstractions, thorough tests, clean refactoring, etc.). Be genuine — positive feedback is part of a good review and helps the author know what to keep doing.
+
+### Open Questions (Needs discussion only)
+
+State the material question, why it affects compatibility or merge readiness, and the team decision needed.
 
 ### Residual Risk (optional)
 
@@ -381,7 +386,7 @@ In branch mode, skip this step — display the review to the user and note the t
 - Issues that are supposed to be caught by CI (linter, typechecker, formatter) — mention "run `make check-all`" if relevant, but don't list every style nit
 - Pre-existing issues on unmodified lines
 - Pedantic nits that don't affect correctness or maintainability
-- Missing comments or docstrings when behavior and the public contract are otherwise clear; flag the underlying ambiguity when they are not
+- Missing docstrings on private helpers when their purpose is clear, or prose-only comment/docstring nits that do not affect correctness or understanding; public API docstrings remain required by `STYLEGUIDE.md`
 - Intentional functionality or API changes that are clearly documented, unless the new design introduces a concrete correctness, extensibility, or compatibility risk, or a maintainability risk that would require a breaking change to correct
 
 ## Edge Cases

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -111,10 +111,10 @@ Before diving into details, build a mental model:
 4. **Identify the primary goal** (feature, refactor, bugfix, etc.)
 5. **Note cross-cutting concerns** (e.g., a rename that touches many files vs. substantive logic changes)
 6. **Check existing feedback** (PR mode): inspect both inline comments (Step 1, item 5) and PR-level review bodies (Step 1, item 5b) so you don't duplicate feedback already given
-7. **Classify the contract impact**: note whether the change introduces or modifies public/exported symbols, config or model schemas, serialized formats, extension/plugin boundaries, or builder APIs
-8. **Inventory the changed contract**: list every new or modified public symbol and public model field, including its subsystem, value kind, lifecycle stage (for example, authored, resolved, compiled, or runtime), and expected callers
+7. **Classify the contract impact**: note whether the change introduces or modifies public/exported symbols, config or model schemas, serialized formats, extension/plugin boundaries, or builder APIs. If none apply, skip items 8-10 and continue to Step 3.5.
+8. **Inventory the changed contract**: list each new or modified public symbol and public model field with its expected callers
 9. **Map invariant ownership**: identify where each new rule is parsed, normalized, validated, resolved, and compiled so duplicated checks and unclear responsibility are visible before the detailed review
-10. **Find the closest existing analogue**: compare the complete neighboring API surface—not just individual names—for builder vocabulary, type precision, export strategy, errors, and documentation depth
+10. **Find the closest existing analogue**: compare the complete neighboring API surface—not just individual names—for builder vocabulary, type precision, export strategy, errors, and contract clarity
 
 ## Step 3.5: Structural Impact (if available)
 
@@ -183,11 +183,11 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 - Is there one canonical public entry point per operation, or do class methods plus module-level wrappers expose redundant APIs?
 - Is each invariant enforced once at the narrowest authoritative layer, rather than repeated or recomputed across models, resolution, compilation, and validation?
 - Are new or modified public signatures clear and minimal?
-- Do generic helpers and `TypeVar`s eliminate enough real duplication to justify their cognitive cost, and do their names follow the surrounding `*T` convention?
+- Do generic helpers and `TypeVar`s eliminate enough real duplication to justify their cognitive cost, and are their names consistent with those already used in the changed module?
 - Are return types precise (not overly broad like `Any`)?
 - Could the new API be misused easily? Is it hard to use incorrectly?
 - Are breaking changes to existing interfaces intentional and documented?
-- Unnecessary wrapper functions or dead code left behind after refactors
+- Dead code left behind after refactors
 - Scalability: in-memory operations that could OOM on large datasets
 - Raw exceptions leaking instead of being normalized to project error types (see AGENTS.md / interface errors)
 - Obvious inefficiencies introduced by this change (N+1 queries, repeated computation, unnecessary copies)
@@ -195,21 +195,20 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 
 **Public interface inventory (mandatory when Step 3 identifies contract impact):**
 
-Review every item in the Step 3 inventory individually. Do not infer that a coherent-looking module implies a coherent public API.
+Review every item in the Step 3 inventory individually, using the invariant map and neighboring analogue built there. Do not infer that a coherent-looking module implies a coherent public API.
 
-- Does the name identify the subsystem and the value's actual role or lifecycle? Avoid context-free names such as `Value`, `Contract`, `authored`, or `submission` when callers need to distinguish authored config from resolved state or an artifact reference from loaded data.
-- Does the parameter or field name match the concrete value it contains? A reference, digest, compiled plan, or resolved config should not be named as though it were the underlying artifact, raw input, or authored declaration.
+- Does each name identify the value's actual role or lifecycle when callers need that distinction?
+- Does each parameter or field name match the concrete value it contains rather than an earlier or later representation?
 - Are public Python inputs expressed with concrete config/model classes where those classes already define the contract? Broad `Mapping[str, object]`, `dict[str, Any]`, or `**kwargs` inputs add normalization branches and weaken discoverability unless accepting arbitrary mappings is an explicit requirement.
 - Does the API vocabulary match neighboring builders and established cardinality? For example, repeatable collection operations should follow the existing `add_*` convention, while `with_*` should retain its established singleton/configuration meaning.
 - Is every exported symbol meant to become a compatibility commitment? Keep implementation bases, compiler internals, and shared utilities private unless external callers need them.
 - Are exceptions named and located at the right subsystem boundary? Avoid generic names that become ambiguous when imported, and prefer the project's canonical error hierarchy over parallel local taxonomies.
-- Do public docstrings explain non-obvious parameter semantics, accepted representations, return values, lifecycle transitions, and raised project errors in proportion to the signature's complexity?
+- Can callers determine parameter semantics, accepted representations, return values, lifecycle transitions, and raised project errors from the public contract itself? Flag ambiguous or incomplete API design, not missing comments or docstrings.
 
 **Boundary and representation checks:**
 
 - Treat plugin-owned or opaque payloads as opaque. Core code may validate a stable envelope it owns, but should not infer extension semantics from familiar-looking keys or current built-in payload shapes.
 - Test the boundary with an unfamiliar future extension value. If valid unknown fields or plugin payloads are rejected, stripped, or reinterpreted, the abstraction is not actually extensible.
-- If identity, hashing, or signing is involved, trace the exact bytes from serialization through hashing. Serialization and digest construction should have one owner, and names should distinguish a digest, canonical representation, and logical identity.
 - At exception boundaries, inspect both the public exception and its chained cause. The wrapper should give stable project context without hiding the actionable third-party validation detail.
 
 **Documentation alignment (same pass — scoped, not a full docs audit):**
@@ -248,7 +247,7 @@ Verify the items below on lines introduced or changed by this branch. Refer to `
 - Modern type syntax (`list[str]`, `str | None` — not `List[str]`, `Optional[str]`)
 - Absolute imports only (no relative imports)
 - Lazy loading for heavy third-party imports via `lazy_heavy_imports` + `TYPE_CHECKING`
-- Naming: snake_case functions starting with a verb, PascalCase classes, UPPER_SNAKE_CASE constants; names also communicate subsystem, lifecycle, and value kind where ambiguity would otherwise leak to callers
+- Naming: snake_case functions starting with a verb, PascalCase classes, UPPER_SNAKE_CASE constants
 - No vacuous comments — comments only for non-obvious intent
 - Public before private ordering in new classes
 - Design principles: DRY (extract on third occurrence), KISS (flat over clever), YAGNI (no speculative abstractions)
@@ -272,6 +271,7 @@ For new or substantially expanded production modules, also use complexity rules 
 ```
 
 Do not report a metric violation by itself. Use it to identify functions or modules that need a closer cohesion, responsibility, and maintainability review, then report the concrete design problem if one exists.
+Expect broad signals in config- or builder-heavy modules; pursue a violation only when it coincides with a concrete cohesion or ownership concern.
 
 If the branch isn't checked out locally (e.g., external fork in PR mode), skip this step and note it in the review.
 
@@ -327,14 +327,14 @@ Call out 2-3 things done well (good abstractions, thorough tests, clean refactor
 
 ### Verdict
 
-Choose the verdict that matches the **highest severity** finding in the review:
+Choose the verdict that matches the **highest severity confirmed finding** in the review. If there are no confirmed Critical or Warning findings but a design question cannot be resolved without team input, use **Needs discussion**.
 
 - **Ship it** — No findings. Ready to merge as-is.
 - **Ship it (with nits)** — Only Suggestions (see above — style improvements, simplifications, or optional enhancements). Nothing blocking.
 - **Needs changes** — Any Critical or Warning findings. List the items that must be addressed before merge.
-- **Needs discussion** — Architectural or design questions that need team input before a decision can be made.
+- **Needs discussion** — No confirmed Critical or Warning findings, but an architectural or design question needs team input before a decision can be made.
 
-An unresolved foundational contract question is not a nit: use **Needs discussion** while the design choice is open, or **Needs changes** when the review identifies a concrete merge blocker. Do not use a **Ship it** verdict merely because the risk is design debt rather than an immediate runtime bug.
+A confirmed foundational contract flaw is Critical and requires **Needs changes**. Reserve **Needs discussion** for uncertainty that requires team input. Do not use any **Ship it** verdict (including **Ship it (with nits)**) while either remains unresolved.
 
 ### Signature (PR mode only)
 
@@ -377,7 +377,8 @@ In branch mode, skip this step — display the review to the user and note the t
 - Issues that are supposed to be caught by CI (linter, typechecker, formatter) — mention "run `make check-all`" if relevant, but don't list every style nit
 - Pre-existing issues on unmodified lines
 - Pedantic nits that don't affect correctness or maintainability
-- Intentional functionality or API changes that are clearly documented, unless the new design introduces a concrete correctness, maintainability, extensibility, or compatibility risk
+- Missing comments or docstrings when behavior and the public contract are otherwise clear; flag the underlying ambiguity when they are not
+- Intentional functionality or API changes that are clearly documented, unless the new design introduces a concrete correctness, extensibility, or compatibility risk, or a maintainability risk that would require a breaking change to correct
 
 ## Edge Cases
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -111,8 +111,8 @@ Before diving into details, build a mental model:
 4. **Identify the primary goal** (feature, refactor, bugfix, etc.)
 5. **Note cross-cutting concerns** (e.g., a rename that touches many files vs. substantive logic changes)
 6. **Check existing feedback** (PR mode): inspect both inline comments (Step 1, item 5) and PR-level review bodies (Step 1, item 5b) so you don't duplicate feedback already given
-7. **Classify the contract impact**: note whether the change introduces or modifies public/exported symbols, config or model schemas, serialized formats, extension/plugin boundaries, or builder APIs. If none apply, skip items 8-10 and continue to Step 3.5.
-8. **Inventory the changed contract**: list each new or modified public symbol and public model field with its expected callers
+7. **Classify the contract impact**: note whether the change introduces or modifies supported public symbols or exports, config or model schemas, serialized formats, extension/plugin boundaries, or builder APIs. If none apply, skip items 8-10 and continue to Step 3.5.
+8. **Inventory the changed contract**: list each changed contract element—including symbols, schema fields, serialized representations, extension entry points, and builder operations—and record its exposure, stability commitment, and expected callers or consumers
 9. **Map invariant ownership**: identify where each new rule is parsed, normalized, validated, resolved, and compiled so duplicated checks and unclear responsibility are visible before the detailed review
 10. **Find the closest existing analogue**: compare the complete neighboring API surface—not just individual names—for builder vocabulary, type precision, export strategy, errors, and contract clarity
 
@@ -181,7 +181,7 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 - Are helpers scoped to their actual consumers? Logic used only to validate or construct one class usually belongs on that class instead of in module-level generic machinery.
 - Are re-exports intentional and sourced from the defining module rather than incidental import chains?
 - Is there one canonical public entry point per operation, or do class methods plus module-level wrappers expose redundant APIs?
-- Is each invariant enforced once at the narrowest authoritative layer, rather than repeated or recomputed across models, resolution, compilation, and validation?
+- Does each business invariant have one authoritative owner, with complementary boundary checks allowed when representation or trust level changes and without independently redefining the rule?
 - Are new or modified public signatures clear and minimal?
 - Do generic helpers and `TypeVar`s eliminate enough real duplication to justify their cognitive cost, and are their names consistent with those already used in the changed module?
 - Are return types precise (not overly broad like `Any`)?
@@ -289,7 +289,7 @@ Write as a supportive teammate, not a gatekeeper. The goal is to help the author
 
 Write the review as **GitHub-flavored Markdown** ready to post as a PR comment. Save it to a temporary file outside the repository (e.g. `/tmp/review-<pr-or-branch>.md`) so it doesn't pollute `git status`. Do not commit this file; treat it as ephemeral.
 
-Use the template below exactly — omit a severity section if it has no findings, but keep all other sections.
+Use the template below exactly — omit a severity section if it has no findings and omit the optional Residual Risk section when empty, but keep all other sections.
 
 ---
 
@@ -325,16 +325,20 @@ Separate each finding with a blank line. Use bold file-and-title as a heading li
 
 Call out 2-3 things done well (good abstractions, thorough tests, clean refactoring, etc.). Be genuine — positive feedback is part of a good review and helps the author know what to keep doing.
 
+### Residual Risk (optional)
+
+Note validation gaps or lower-impact uncertainty that do not change merge readiness. If a risk is concrete enough to require action before merge, report it as a finding instead.
+
 ### Verdict
 
-Choose the verdict that matches the **highest severity confirmed finding** in the review. If there are no confirmed Critical or Warning findings but a design question cannot be resolved without team input, use **Needs discussion**.
+Choose the verdict that matches the **highest severity confirmed finding** in the review. If there are no confirmed Critical or Warning findings but a design question material to compatibility or merge readiness cannot be resolved without team input, use **Needs discussion**.
 
 - **Ship it** — No findings. Ready to merge as-is.
 - **Ship it (with nits)** — Only Suggestions (see above — style improvements, simplifications, or optional enhancements). Nothing blocking.
 - **Needs changes** — Any Critical or Warning findings. List the items that must be addressed before merge.
-- **Needs discussion** — No confirmed Critical or Warning findings, but an architectural or design question needs team input before a decision can be made.
+- **Needs discussion** — No confirmed Critical or Warning findings, but an architectural or design question material to compatibility or merge readiness needs team input before a decision can be made.
 
-A confirmed foundational contract flaw is Critical and requires **Needs changes**. Reserve **Needs discussion** for uncertainty that requires team input. Do not use any **Ship it** verdict (including **Ship it (with nits)**) while either remains unresolved.
+A confirmed foundational contract flaw is Critical and requires **Needs changes**. Reserve **Needs discussion** for material uncertainty that requires team input. Lower-impact uncertainty belongs in **Residual Risk** and does not preclude **Ship it** or **Ship it (with nits)**.
 
 ### Signature (PR mode only)
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -111,6 +111,10 @@ Before diving into details, build a mental model:
 4. **Identify the primary goal** (feature, refactor, bugfix, etc.)
 5. **Note cross-cutting concerns** (e.g., a rename that touches many files vs. substantive logic changes)
 6. **Check existing feedback** (PR mode): inspect both inline comments (Step 1, item 5) and PR-level review bodies (Step 1, item 5b) so you don't duplicate feedback already given
+7. **Classify the contract impact**: note whether the change introduces or modifies public/exported symbols, config or model schemas, serialized formats, extension/plugin boundaries, or builder APIs
+8. **Inventory the changed contract**: list every new or modified public symbol and public model field, including its subsystem, value kind, lifecycle stage (for example, authored, resolved, compiled, or runtime), and expected callers
+9. **Map invariant ownership**: identify where each new rule is parsed, normalized, validated, resolved, and compiled so duplicated checks and unclear responsibility are visible before the detailed review
+10. **Find the closest existing analogue**: compare the complete neighboring API surface—not just individual names—for builder vocabulary, type precision, export strategy, errors, and documentation depth
 
 ## Step 3.5: Structural Impact (if available)
 
@@ -132,10 +136,13 @@ If the file exists, read it and use it to calibrate your review:
 - **HIGH risk**: apply extra scrutiny in Pass 2 (Design & Architecture).
   Verify backward compatibility for god nodes. Check that cross-package
   changes don't break existing callers.
-- **Import violations**: flag them as Warnings in the review if they
-  represent real dependency direction issues (not just inferred edges).
+- **Import violations**: flag real dependency direction issues (not just
+  inferred edges) as at least Warnings. Use Critical when the violation
+  breaks packaging or establishes a foundational public boundary in the
+  wrong layer.
 - **LOW risk**: the structural analysis confirms a localized change. You
-  can focus more on correctness (Pass 1) and less on architecture.
+  can focus more on correctness (Pass 1), but still perform the mandatory
+  public-contract checks below when applicable.
 
 If the file does not exist (e.g. local branch review), skip this step.
 
@@ -166,10 +173,17 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 
 - Does the change fit the existing architecture and patterns?
 - Are new abstractions at the right level? (too abstract / too concrete)
-- Single responsibility — does each new function/class do one thing?
+- Single responsibility — does each new function, class, and module do one coherent job?
+- If one module owns distinct phases such as authored config, resolution, compilation, and validation, would splitting those responsibilities make ownership and future changes clearer?
 - Are new dependencies flowing in the right direction?
 - Could this introduce circular imports or unnecessary coupling?
+- Does every symbol live in the module that owns it? A leading-underscore helper imported by sibling modules is a misplaced shared API, not truly private.
+- Are helpers scoped to their actual consumers? Logic used only to validate or construct one class usually belongs on that class instead of in module-level generic machinery.
+- Are re-exports intentional and sourced from the defining module rather than incidental import chains?
+- Is there one canonical public entry point per operation, or do class methods plus module-level wrappers expose redundant APIs?
+- Is each invariant enforced once at the narrowest authoritative layer, rather than repeated or recomputed across models, resolution, compilation, and validation?
 - Are new or modified public signatures clear and minimal?
+- Do generic helpers and `TypeVar`s eliminate enough real duplication to justify their cognitive cost, and do their names follow the surrounding `*T` convention?
 - Are return types precise (not overly broad like `Any`)?
 - Could the new API be misused easily? Is it hard to use incorrectly?
 - Are breaking changes to existing interfaces intentional and documented?
@@ -178,6 +192,25 @@ Re-read the changed files with a focus on **structure and design of the new/modi
 - Raw exceptions leaking instead of being normalized to project error types (see AGENTS.md / interface errors)
 - Obvious inefficiencies introduced by this change (N+1 queries, repeated computation, unnecessary copies)
 - Appropriate data structures for the access pattern
+
+**Public interface inventory (mandatory when Step 3 identifies contract impact):**
+
+Review every item in the Step 3 inventory individually. Do not infer that a coherent-looking module implies a coherent public API.
+
+- Does the name identify the subsystem and the value's actual role or lifecycle? Avoid context-free names such as `Value`, `Contract`, `authored`, or `submission` when callers need to distinguish authored config from resolved state or an artifact reference from loaded data.
+- Does the parameter or field name match the concrete value it contains? A reference, digest, compiled plan, or resolved config should not be named as though it were the underlying artifact, raw input, or authored declaration.
+- Are public Python inputs expressed with concrete config/model classes where those classes already define the contract? Broad `Mapping[str, object]`, `dict[str, Any]`, or `**kwargs` inputs add normalization branches and weaken discoverability unless accepting arbitrary mappings is an explicit requirement.
+- Does the API vocabulary match neighboring builders and established cardinality? For example, repeatable collection operations should follow the existing `add_*` convention, while `with_*` should retain its established singleton/configuration meaning.
+- Is every exported symbol meant to become a compatibility commitment? Keep implementation bases, compiler internals, and shared utilities private unless external callers need them.
+- Are exceptions named and located at the right subsystem boundary? Avoid generic names that become ambiguous when imported, and prefer the project's canonical error hierarchy over parallel local taxonomies.
+- Do public docstrings explain non-obvious parameter semantics, accepted representations, return values, lifecycle transitions, and raised project errors in proportion to the signature's complexity?
+
+**Boundary and representation checks:**
+
+- Treat plugin-owned or opaque payloads as opaque. Core code may validate a stable envelope it owns, but should not infer extension semantics from familiar-looking keys or current built-in payload shapes.
+- Test the boundary with an unfamiliar future extension value. If valid unknown fields or plugin payloads are rejected, stripped, or reinterpreted, the abstraction is not actually extensible.
+- If identity, hashing, or signing is involved, trace the exact bytes from serialization through hashing. Serialization and digest construction should have one owner, and names should distinguish a digest, canonical representation, and logical identity.
+- At exception boundaries, inspect both the public exception and its chained cause. The wrapper should give stable project context without hiding the actionable third-party validation detail.
 
 **Documentation alignment (same pass — scoped, not a full docs audit):**
 
@@ -202,6 +235,8 @@ Final pass focused on **project conventions and test quality for new/modified co
 - Are edge cases tested?
 - Are mocks/stubs used appropriately (at boundaries, not deep internals)?
 - Do new test names clearly describe what they verify?
+- For new public contracts, do tests exercise direct supported construction as well as builder/factory paths, lifecycle transitions, malformed boundary input, and an unfamiliar extension/plugin case where applicable?
+- For normalized exceptions, do tests assert the stable public error and verify that the chained cause preserves useful underlying detail?
 
 **Project Standards (from AGENTS.md and STYLEGUIDE.md) — apply to new/modified code only:**
 
@@ -213,7 +248,7 @@ Verify the items below on lines introduced or changed by this branch. Refer to `
 - Modern type syntax (`list[str]`, `str | None` — not `List[str]`, `Optional[str]`)
 - Absolute imports only (no relative imports)
 - Lazy loading for heavy third-party imports via `lazy_heavy_imports` + `TYPE_CHECKING`
-- Naming: snake_case functions starting with a verb, PascalCase classes, UPPER_SNAKE_CASE constants
+- Naming: snake_case functions starting with a verb, PascalCase classes, UPPER_SNAKE_CASE constants; names also communicate subsystem, lifecycle, and value kind where ambiguity would otherwise leak to callers
 - No vacuous comments — comments only for non-obvious intent
 - Public before private ordering in new classes
 - Design principles: DRY (extract on third occurrence), KISS (flat over clever), YAGNI (no speculative abstractions)
@@ -230,13 +265,21 @@ Run the linter on all changed files (requires local checkout). Use the venv dire
 
 > **Note**: This runs ruff only on the changed files for speed. For a full project-wide check, use `make check-all` or `uv run ruff check` (and `ruff format --check`) without file arguments.
 
+For new or substantially expanded production modules, also use complexity rules as an exploratory signal:
+
+```bash
+.venv/bin/ruff check --select C901,PLR0912,PLR0913,PLR0915 <changed-production-files>
+```
+
+Do not report a metric violation by itself. Use it to identify functions or modules that need a closer cohesion, responsibility, and maintainability review, then report the concrete design problem if one exists.
+
 If the branch isn't checked out locally (e.g., external fork in PR mode), skip this step and note it in the review.
 
 ## Tone
 
 Write as a supportive teammate, not a gatekeeper. The goal is to help the author ship great code, not to prove you found problems.
 
-- **Be cordial and collaborative.** Use "we" language and frame findings as questions or suggestions ("Could we …?", "What do you think about …?", "Nice approach — one thought: …").
+- **Be cordial and collaborative.** Use "we" language and frame genuine alternatives as questions or suggestions ("Could we …?", "What do you think about …?", "Nice approach — one thought: …"). State confirmed merge blockers directly.
 - **Assume good intent.** If something looks off, ask before assuming it's wrong — the author may have context you don't.
 - **Lead with what's good.** Acknowledge effort and smart decisions before raising concerns.
 - **Keep it conversational.** Avoid stiff, formal phrasing. Write the way you'd talk to a colleague at a whiteboard.
@@ -270,10 +313,10 @@ Group findings by severity. Omit any severity section that has no findings. Form
 Separate each finding with a blank line. Use bold file-and-title as a heading line, then bullet points for What/Why/Suggestion. Never use numbered lists (`1.`, `2.`) for findings or their sub-items.
 
 #### Critical — Let's fix these before merge
-> Issues that would cause bugs, data loss, security vulnerabilities, or broken functionality.
+> Issues that would cause bugs, data loss, security vulnerabilities, or broken functionality; also foundational flaws in a new or materially changed public, serialized, or extension contract that should block merge because correcting them after release would require a breaking compatibility change.
 
 #### Warnings — Worth addressing
-> Design issues, missing error handling, test gaps, or violations of project standards that could cause problems later.
+> Significant design issues that are not foundational compatibility blockers, missing error handling, test gaps, or violations of project standards that could cause problems later.
 
 #### Suggestions — Take it or leave it
 > Style improvements, minor simplifications, or optional enhancements that would improve code quality.
@@ -290,6 +333,8 @@ Choose the verdict that matches the **highest severity** finding in the review:
 - **Ship it (with nits)** — Only Suggestions (see above — style improvements, simplifications, or optional enhancements). Nothing blocking.
 - **Needs changes** — Any Critical or Warning findings. List the items that must be addressed before merge.
 - **Needs discussion** — Architectural or design questions that need team input before a decision can be made.
+
+An unresolved foundational contract question is not a nit: use **Needs discussion** while the design choice is open, or **Needs changes** when the review identifies a concrete merge blocker. Do not use a **Ship it** verdict merely because the risk is design debt rather than an immediate runtime bug.
 
 ### Signature (PR mode only)
 
@@ -321,7 +366,7 @@ In branch mode, skip this step — display the review to the user and note the t
 - **Only flag what's new**: Report issues introduced by this changeset — not pre-existing patterns or style in untouched code, unless explicitly asked by the user
 - **Be specific**: "This could return None on line 42 when `items` is empty" not "handle edge cases better"
 - **Suggest, don't just criticize**: Always pair a problem with a concrete suggestion
-- **Distinguish severity honestly**: Don't inflate nits to warnings; don't downplay real issues
+- **Distinguish severity honestly**: Don't inflate cosmetic naming or internal refactors into blockers. Do treat foundational public-contract design as Critical when merging would create a hard-to-reverse compatibility commitment.
 - **Consider intent**: Review what the author was trying to do, not what you would have done differently
 - **Batch related issues**: If the same pattern appears in multiple places, note it once and list all locations
 - **Read the full file**: Diff-only reviews miss context — always read the surrounding code, but only flag new issues
@@ -332,7 +377,7 @@ In branch mode, skip this step — display the review to the user and note the t
 - Issues that are supposed to be caught by CI (linter, typechecker, formatter) — mention "run `make check-all`" if relevant, but don't list every style nit
 - Pre-existing issues on unmodified lines
 - Pedantic nits that don't affect correctness or maintainability
-- Intentional functionality or API changes that are clearly documented
+- Intentional functionality or API changes that are clearly documented, unless the new design introduces a concrete correctness, maintainability, extensibility, or compatibility risk
 
 ## Edge Cases
 


### PR DESCRIPTION
## 📋 Summary
Strengthens the review-code skill so foundational design, interface, and consistency issues are evaluated explicitly before a new public contract becomes difficult to change.

## 🔗 Related Issue
N/A

## 🔄 Changes
- Require a contract inventory, invariant-ownership map, and comparison with neighboring APIs during scope analysis.
- Add concrete checks for module cohesion, private-symbol ownership, redundant entry points, generic-helper readability, builder vocabulary, precise input types, lifecycle-aware naming, exception scope, and opaque extension boundaries.
- Add public-contract test scenarios and exploratory complexity checks that prompt manual maintainability review.
- Treat hard-to-reverse flaws in new public, serialized, or extension contracts as Critical and prevent Ship it verdicts while foundational design questions remain unresolved.

## 🧪 Testing
- [x] Commit hooks pass
- [x] git diff --check passes
- [ ] make test passes (not run; instruction-only Markdown change)
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

The generic skill quick validator was also attempted. It rejects the repository-standard argument-hint and disable-model-invocation frontmatter keys; this change does not modify those keys.

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no product architecture change)