### PR TITLE
fix: replace retired NVIDIA embedding model

### DIFF
--- a/fern/versions/latest/pages/concepts/models/default-model-settings.mdx
+++ b/fern/versions/latest/pages/concepts/models/default-model-settings.mdx
@@ -49,7 +49,7 @@ The following model configurations are automatically available when `NVIDIA_API_
 | `nvidia-text` | `nvidia/nemotron-3-nano-30b-a3b` | General text generation | `temperature=1.0, top_p=1.0` |
 | `nvidia-reasoning` | `nvidia/nemotron-3-super-120b-a12b` | Reasoning and analysis tasks | `temperature=1.0, top_p=0.95, extra_body={"reasoning_effort": "medium"}` |
 | `nvidia-vision` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Omni multimodal understanding for image, audio, and video inputs | `temperature=0.60, top_p=0.95` |
-| `nvidia-embedding` | `nvidia/llama-nemotron-embed-1b-v2` | Text embeddings | `encoding_format="float", extra_body={"input_type": "query"}` |
+| `nvidia-embedding` | `nvidia/nemotron-3-embed-1b` | Text embeddings | `encoding_format="float", extra_body={"input_type": "query"}` |
 
 
 ### OpenAI Models

--- a/fern/versions/latest/pages/concepts/models/model-configs.mdx
+++ b/fern/versions/latest/pages/concepts/models/model-configs.mdx
@@ -101,7 +101,7 @@ model_configs = [
     # Embedding tasks
     dd.ModelConfig(
         alias="embedding_model",
-        model="nvidia/llama-nemotron-embed-1b-v2",
+        model="nvidia/nemotron-3-embed-1b",
         provider="nvidia",
         inference_parameters=dd.EmbeddingInferenceParams(
             encoding_format="float",

--- a/packages/data-designer-config/src/data_designer/config/utils/constants.py
+++ b/packages/data-designer-config/src/data_designer/config/utils/constants.py
@@ -360,7 +360,7 @@ PREDEFINED_PROVIDERS_MODEL_MAP = {
             "inference_parameters": NEMOTRON_3_NANO_OMNI_30B_A3B_REASONING_INFERENCE_PARAMS,
         },
         "embedding": {
-            "model": "nvidia/llama-nemotron-embed-1b-v2",
+            "model": "nvidia/nemotron-3-embed-1b",
             "inference_parameters": DEFAULT_EMBEDDING_INFERENCE_PARAMS | {"extra_body": {"input_type": "query"}},
         },
     },

--- a/packages/data-designer-config/tests/config/test_default_model_settings.py
+++ b/packages/data-designer-config/tests/config/test_default_model_settings.py
@@ -65,7 +65,7 @@ def test_get_builtin_model_configs():
     assert builtin_model_configs[2].model == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
     assert builtin_model_configs[2].provider == "nvidia"
     assert builtin_model_configs[3].alias == "nvidia-embedding"
-    assert builtin_model_configs[3].model == "nvidia/llama-nemotron-embed-1b-v2"
+    assert builtin_model_configs[3].model == "nvidia/nemotron-3-embed-1b"
     assert builtin_model_configs[3].provider == "nvidia"
     assert builtin_model_configs[4].alias == "openai-text"
     assert builtin_model_configs[4].model == "gpt-4.1"


### PR DESCRIPTION
## 📋 Summary

Replace DataDesigner's retired NVIDIA Build embedding default with `nvidia/nemotron-3-embed-1b`. The previous model reached end of life on August 25 and now causes the scheduled provider health check to fail with HTTP 410.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Update the predefined NVIDIA embedding model to `nvidia/nemotron-3-embed-1b`.
- Update the built-in model configuration assertion.
- Update the published default-model table and copyable Fern configuration example.

## 🧪 Testing

- [x] `.venv/bin/pytest -p no:cacheprovider packages/data-designer-config/tests/config/test_default_model_settings.py`
- [x] Live DD health check for `nvidia/embedding`
- [x] `make check-fern-docs-locally`
- [x] `.venv/bin/ruff check --fix .`
- [x] `.venv/bin/ruff format .`
- [x] E2E tests: N/A - covered by the targeted live provider health check

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs: N/A - model ID replacement only

---
*Description updated with AI*