### PR TITLE
feat: add orcarouter as a built-in model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Start with one of our default model providers:
 - [NVIDIA Build API](https://build.nvidia.com)
 - [OpenAI](https://platform.openai.com/api-keys)
 - [OpenRouter](https://openrouter.ai)
+- [OrcaRouter](https://www.orcarouter.ai)
 
 Grab your API key(s) using the above links and set one or more of the following environment variables:
 ```bash
@@ -61,6 +62,8 @@ export NVIDIA_API_KEY="your-api-key-here"
 export OPENAI_API_KEY="your-openai-api-key-here"
 
 export OPENROUTER_API_KEY="your-openrouter-api-key-here"
+
+export ORCAROUTER_API_KEY="your-orcarouter-api-key-here"
 ```
 
 ### 3. Start generating data!

--- a/fern/versions/latest/pages/concepts/models/custom-model-settings.mdx
+++ b/fern/versions/latest/pages/concepts/models/custom-model-settings.mdx
@@ -91,7 +91,7 @@ preview_result.display_sample_record()
 ```
 
 <Note title="Default Providers Always Available">
-  When you only specify `model_configs`, the default model providers (NVIDIA, OpenAI, and OpenRouter) are still available. You only need to create custom providers if you want to connect to different endpoints or modify provider settings.
+  When you only specify `model_configs`, the default model providers (NVIDIA, OpenAI, OpenRouter, and OrcaRouter) are still available. You only need to create custom providers if you want to connect to different endpoints or modify provider settings.
 </Note>
 
 <Note title="Provider is required">

--- a/fern/versions/latest/pages/concepts/models/default-model-settings.mdx
+++ b/fern/versions/latest/pages/concepts/models/default-model-settings.mdx
@@ -36,6 +36,15 @@ The OpenAI provider gives you access to GPT models and other OpenAI offerings.
 
 The OpenRouter provider gives you access to a unified interface for many different language models from various providers.
 
+### OrcaRouter Provider (`orcarouter`)
+
+- **Endpoint**: `https://api.orcarouter.ai/v1`
+- **API Key**: Set via `ORCAROUTER_API_KEY` environment variable
+- **Models**: Access to a wide variety of models through OrcaRouter's unified gateway
+- **Getting Started**: Get your API key from [orcarouter.ai](https://www.orcarouter.ai)
+
+The OrcaRouter provider gives you access to a unified OpenAI-compatible gateway for many different language models from various providers, with adaptive routing and automatic failover across upstreams.
+
 ## Model Configurations
 
 Data Designer provides pre-configured model aliases for common use cases. When you create a `DataDesignerConfigBuilder` without specifying `model_configs`, these default configurations are automatically available.
@@ -73,6 +82,17 @@ The following model configurations are automatically available when `OPENROUTER_
 | `openrouter-reasoning` | `openai/gpt-oss-20b` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
 | `openrouter-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Omni multimodal understanding for image, audio, and video inputs, subject to OpenRouter model support | `temperature=0.60, top_p=0.95` |
 | `openrouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
+
+### OrcaRouter Models
+
+The following model configurations are automatically available when `ORCAROUTER_API_KEY` is set:
+
+| Alias | Model | Use Case | Inference Parameters |
+|-------|-------|----------|---------------------|
+| `orcarouter-text` | `openai/gpt-4.1` | General text generation | `temperature=0.85, top_p=0.95` |
+| `orcarouter-reasoning` | `deepseek/deepseek-v4-pro-0813` | Reasoning and analysis tasks | `temperature=0.35, top_p=0.95` |
+| `orcarouter-vision` | `openai/gpt-4o` | Vision and image understanding | `temperature=0.85, top_p=0.95` |
+| `orcarouter-embedding` | `openai/text-embedding-3-large` | Text embeddings | `encoding_format="float"` |
 
 <Note title="Modality support depends on the model">
   The `multi_modal_context` field can include image, audio, and video contexts, but each model/provider combination has its own accepted input formats, media-size limits, and modality mix. Use an image-capable model for image-only workflows, and use an omni or otherwise multimodal model before sending audio or video context. Local audio/video paths require explicit URL mode (`data_type=url`) and require the model endpoint to have filesystem access to the same paths, typically a colocated vLLM server configured for local media access.
@@ -113,7 +133,7 @@ Both methods operate on the same files, ensuring consistency across your entire 
 ## Important Notes
 
 <Warning title="API Key Requirements">
-  While default model configurations are always available, you need to set the appropriate API key environment variable (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`) to actually use the corresponding models for data generation. Without a valid API key, any attempt to generate data using that provider's models will fail.
+  While default model configurations are always available, you need to set the appropriate API key environment variable (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `ORCAROUTER_API_KEY`) to actually use the corresponding models for data generation. Without a valid API key, any attempt to generate data using that provider's models will fail.
 </Warning>
 
 <Warning title="Hosted Provider Data Handling">
@@ -128,6 +148,7 @@ Both methods operate on the same files, ensuring consistency across your entire 
 export NVIDIA_API_KEY="your-api-key-here"
 export OPENAI_API_KEY="your-openai-api-key-here"
 export OPENROUTER_API_KEY="your-openrouter-api-key-here"
+export ORCAROUTER_API_KEY="your-orcarouter-api-key-here"
 ```
 </Tip>
 

--- a/fern/versions/latest/pages/concepts/models/model-providers.mdx
+++ b/fern/versions/latest/pages/concepts/models/model-providers.mdx
@@ -28,7 +28,7 @@ Data Designer supports two provider types:
 
 | Type | Description |
 |------|-------------|
-| `"openai"` | OpenAI-compatible chat completion API. This is the default and works with most providers, including NVIDIA NIM, vLLM, TGI, OpenRouter, Together AI, and OpenAI itself. |
+| `"openai"` | OpenAI-compatible chat completion API. This is the default and works with most providers, including NVIDIA NIM, vLLM, TGI, OpenRouter, OrcaRouter, Together AI, and OpenAI itself. |
 | `"anthropic"` | Anthropic's native Messages API for Claude models. Use this when connecting directly to Anthropic's API. |
 
 Most self-hosted and third-party endpoints expose an OpenAI-compatible API, so `provider_type="openai"` is the right choice in the majority of cases. Only use `"anthropic"` when connecting directly to Anthropic's API at `https://api.anthropic.com`.

--- a/fern/versions/latest/pages/index.mdx
+++ b/fern/versions/latest/pages/index.mdx
@@ -41,6 +41,9 @@ export OPENAI_API_KEY="your-openai-api-key-here"
 
 # OpenRouter (openrouter.ai)
 export OPENROUTER_API_KEY="your-openrouter-api-key-here"
+
+# OrcaRouter (orcarouter.ai)
+export ORCAROUTER_API_KEY="your-orcarouter-api-key-here"
 ```
 
 Verify your configuration is ready:

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -299,6 +299,10 @@ OPENROUTER_PROVIDER_NAME = "openrouter"
 
 OPENROUTER_API_KEY_ENV_VAR_NAME = "OPENROUTER_API_KEY"
 
+ORCAROUTER_PROVIDER_NAME = "orcarouter"
+
+ORCAROUTER_API_KEY_ENV_VAR_NAME = "ORCAROUTER_API_KEY"
+
 ATTRIBUTION_TITLE = "NeMo Data Designer"
 ATTRIBUTION_REFERER = "https://github.com/NVIDIA-NeMo/DataDesigner"
 
@@ -328,6 +332,12 @@ PREDEFINED_PROVIDERS = [
         "endpoint": "https://openrouter.ai/api/v1",
         "provider_type": "openai",
         "api_key": OPENROUTER_API_KEY_ENV_VAR_NAME,
+    },
+    {
+        "name": ORCAROUTER_PROVIDER_NAME,
+        "endpoint": "https://api.orcarouter.ai/v1",
+        "provider_type": "openai",
+        "api_key": ORCAROUTER_API_KEY_ENV_VAR_NAME,
     },
 ]
 
@@ -380,6 +390,18 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
             "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
             "inference_parameters": NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS,
         },
+        "embedding": {
+            "model": "openai/text-embedding-3-large",
+            "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS,
+        },
+    },
+    ORCAROUTER_PROVIDER_NAME: {
+        "text": {"model": "openai/gpt-4.1", "inference_parameters": DEFAULT_TEXT_INFERENCE_PARAMS},
+        "reasoning": {
+            "model": "deepseek/deepseek-v4-pro-0813",
+            "inference_parameters": DEFAULT_REASONING_INFERENCE_PARAMS,
+        },
+        "vision": {"model": "openai/gpt-4o", "inference_parameters": DEFAULT_VISION_INFERENCE_PARAMS},
         "embedding": {
             "model": "openai/text-embedding-3-large",
             "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS,

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -54,7 +54,7 @@ def test_get_default_inference_parameters():
 
 def test_get_builtin_model_configs():
     builtin_model_configs = get_builtin_model_configs()
-    assert len(builtin_model_configs) == 12
+    assert len(builtin_model_configs) == 16
     assert builtin_model_configs[0].alias == "nvidia-text"
     assert builtin_model_configs[0].model == "nvidia/nemotron-3-nano-30b-a3b"
     assert builtin_model_configs[0].provider == "nvidia"
@@ -95,11 +95,31 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[11].alias == "openrouter-embedding"
     assert builtin_model_configs[11].model == "openai/text-embedding-3-large"
     assert builtin_model_configs[11].provider == "openrouter"
+    assert builtin_model_configs[12].alias == "orcarouter-text"
+    assert builtin_model_configs[12].model == "openai/gpt-4.1"
+    assert builtin_model_configs[12].provider == "orcarouter"
+    assert builtin_model_configs[12].inference_parameters == ChatCompletionInferenceParams(
+        temperature=0.85,
+        top_p=0.95,
+    )
+    assert builtin_model_configs[13].alias == "orcarouter-reasoning"
+    assert builtin_model_configs[13].model == "deepseek/deepseek-v4-pro-0813"
+    assert builtin_model_configs[13].provider == "orcarouter"
+    assert builtin_model_configs[13].inference_parameters == ChatCompletionInferenceParams(
+        temperature=0.35,
+        top_p=0.95,
+    )
+    assert builtin_model_configs[14].alias == "orcarouter-vision"
+    assert builtin_model_configs[14].model == "openai/gpt-4o"
+    assert builtin_model_configs[14].provider == "orcarouter"
+    assert builtin_model_configs[15].alias == "orcarouter-embedding"
+    assert builtin_model_configs[15].model == "openai/text-embedding-3-large"
+    assert builtin_model_configs[15].provider == "orcarouter"
 
 
 def test_get_builtin_model_providers():
     builtin_model_providers = get_builtin_model_providers()
-    assert len(builtin_model_providers) == 3
+    assert len(builtin_model_providers) == 4
     assert builtin_model_providers[0].name == "nvidia"
     assert builtin_model_providers[0].endpoint == "https://integrate.api.nvidia.com/v1"
     assert builtin_model_providers[0].provider_type == "openai"
@@ -115,6 +135,11 @@ def test_get_builtin_model_providers():
     assert builtin_model_providers[2].provider_type == "openai"
     assert builtin_model_providers[2].api_key == "OPENROUTER_API_KEY"
     assert builtin_model_providers[2].extra_headers is None
+    assert builtin_model_providers[3].name == "orcarouter"
+    assert builtin_model_providers[3].endpoint == "https://api.orcarouter.ai/v1"
+    assert builtin_model_providers[3].provider_type == "openai"
+    assert builtin_model_providers[3].api_key == "ORCAROUTER_API_KEY"
+    assert builtin_model_providers[3].extra_headers is None
 
 
 def test_get_default_model_configs_path_exists(tmp_path: Path):


### PR DESCRIPTION
## 📋 Summary

This PR adds **OrcaRouter** as a built-in model provider, fully parallel to the existing OpenRouter wiring. Data Designer is a framework for generating high-quality synthetic datasets, and its model configs already ship NVIDIA, OpenAI, and OpenRouter as first-class providers; OrcaRouter now joins them as a named `orcarouter` provider instead of being used through an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## 🔗 Related Issue

Fixes #897

## 🔄 Changes

The change mirrors the existing `openrouter` provider block-for-block across the same files:

- **`packages/data-designer-config/src/data_designer/config/utils/constants.py`**
  - Adds `ORCAROUTER_PROVIDER_NAME = "orcarouter"` and `ORCAROUTER_API_KEY_ENV_VAR_NAME = "ORCAROUTER_API_KEY"` next to their `OPENROUTER_*` counterparts.
  - Registers `orcarouter` in `PREDEFINED_PROVIDERS` with `endpoint=https://api.orcarouter.ai/v1`, `provider_type="openai"`, and `api_key=ORCAROUTER_API_KEY` — the exact shape of the `openrouter` entry.
  - Adds an `ORCAROUTER_PROVIDER_NAME` block to `PREDEFINED_PROVIDERS_MODEL_MAP` with `orcarouter-text`, `orcarouter-reasoning`, `orcarouter-vision`, and `orcarouter-embedding` aliases, mirroring the `openrouter` key.

- **`packages/data-designer-config/tests/config/test_default_model_settings.py`**
  - Updates the builtin counts (`3 → 4` providers, `12 → 16` model configs) and asserts the new `orcarouter` provider + aliases, exactly as the `openrouter` assertions are written.

- **Docs**
  - `README.md` — adds OrcaRouter to the default providers list and the `ORCAROUTER_API_KEY` env var example.
  - `fern/versions/latest/pages/concepts/models/default-model-settings.mdx` — adds the OrcaRouter provider section and OrcaRouter models table (mirroring the OpenRouter sections), plus the env-var mentions in the API-key warning/tip.
  - `fern/versions/latest/pages/index.mdx`, `concepts/models/model-providers.mdx`, and `concepts/models/custom-model-settings.mdx` — mention OrcaRouter alongside the existing default providers.

### Models chosen

Each alias was validated against OrcaRouter's live model catalog (all return HTTP 200 through the new provider wiring):

| Alias | Model | Modality |
|-------|-------|----------|
| `orcarouter-text` | `openai/gpt-4.1` | text |
| `orcarouter-reasoning` | `deepseek/deepseek-v4-pro-0813` | reasoning |
| `orcarouter-vision` | `openai/gpt-4o` | vision (verified with an image input) |
| `orcarouter-embedding` | `openai/text-embedding-3-large` | embeddings (3072-dim) |

## 🧪 Testing

- `make check-all-fix` equivalent: `ruff check` and `ruff format --check` pass across all three packages.
- `pytest packages/data-designer-config/tests/` → 644 passed.
- `pytest packages/data-designer-engine/tests/engine/models/test_facade.py` → 91 passed (OpenRouter-specific attribution tests unaffected).
- L3 live test: exercised the new `orcarouter` provider through the real `ModelFacade` → `create_model_client` path (`ModelProviderRegistry` + `EnvironmentResolver`) against `api.orcarouter.ai`:
  - `orcarouter-text` chat → `200`, returned `hello`
  - `orcarouter-reasoning` chat → `200`, returned `hello`
  - `orcarouter-embedding` → `200`, 3072-dim vector
- Note: 6 pre-existing test failures in the full suite (`make test`) are sandbox-environment artifacts (the `make` binary and tiktoken cache are unavailable) and fail identically on the pristine baseline.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
