### PR TITLE
fix: harden Slurm image publication

### DIFF
--- a/packages/data-designer-slurm/src/data_designer/slurm/images/filesystem.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/filesystem.py
@@ -148,7 +148,7 @@ def read_regular_text(directory_descriptor: int, name: str, display_path: Path) 
             raise OSError(f"registry path {display_path} is not a regular file")
         descriptor = os.open(
             name,
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
             dir_fd=directory_descriptor,
         )
         after_open = os.fstat(descriptor)
@@ -157,7 +157,21 @@ def read_regular_text(directory_descriptor: int, name: str, display_path: Path) 
         registry_file = os.fdopen(descriptor, "r", encoding="utf-8")
         descriptor = None
         with registry_file:
-            return registry_file.read()
+            content = registry_file.read()
+            after_read = os.fstat(registry_file.fileno())
+            after_path = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(after_read.st_mode)
+            or not stat.S_ISREG(after_path.st_mode)
+            or _get_file_facts(after_open) != _get_file_facts(after_read)
+            or _get_file_facts(after_read) != _get_file_facts(after_path)
+        ):
+            raise OSError(f"registry path {display_path} changed while it was being read")
+        return content
     finally:
         if descriptor is not None:
             os.close(descriptor)
+
+
+def _get_file_facts(status: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns, status.st_ctime_ns)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/lifecycle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/lifecycle.py
@@ -8,22 +8,28 @@ from __future__ import annotations
 import hashlib
 import os
 import stat
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 
 from pydantic import TypeAdapter, ValidationError
 
-from data_designer.slurm.config import ImageBuildRequest, SelectedSlurmProfile
+from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, SelectedSlurmProfile
 from data_designer.slurm.contracts import ArtifactReference, Identifier
 from data_designer.slurm.images.errors import ImageLifecycleError
-from data_designer.slurm.images.filesystem import ensure_private_directory
+from data_designer.slurm.images.filesystem import (
+    ensure_private_directory,
+    open_verified_child_directory,
+    open_verified_directory,
+)
 from data_designer.slurm.images.records import (
     ImageLifecycleOperation,
     ImageLifecyclePlan,
+    RegisteredImage,
     validate_enroot_mount_path,
     validate_oci_source_for_lifecycle,
 )
+from data_designer.slurm.images.service import VerifiedImageRegistry
 from data_designer.slurm.launcher.batch import quote_shell_value, render_batch_directives
 from data_designer.slurm.launcher.client import SlurmCommandClient
 from data_designer.slurm.launcher.models import SlurmJobSubmissionReceipt
@@ -36,15 +42,23 @@ _RESOURCE_PACKAGE = "data_designer.slurm.images.resources"
 _IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 _MINIMUM_ENROOT_OCI_VERSION = (4, 0)
 _MINIMUM_ENROOT_SQSH_VERSION = (3, 5)
+_MAXIMUM_INSPECTION_SIZE = 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
 class PreparedImageLifecycleJob:
-    """Persisted, checksum-bound files ready for one Slurm submission."""
+    """Persisted, checksum-bound files ready for one Slurm submission.
+
+    Attributes:
+        plan: Structured lifecycle intent and package-owned paths.
+        plan_file: Checksum-bound persisted plan.
+        script_file: Checksum-bound batch script.
+    """
 
     plan: ImageLifecyclePlan
     plan_file: ArtifactReference
     script_file: ArtifactReference
+    _job_directory_identity: tuple[int, int] = field(repr=False, compare=False)
 
 
 def prepare_image_lifecycle_job(
@@ -73,11 +87,16 @@ def prepare_image_lifecycle_job(
     temporary_root = image_root / ".tmp"
     job_root = temporary_root / "jobs"
     job_directory = job_root / lifecycle_id
+    job_directory_created = False
+    job_directory_identity: tuple[int, int] | None = None
     try:
         ensure_private_directory(image_root, parents=True)
         ensure_private_directory(temporary_root, parents=False)
         ensure_private_directory(job_root, parents=False)
         job_directory.mkdir(mode=0o700)
+        job_directory_created = True
+        job_directory_status = job_directory.lstat()
+        job_directory_identity = (job_directory_status.st_dev, job_directory_status.st_ino)
         inspection_directory = job_directory / "output"
         ensure_private_directory(inspection_directory, parents=False)
         inspector_script = _stage_resource(job_directory, _INSPECTOR_FILENAME)
@@ -105,8 +124,16 @@ def prepare_image_lifecycle_job(
             mode=0o500,
         )
     except (OSError, ValueError) as error:
+        if job_directory_created and job_directory_identity is not None:
+            _try_remove_job_directory(job_directory, expected_identity=job_directory_identity)
         raise ImageLifecycleError(f"cannot prepare image lifecycle job {lifecycle_id!r}") from error
-    return PreparedImageLifecycleJob(plan=plan, plan_file=plan_file, script_file=script_file)
+    assert job_directory_identity is not None
+    return PreparedImageLifecycleJob(
+        plan=plan,
+        plan_file=plan_file,
+        script_file=script_file,
+        _job_directory_identity=job_directory_identity,
+    )
 
 
 def render_image_lifecycle_script(plan: ImageLifecyclePlan) -> str:
@@ -143,6 +170,7 @@ if [[ -e "${{DD_IMAGE_SQSH}}" || -L "${{DD_IMAGE_SQSH}}" ]]; then
     exit 73
 fi
 verify_enroot_compatibility {minimum_major} {minimum_minor} "digest-pinned OCI imports"
+DD_REMOVE_SQSH_ON_FAILURE=1
 enroot import -o "${{DD_IMAGE_SQSH}}" "${{DD_OCI_SOURCE}}"
 """
     else:
@@ -150,6 +178,28 @@ enroot import -o "${{DD_IMAGE_SQSH}}" "${{DD_OCI_SOURCE}}"
         existing_sqsh_preflight = (
             f'verify_enroot_compatibility {minimum_major} {minimum_minor} "existing SQSH inspection"\n'
         )
+    inspection_source_block = (
+        f"""DD_INSPECTION_SQSH={quote_shell_value(f"{plan.job_directory}/verified.sqsh")}
+if [[ -e "${{DD_INSPECTION_SQSH}}" || -L "${{DD_INSPECTION_SQSH}}" ]]; then
+    printf '%s\\n' 'verified SQSH snapshot path already exists' >&2
+    exit 73
+fi
+DD_REMOVE_INSPECTION_SQSH_ON_EXIT=1
+if cp --help 2>&1 | grep -q -- '--reflink'; then
+    cp --reflink=auto -- "${{DD_VERIFIED_SQSH}}" "${{DD_INSPECTION_SQSH}}"
+else
+    cp -- "${{DD_VERIFIED_SQSH}}" "${{DD_INSPECTION_SQSH}}"
+fi
+chmod 0400 "${{DD_INSPECTION_SQSH}}"
+readonly DD_INSPECTION_SQSH_SHA256="$(compute_file_sha256 "${{DD_INSPECTION_SQSH}}")"
+if [[ "${{DD_INSPECTION_SQSH_SHA256}}" != "${{DD_SQSH_SHA256}}" ]]; then
+    printf '%s\\n' 'SQSH bytes changed while creating the inspection snapshot' >&2
+    exit 74
+fi
+"""
+        if plan.operation is ImageLifecycleOperation.INSPECT_SQSH
+        else 'DD_INSPECTION_SQSH="${DD_IMAGE_SQSH}"\n'
+    )
 
     return f"""#!/usr/bin/env bash
 {directives}
@@ -165,6 +215,29 @@ readonly DD_INSPECTOR={quote_shell_value(plan.inspector_script.path)}
 readonly DD_INSPECTOR_SHA256={quote_shell_value(plan.inspector_script.sha256)}
 readonly DD_ENROOT_RC={quote_shell_value(plan.enroot_rc.path)}
 readonly DD_ENROOT_RC_SHA256={quote_shell_value(plan.enroot_rc.sha256)}
+DD_CONTAINER_NAME=""
+DD_REMOVE_SQSH_ON_FAILURE=0
+DD_INSPECTION_SQSH=""
+DD_REMOVE_INSPECTION_SQSH_ON_EXIT=0
+
+cleanup() {{
+    local status="$?"
+    if [[ -n "${{DD_CONTAINER_NAME}}" ]]; then
+        enroot remove -f "${{DD_CONTAINER_NAME}}" >/dev/null 2>&1 || true
+    fi
+    exec 9<&- 2>/dev/null || true
+    if (( DD_REMOVE_INSPECTION_SQSH_ON_EXIT == 1 )); then
+        rm -f -- "${{DD_INSPECTION_SQSH}}" >/dev/null 2>&1 || true
+    fi
+    if (( status != 0 )); then
+        rm -f -- "${{DD_INSPECTION_OUTPUT}}" >/dev/null 2>&1 || true
+        if (( DD_REMOVE_SQSH_ON_FAILURE == 1 )); then
+            rm -f -- "${{DD_IMAGE_SQSH}}" >/dev/null 2>&1 || true
+        fi
+    fi
+    return "${{status}}"
+}}
+trap cleanup EXIT
 
 compute_file_sha256() {{
     local actual_sha256
@@ -227,14 +300,25 @@ if [[ ! ${{SLURM_JOB_ID:-}} =~ ^[1-9][0-9]*$ ]]; then
     printf '%s\\n' 'SLURM_JOB_ID must be a positive integer' >&2
     exit 64
 fi
-readonly DD_CONTAINER_NAME="dd-image-${{SLURM_JOB_ID}}"
+DD_CONTAINER_NAME="dd-image-${{SLURM_JOB_ID}}"
+exec 9<"${{DD_IMAGE_SQSH}}"
+if [[ -e /proc/self/fd/9 ]]; then
+    readonly DD_VERIFIED_SQSH="/proc/self/fd/9"
+else
+    readonly DD_VERIFIED_SQSH="${{DD_IMAGE_SQSH}}"
+fi
+if [[ ! -f "${{DD_VERIFIED_SQSH}}" ]]; then
+    printf '%s\\n' 'SQSH descriptor is not a regular file' >&2
+    exit 74
+fi
+readonly DD_VERIFIED_SQSH_SHA256="$(compute_file_sha256 "${{DD_VERIFIED_SQSH}}")"
+if [[ "${{DD_VERIFIED_SQSH_SHA256}}" != "${{DD_SQSH_SHA256}}" ]]; then
+    printf '%s\\n' 'SQSH bytes changed before inspection' >&2
+    exit 74
+fi
+{inspection_source_block}
 
-cleanup() {{
-    enroot remove -f "${{DD_CONTAINER_NAME}}" >/dev/null 2>&1 || true
-}}
-trap cleanup EXIT
-
-enroot create -f --name "${{DD_CONTAINER_NAME}}" "${{DD_IMAGE_SQSH}}"
+enroot create -f --name "${{DD_CONTAINER_NAME}}" "${{DD_INSPECTION_SQSH}}"
 ENROOT_LOGIN_SHELL=no ENROOT_MOUNT_HOME=no enroot start --root \
     --rc "${{DD_ENROOT_RC}}" \
     --mount "${{DD_INSPECTOR}}:/opt/data-designer-slurm/inspect_image.py:x-create=file,bind,ro" \
@@ -253,6 +337,26 @@ exec "${{python_path}}" "$@"
     /opt/data-designer-slurm/output/inspection.json
 
 [[ -s "${{DD_INSPECTION_OUTPUT}}" ]]
+readonly DD_FINAL_INSPECTION_SQSH_SHA256="$(compute_file_sha256 "${{DD_INSPECTION_SQSH}}")"
+if [[ "${{DD_FINAL_INSPECTION_SQSH_SHA256}}" != "${{DD_SQSH_SHA256}}" ]]; then
+    printf '%s\n' 'SQSH inspection snapshot changed during inspection' >&2
+    exit 74
+fi
+readonly DD_FINAL_SQSH_SHA256="$(compute_file_sha256 "${{DD_VERIFIED_SQSH}}")"
+if [[ "${{DD_FINAL_SQSH_SHA256}}" != "${{DD_SQSH_SHA256}}" ]]; then
+    printf '%s\\n' 'SQSH bytes changed during inspection' >&2
+    exit 74
+fi
+if [[ ! -f "${{DD_IMAGE_SQSH}}" || -L "${{DD_IMAGE_SQSH}}" ]]; then
+    printf '%s\\n' 'SQSH path changed during inspection' >&2
+    exit 74
+fi
+readonly DD_FINAL_PATH_SHA256="$(compute_file_sha256 "${{DD_IMAGE_SQSH}}")"
+if [[ "${{DD_FINAL_PATH_SHA256}}" != "${{DD_SQSH_SHA256}}" ]]; then
+    printf '%s\\n' 'SQSH path changed during inspection' >&2
+    exit 74
+fi
+true
 """
 
 
@@ -261,6 +365,82 @@ def submit_prepared_image_lifecycle(
     client: SlurmCommandClient,
 ) -> SlurmJobSubmissionReceipt:
     """Verify and submit one prepared image lifecycle script."""
+    verified_script = _verify_prepared_lifecycle(prepared)
+    try:
+        script_text = verified_script.decode("utf-8", errors="strict")
+    except UnicodeError as error:
+        raise ImageLifecycleError("prepared image lifecycle script is not valid UTF-8") from error
+    return client.submit_script(script_text)
+
+
+def publish_completed_image_lifecycle(
+    prepared: PreparedImageLifecycleJob,
+    *,
+    replace: bool = False,
+) -> RegisteredImage:
+    """Validate, atomically publish, and register one completed lifecycle result.
+
+    Args:
+        prepared: The exact checksum-bound job whose inspection has completed.
+        replace: Whether an existing alias may be replaced explicitly.
+
+    Returns:
+        The durable alias binding for the verified SQSH.
+
+    Raises:
+        SlurmImageError: If validation, publication, registration, or cleanup fails.
+            Cleanup failure after a committed publication does not invalidate the alias.
+    """
+    try:
+        _verify_prepared_lifecycle(prepared)
+        inspection_content = _read_regular_file(
+            Path(prepared.plan.inspection_output_path),
+            maximum_size=_MAXIMUM_INSPECTION_SIZE,
+        )
+        try:
+            inspection = ImageInspectionRecord.model_validate_json(inspection_content, strict=True)
+        except (UnicodeError, ValueError, ValidationError) as error:
+            raise ImageLifecycleError("image lifecycle inspection output is invalid") from error
+        registry = VerifiedImageRegistry(prepared.plan.selected_profile.profile.workspace_root)
+        if prepared.plan.operation is ImageLifecycleOperation.IMPORT_OCI:
+            source_oci_digest = prepared.plan.source_oci_digest
+            if source_oci_digest is None:
+                raise ImageLifecycleError("OCI image lifecycle result is missing its source digest")
+            registered = registry.publish_imported(
+                prepared.plan.request,
+                inspection,
+                Path(prepared.plan.sqsh_path),
+                source_oci_digest=source_oci_digest,
+                replace=replace,
+            )
+        else:
+            registered = registry.register_existing(prepared.plan.request, inspection, replace=replace)
+    except BaseException:
+        _try_remove_job_directory(
+            Path(prepared.plan.job_directory),
+            expected_identity=prepared._job_directory_identity,
+        )
+        raise
+    cleanup_prepared_image_lifecycle(prepared)
+    return registered
+
+
+def cleanup_prepared_image_lifecycle(prepared: PreparedImageLifecycleJob) -> None:
+    """Remove package-owned temporary state for one completed or failed lifecycle job.
+
+    Raises:
+        ImageLifecycleError: If the package-owned job directory cannot be removed.
+    """
+    job_directory = Path(prepared.plan.job_directory)
+    try:
+        _delete_job_directory(job_directory, expected_identity=prepared._job_directory_identity)
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        raise ImageLifecycleError(f"cannot clean image lifecycle job {prepared.plan.lifecycle_id!r}") from error
+
+
+def _verify_prepared_lifecycle(prepared: PreparedImageLifecycleJob) -> bytes:
     expected_artifacts = (
         (
             "plan",
@@ -289,11 +469,7 @@ def submit_prepared_image_lifecycle(
             verified_script = actual_content
     if verified_script is None:
         raise ImageLifecycleError("prepared image lifecycle script was not verified")
-    try:
-        script_text = verified_script.decode("utf-8", errors="strict")
-    except UnicodeError as error:
-        raise ImageLifecycleError("prepared image lifecycle script is not valid UTF-8") from error
-    return client.submit_script(script_text)
+    return verified_script
 
 
 def _stage_resource(job_directory: Path, filename: str) -> ArtifactReference:
@@ -330,18 +506,88 @@ def _write_file(path: Path, content: bytes, *, mode: int) -> ArtifactReference:
     return ArtifactReference(path=path.as_posix(), sha256=hashlib.sha256(content).hexdigest())
 
 
-def _read_regular_file(path: Path) -> bytes:
+def _read_regular_file(path: Path, *, maximum_size: int | None = None) -> bytes:
     descriptor: int | None = None
     try:
-        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        before_open = path.lstat()
+        if not stat.S_ISREG(before_open.st_mode):
+            raise ImageLifecycleError("prepared image lifecycle file is not regular")
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+        )
         path_status = os.fstat(descriptor)
-        if not stat.S_ISREG(path_status.st_mode):
+        if not stat.S_ISREG(path_status.st_mode) or (before_open.st_dev, before_open.st_ino) != (
+            path_status.st_dev,
+            path_status.st_ino,
+        ):
             raise ImageLifecycleError("prepared image lifecycle file is not regular")
         with os.fdopen(descriptor, "rb") as source:
             descriptor = None
-            return source.read()
+            content = source.read() if maximum_size is None else source.read(maximum_size + 1)
+            after_read = os.fstat(source.fileno())
+            after_path = path.lstat()
+        if (
+            not stat.S_ISREG(after_read.st_mode)
+            or not stat.S_ISREG(after_path.st_mode)
+            or _get_file_facts(path_status) != _get_file_facts(after_read)
+            or _get_file_facts(after_read) != _get_file_facts(after_path)
+        ):
+            raise ImageLifecycleError("prepared image lifecycle file changed while it was being read")
+        if maximum_size is not None and len(content) > maximum_size:
+            raise ImageLifecycleError("image lifecycle inspection output is too large")
+        return content
     except OSError as error:
         raise ImageLifecycleError("cannot read prepared image lifecycle file") from error
     finally:
         if descriptor is not None:
             os.close(descriptor)
+
+
+def _get_file_facts(status: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns, status.st_ctime_ns)
+
+
+def _delete_job_directory(job_directory: Path, *, expected_identity: tuple[int, int]) -> None:
+    with open_verified_directory(job_directory.parent) as parent_descriptor:
+        with open_verified_child_directory(
+            parent_descriptor,
+            job_directory.name,
+            job_directory,
+        ) as job_directory_descriptor:
+            status = os.fstat(job_directory_descriptor)
+            if (status.st_dev, status.st_ino) != expected_identity:
+                raise OSError(f"image lifecycle job directory {job_directory} changed before cleanup")
+            _clear_directory(job_directory_descriptor, job_directory)
+        current_status = os.stat(job_directory.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if (current_status.st_dev, current_status.st_ino) != expected_identity:
+            raise OSError(f"image lifecycle job directory {job_directory} changed during cleanup")
+        os.rmdir(job_directory.name, dir_fd=parent_descriptor)
+        os.fsync(parent_descriptor)
+
+
+def _clear_directory(directory_descriptor: int, display_path: Path) -> None:
+    for name in os.listdir(directory_descriptor):
+        status = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+        child_path = display_path / name
+        if stat.S_ISDIR(status.st_mode):
+            with open_verified_child_directory(
+                directory_descriptor,
+                name,
+                child_path,
+            ) as child_descriptor:
+                _clear_directory(child_descriptor, child_path)
+            current_status = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+            if (current_status.st_dev, current_status.st_ino) != (status.st_dev, status.st_ino):
+                raise OSError(f"image lifecycle directory {child_path} changed during cleanup")
+            os.rmdir(name, dir_fd=directory_descriptor)
+        else:
+            os.unlink(name, dir_fd=directory_descriptor)
+    os.fsync(directory_descriptor)
+
+
+def _try_remove_job_directory(job_directory: Path, *, expected_identity: tuple[int, int]) -> None:
+    try:
+        _delete_job_directory(job_directory, expected_identity=expected_identity)
+    except OSError:
+        pass

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/lifecycle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/lifecycle.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import hashlib
 import os
 import stat
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
@@ -365,7 +367,8 @@ def submit_prepared_image_lifecycle(
     client: SlurmCommandClient,
 ) -> SlurmJobSubmissionReceipt:
     """Verify and submit one prepared image lifecycle script."""
-    verified_script = _verify_prepared_lifecycle(prepared)
+    with _open_prepared_job_directory(prepared) as job_directory_descriptor:
+        verified_script = _verify_prepared_lifecycle(prepared, job_directory_descriptor)
     try:
         script_text = verified_script.decode("utf-8", errors="strict")
     except UnicodeError as error:
@@ -392,29 +395,42 @@ def publish_completed_image_lifecycle(
             Cleanup failure after a committed publication does not invalidate the alias.
     """
     try:
-        _verify_prepared_lifecycle(prepared)
-        inspection_content = _read_regular_file(
-            Path(prepared.plan.inspection_output_path),
-            maximum_size=_MAXIMUM_INSPECTION_SIZE,
-        )
-        try:
-            inspection = ImageInspectionRecord.model_validate_json(inspection_content, strict=True)
-        except (UnicodeError, ValueError, ValidationError) as error:
-            raise ImageLifecycleError("image lifecycle inspection output is invalid") from error
-        registry = VerifiedImageRegistry(prepared.plan.selected_profile.profile.workspace_root)
-        if prepared.plan.operation is ImageLifecycleOperation.IMPORT_OCI:
-            source_oci_digest = prepared.plan.source_oci_digest
-            if source_oci_digest is None:
-                raise ImageLifecycleError("OCI image lifecycle result is missing its source digest")
-            registered = registry.publish_imported(
-                prepared.plan.request,
-                inspection,
-                Path(prepared.plan.sqsh_path),
-                source_oci_digest=source_oci_digest,
-                replace=replace,
-            )
-        else:
-            registered = registry.register_existing(prepared.plan.request, inspection, replace=replace)
+        with _open_prepared_job_directory(prepared) as job_directory_descriptor:
+            _verify_prepared_lifecycle(prepared, job_directory_descriptor)
+            inspection_path = Path(prepared.plan.inspection_output_path)
+            try:
+                with open_verified_child_directory(
+                    job_directory_descriptor,
+                    inspection_path.parent.name,
+                    inspection_path.parent,
+                ) as inspection_directory_descriptor:
+                    inspection_content = _read_regular_file(
+                        inspection_directory_descriptor,
+                        inspection_path.name,
+                        inspection_path,
+                        maximum_size=_MAXIMUM_INSPECTION_SIZE,
+                    )
+            except OSError as error:
+                raise ImageLifecycleError("cannot read prepared image lifecycle inspection output") from error
+            try:
+                inspection = ImageInspectionRecord.model_validate_json(inspection_content, strict=True)
+            except (UnicodeError, ValueError, ValidationError) as error:
+                raise ImageLifecycleError("image lifecycle inspection output is invalid") from error
+            registry = VerifiedImageRegistry(prepared.plan.selected_profile.profile.workspace_root)
+            if prepared.plan.operation is ImageLifecycleOperation.IMPORT_OCI:
+                source_oci_digest = prepared.plan.source_oci_digest
+                if source_oci_digest is None:
+                    raise ImageLifecycleError("OCI image lifecycle result is missing its source digest")
+                registered = registry.publish_imported(
+                    prepared.plan.request,
+                    inspection,
+                    Path(prepared.plan.sqsh_path),
+                    source_oci_digest=source_oci_digest,
+                    candidate_directory_descriptor=job_directory_descriptor,
+                    replace=replace,
+                )
+            else:
+                registered = registry.register_existing(prepared.plan.request, inspection, replace=replace)
     except BaseException:
         _try_remove_job_directory(
             Path(prepared.plan.job_directory),
@@ -440,7 +456,10 @@ def cleanup_prepared_image_lifecycle(prepared: PreparedImageLifecycleJob) -> Non
         raise ImageLifecycleError(f"cannot clean image lifecycle job {prepared.plan.lifecycle_id!r}") from error
 
 
-def _verify_prepared_lifecycle(prepared: PreparedImageLifecycleJob) -> bytes:
+def _verify_prepared_lifecycle(
+    prepared: PreparedImageLifecycleJob,
+    job_directory_descriptor: int,
+) -> bytes:
     expected_artifacts = (
         (
             "plan",
@@ -458,7 +477,11 @@ def _verify_prepared_lifecycle(prepared: PreparedImageLifecycleJob) -> bytes:
     verified_script: bytes | None = None
     for label, artifact, expected_path, expected_content in expected_artifacts:
         expected_sha256 = hashlib.sha256(expected_content).hexdigest()
-        actual_content = _read_regular_file(expected_path)
+        actual_content = _read_regular_file(
+            job_directory_descriptor,
+            expected_path.name,
+            expected_path,
+        )
         if (
             artifact.path != expected_path.as_posix()
             or artifact.sha256 != expected_sha256
@@ -470,6 +493,27 @@ def _verify_prepared_lifecycle(prepared: PreparedImageLifecycleJob) -> bytes:
     if verified_script is None:
         raise ImageLifecycleError("prepared image lifecycle script was not verified")
     return verified_script
+
+
+@contextmanager
+def _open_prepared_job_directory(prepared: PreparedImageLifecycleJob) -> Iterator[int]:
+    job_directory = Path(prepared.plan.job_directory)
+    with ExitStack() as stack:
+        try:
+            parent_descriptor = stack.enter_context(open_verified_directory(job_directory.parent))
+            job_directory_descriptor = stack.enter_context(
+                open_verified_child_directory(
+                    parent_descriptor,
+                    job_directory.name,
+                    job_directory,
+                )
+            )
+            status = os.fstat(job_directory_descriptor)
+        except OSError as error:
+            raise ImageLifecycleError("cannot access prepared image lifecycle job directory") from error
+        if (status.st_dev, status.st_ino) != prepared._job_directory_identity:
+            raise ImageLifecycleError("prepared image lifecycle job directory no longer matches its identity")
+        yield job_directory_descriptor
 
 
 def _stage_resource(job_directory: Path, filename: str) -> ArtifactReference:
@@ -506,15 +550,22 @@ def _write_file(path: Path, content: bytes, *, mode: int) -> ArtifactReference:
     return ArtifactReference(path=path.as_posix(), sha256=hashlib.sha256(content).hexdigest())
 
 
-def _read_regular_file(path: Path, *, maximum_size: int | None = None) -> bytes:
+def _read_regular_file(
+    directory_descriptor: int,
+    name: str,
+    display_path: Path,
+    *,
+    maximum_size: int | None = None,
+) -> bytes:
     descriptor: int | None = None
     try:
-        before_open = path.lstat()
+        before_open = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
         if not stat.S_ISREG(before_open.st_mode):
             raise ImageLifecycleError("prepared image lifecycle file is not regular")
         descriptor = os.open(
-            path,
+            name,
             os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=directory_descriptor,
         )
         path_status = os.fstat(descriptor)
         if not stat.S_ISREG(path_status.st_mode) or (before_open.st_dev, before_open.st_ino) != (
@@ -526,7 +577,7 @@ def _read_regular_file(path: Path, *, maximum_size: int | None = None) -> bytes:
             descriptor = None
             content = source.read() if maximum_size is None else source.read(maximum_size + 1)
             after_read = os.fstat(source.fileno())
-            after_path = path.lstat()
+            after_path = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
         if (
             not stat.S_ISREG(after_read.st_mode)
             or not stat.S_ISREG(after_path.st_mode)
@@ -538,7 +589,7 @@ def _read_regular_file(path: Path, *, maximum_size: int | None = None) -> bytes:
             raise ImageLifecycleError("image lifecycle inspection output is too large")
         return content
     except OSError as error:
-        raise ImageLifecycleError("cannot read prepared image lifecycle file") from error
+        raise ImageLifecycleError(f"cannot read prepared image lifecycle file {display_path!s}") from error
     finally:
         if descriptor is not None:
             os.close(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -99,6 +99,7 @@ class ImageRegistryStore:
         image: RegisteredImage,
         *,
         verify_before_publish: Callable[[RegisteredImage], None],
+        prepare_before_publish: Callable[[RegisteredImage], None] | None = None,
         verify_after_publish: Callable[[RegisteredImage], None] | None = None,
         rollback_after_failure: Callable[[RegisteredImage], None] | None = None,
         replace: bool = False,
@@ -108,8 +109,11 @@ class ImageRegistryStore:
         Args:
             image: Immutable alias and artifact facts to persist.
             verify_before_publish: Final verification or artifact-publication callback run under all writer locks.
+            prepare_before_publish: Optional expensive preparation run under the alias and target locks, but outside
+                the global registry lock. The registry is revalidated after this callback returns.
             verify_after_publish: Optional verification run after registry replacement but before commit.
-            rollback_after_failure: Optional no-fail cleanup run under all writer locks after registry rollback.
+            rollback_after_failure: Optional no-fail cleanup run under the alias and target locks after registry
+                rollback.
             replace: Whether an existing alias may be replaced explicitly.
 
         Returns:
@@ -134,33 +138,40 @@ class ImageRegistryStore:
                     target_lock_name,
                     self._lock_directory / target_lock_name,
                 ),
-                acquire_file_lock(
-                    lock_directory_descriptor,
-                    _REGISTRY_LOCK_FILENAME,
-                    self._lock_directory / _REGISTRY_LOCK_FILENAME,
-                ),
             ):
-                self._recover_transaction(image_root_descriptor)
-                snapshot = self._load_from_directory(image_root_descriptor)
-                existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
-                if existing is not None and not replace:
-                    raise ImageConflictError(f"image alias {image.name!r} is already registered")
-                self._validate_path_facts(snapshot, image, replacing=existing)
-                images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
-                updated = ImageRegistryDocument(
-                    schema_version=1,
-                    images=tuple(sorted(images, key=lambda entry: entry.name)),
-                )
                 try:
-                    self._save(
-                        image_root_descriptor,
-                        snapshot,
-                        updated,
-                        verify_before_publish=lambda: verify_before_publish(image),
-                        verify_after_publish=(
-                            None if verify_after_publish is None else lambda: verify_after_publish(image)
-                        ),
-                    )
+                    if prepare_before_publish is not None:
+                        with acquire_file_lock(
+                            lock_directory_descriptor,
+                            _REGISTRY_LOCK_FILENAME,
+                            self._lock_directory / _REGISTRY_LOCK_FILENAME,
+                        ):
+                            self._recover_transaction(image_root_descriptor)
+                            self._build_registration(
+                                self._load_from_directory(image_root_descriptor),
+                                image,
+                                replace=replace,
+                            )
+                        prepare_before_publish(image)
+                    with acquire_file_lock(
+                        lock_directory_descriptor,
+                        _REGISTRY_LOCK_FILENAME,
+                        self._lock_directory / _REGISTRY_LOCK_FILENAME,
+                    ):
+                        self._recover_transaction(image_root_descriptor)
+                        snapshot = self._load_from_directory(image_root_descriptor)
+                        updated = self._build_registration(snapshot, image, replace=replace)
+                        self._save(
+                            image_root_descriptor,
+                            snapshot,
+                            updated,
+                            verify_before_publish=lambda: verify_before_publish(image),
+                            verify_after_publish=(
+                                None if verify_after_publish is None else lambda: verify_after_publish(image)
+                            ),
+                        )
+                except _RegistryCommitUncertainError:
+                    raise
                 except BaseException:
                     if rollback_after_failure is not None:
                         rollback_after_failure(image)
@@ -286,8 +297,10 @@ class ImageRegistryStore:
             rollback_installed = False
             try:
                 os.fsync(image_root_descriptor)
-            except OSError:
-                return
+            except OSError as error:
+                raise _RegistryCommitUncertainError(
+                    f"cannot persist image registry {self._registry_path}; commit state requires recovery"
+                ) from error
             try:
                 os.unlink(_REGISTRY_COMMITTED_FILENAME, dir_fd=image_root_descriptor)
                 os.fsync(image_root_descriptor)
@@ -392,6 +405,23 @@ class ImageRegistryStore:
             raise ImageRegistryError(f"cannot access image registry beneath {self._image_root}") from error
 
     @staticmethod
+    def _build_registration(
+        snapshot: ImageRegistryDocument,
+        image: RegisteredImage,
+        *,
+        replace: bool,
+    ) -> ImageRegistryDocument:
+        existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
+        if existing is not None and not replace:
+            raise ImageConflictError(f"image alias {image.name!r} is already registered")
+        ImageRegistryStore._validate_path_facts(snapshot, image, replacing=existing)
+        images = tuple(entry for entry in snapshot.images if entry.name != image.name) + (image,)
+        return ImageRegistryDocument(
+            schema_version=1,
+            images=tuple(sorted(images, key=lambda entry: entry.name)),
+        )
+
+    @staticmethod
     def _validate_path_facts(
         snapshot: ImageRegistryDocument,
         image: RegisteredImage,
@@ -405,6 +435,10 @@ class ImageRegistryStore:
                 continue
             if existing.immutable_facts != image.immutable_facts:
                 raise ImageConflictError(f"image path {image.path!r} already has different immutable facts")
+
+
+class _RegistryCommitUncertainError(ImageRegistryError):
+    """Report a failed commit sync while preserving its recovery marker."""
 
 
 class _UniqueKeySafeLoader(yaml.SafeLoader):

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import stat
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -37,11 +39,17 @@ from data_designer.slurm.images.records import ImageRegistryDocument, Registered
 _LOCK_DIRECTORY_NAME = ".locks"
 _REGISTRY_FILENAME = "registry.yaml"
 _REGISTRY_LOCK_FILENAME = "registry.lock"
+_REGISTRY_ROLLBACK_FILENAME = ".registry.rollback.yaml"
+_REGISTRY_COMMITTED_FILENAME = ".registry.committed.yaml"
 _IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 
 
 class ImageRegistryStore:
-    """Persist image aliases beneath one explicitly selected shared workspace."""
+    """Persist image aliases beneath one explicitly selected shared workspace.
+
+    Writers acquire alias, target when present, then registry locks; readers
+    acquire only the registry lock. Keeping this order fixed prevents deadlocks.
+    """
 
     def __init__(self, workspace_root: str | Path) -> None:
         try:
@@ -91,11 +99,29 @@ class ImageRegistryStore:
         image: RegisteredImage,
         *,
         verify_before_publish: Callable[[RegisteredImage], None],
+        verify_after_publish: Callable[[RegisteredImage], None] | None = None,
+        rollback_after_failure: Callable[[RegisteredImage], None] | None = None,
         replace: bool = False,
     ) -> RegisteredImage:
-        """Atomically add or explicitly replace one verified image alias."""
+        """Atomically add or explicitly replace one verified image alias.
+
+        Args:
+            image: Immutable alias and artifact facts to persist.
+            verify_before_publish: Final verification or artifact-publication callback run under all writer locks.
+            verify_after_publish: Optional verification run after registry replacement but before commit.
+            rollback_after_failure: Optional no-fail cleanup run under all writer locks after registry rollback.
+            replace: Whether an existing alias may be replaced explicitly.
+
+        Returns:
+            The registered alias facts.
+
+        Raises:
+            ImageConflictError: If the alias or target facts conflict with existing state.
+            ImageRegistryError: If registry storage cannot be locked, read, recovered, or persisted.
+        """
         self._ensure_storage()
         alias_lock_name = f"alias-{image.name}.lock"
+        target_lock_name = _get_target_lock_name(image.path)
         with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
             with (
                 acquire_file_lock(
@@ -105,10 +131,16 @@ class ImageRegistryStore:
                 ),
                 acquire_file_lock(
                     lock_directory_descriptor,
+                    target_lock_name,
+                    self._lock_directory / target_lock_name,
+                ),
+                acquire_file_lock(
+                    lock_directory_descriptor,
                     _REGISTRY_LOCK_FILENAME,
                     self._lock_directory / _REGISTRY_LOCK_FILENAME,
                 ),
             ):
+                self._recover_transaction(image_root_descriptor)
                 snapshot = self._load_from_directory(image_root_descriptor)
                 existing = next((entry for entry in snapshot.images if entry.name == image.name), None)
                 if existing is not None and not replace:
@@ -119,11 +151,20 @@ class ImageRegistryStore:
                     schema_version=1,
                     images=tuple(sorted(images, key=lambda entry: entry.name)),
                 )
-                self._save(
-                    image_root_descriptor,
-                    updated,
-                    verify_before_publish=lambda: verify_before_publish(image),
-                )
+                try:
+                    self._save(
+                        image_root_descriptor,
+                        snapshot,
+                        updated,
+                        verify_before_publish=lambda: verify_before_publish(image),
+                        verify_after_publish=(
+                            None if verify_after_publish is None else lambda: verify_after_publish(image)
+                        ),
+                    )
+                except BaseException:
+                    if rollback_after_failure is not None:
+                        rollback_after_failure(image)
+                    raise
         return image
 
     def unregister(self, name: Identifier) -> RegisteredImage:
@@ -144,6 +185,7 @@ class ImageRegistryStore:
                     self._lock_directory / _REGISTRY_LOCK_FILENAME,
                 ),
             ):
+                self._recover_transaction(image_root_descriptor)
                 snapshot = self._load_from_directory(image_root_descriptor)
                 try:
                     removed = next(image for image in snapshot.images if image.name == name)
@@ -153,15 +195,29 @@ class ImageRegistryStore:
                     schema_version=1,
                     images=tuple(image for image in snapshot.images if image.name != name),
                 )
-                self._save(image_root_descriptor, updated)
+                self._save(image_root_descriptor, snapshot, updated)
         return removed
 
     def _load(self) -> ImageRegistryDocument:
         try:
-            with open_verified_directory(self._image_root) as image_root_descriptor:
-                return self._load_from_directory(image_root_descriptor)
+            self._image_root.lstat()
         except FileNotFoundError:
             return ImageRegistryDocument(schema_version=1)
+        except OSError as error:
+            raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
+        try:
+            self._ensure_storage()
+        except ImageRegistryError as error:
+            raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
+        try:
+            with self._open_storage() as (image_root_descriptor, lock_directory_descriptor):
+                with acquire_file_lock(
+                    lock_directory_descriptor,
+                    _REGISTRY_LOCK_FILENAME,
+                    self._lock_directory / _REGISTRY_LOCK_FILENAME,
+                ):
+                    self._recover_transaction(image_root_descriptor)
+                    return self._load_from_directory(image_root_descriptor)
         except OSError as error:
             raise ImageRegistryError(f"cannot load image registry {self._registry_path}") from error
 
@@ -180,16 +236,95 @@ class ImageRegistryStore:
     def _save(
         self,
         image_root_descriptor: int,
+        previous: ImageRegistryDocument,
         snapshot: ImageRegistryDocument,
         *,
         verify_before_publish: Callable[[], None] | None = None,
+        verify_after_publish: Callable[[], None] | None = None,
     ) -> None:
         temporary_name: str | None = None
+        rollback_temporary_name: str | None = None
+        rollback_installed = False
+        try:
+            rollback_temporary_name = self._write_temporary_snapshot(
+                image_root_descriptor,
+                previous,
+                prefix=".registry.rollback.",
+            )
+            os.replace(
+                rollback_temporary_name,
+                _REGISTRY_ROLLBACK_FILENAME,
+                src_dir_fd=image_root_descriptor,
+                dst_dir_fd=image_root_descriptor,
+            )
+            rollback_temporary_name = None
+            rollback_installed = True
+            os.fsync(image_root_descriptor)
+            temporary_name = self._write_temporary_snapshot(
+                image_root_descriptor,
+                snapshot,
+                prefix=".registry.",
+            )
+            if verify_before_publish is not None:
+                verify_before_publish()
+            os.replace(
+                temporary_name,
+                _REGISTRY_FILENAME,
+                src_dir_fd=image_root_descriptor,
+                dst_dir_fd=image_root_descriptor,
+            )
+            temporary_name = None
+            if verify_after_publish is not None:
+                verify_after_publish()
+            os.fsync(image_root_descriptor)
+            os.replace(
+                _REGISTRY_ROLLBACK_FILENAME,
+                _REGISTRY_COMMITTED_FILENAME,
+                src_dir_fd=image_root_descriptor,
+                dst_dir_fd=image_root_descriptor,
+            )
+            rollback_installed = False
+            try:
+                os.fsync(image_root_descriptor)
+            except OSError:
+                return
+            try:
+                os.unlink(_REGISTRY_COMMITTED_FILENAME, dir_fd=image_root_descriptor)
+                os.fsync(image_root_descriptor)
+            except OSError:
+                pass
+        except BaseException as error:
+            if rollback_installed:
+                try:
+                    self._recover_transaction(image_root_descriptor)
+                    rollback_installed = False
+                except ImageRegistryError:
+                    pass
+            if isinstance(error, (OSError, TypeError, yaml.YAMLError)):
+                raise ImageRegistryError(f"cannot persist image registry {self._registry_path}") from error
+            raise
+        finally:
+            for name in (temporary_name, rollback_temporary_name):
+                if name is None:
+                    continue
+                try:
+                    os.unlink(name, dir_fd=image_root_descriptor)
+                except OSError:
+                    pass
+
+    def _write_temporary_snapshot(
+        self,
+        image_root_descriptor: int,
+        snapshot: ImageRegistryDocument,
+        *,
+        prefix: str,
+    ) -> str:
         descriptor: int | None = None
+        temporary_name: str | None = None
         try:
             descriptor, temporary_name = create_temporary_file(
                 image_root_descriptor,
-                prefix=".registry.",
+                prefix=prefix,
                 suffix=".tmp",
             )
             output = os.fdopen(descriptor, "w", encoding="utf-8")
@@ -203,18 +338,8 @@ class ImageRegistryStore:
                 )
                 output.flush()
                 os.fsync(output.fileno())
-            if verify_before_publish is not None:
-                verify_before_publish()
-            os.replace(
-                temporary_name,
-                _REGISTRY_FILENAME,
-                src_dir_fd=image_root_descriptor,
-                dst_dir_fd=image_root_descriptor,
-            )
-            os.fsync(image_root_descriptor)
-        except (OSError, TypeError, yaml.YAMLError) as error:
-            raise ImageRegistryError(f"cannot persist image registry {self._registry_path}") from error
-        finally:
+            return temporary_name
+        except BaseException:
             if descriptor is not None:
                 os.close(descriptor)
             if temporary_name is not None:
@@ -222,6 +347,29 @@ class ImageRegistryStore:
                     os.unlink(temporary_name, dir_fd=image_root_descriptor)
                 except OSError:
                     pass
+            raise
+
+    def _recover_transaction(self, image_root_descriptor: int) -> None:
+        try:
+            rollback_exists = _has_regular_marker(image_root_descriptor, _REGISTRY_ROLLBACK_FILENAME)
+            committed_exists = _has_regular_marker(image_root_descriptor, _REGISTRY_COMMITTED_FILENAME)
+            if rollback_exists and committed_exists:
+                raise OSError("image registry contains conflicting transaction markers")
+            if committed_exists:
+                os.unlink(_REGISTRY_COMMITTED_FILENAME, dir_fd=image_root_descriptor)
+                os.fsync(image_root_descriptor)
+                return
+            if not rollback_exists:
+                return
+            os.replace(
+                _REGISTRY_ROLLBACK_FILENAME,
+                _REGISTRY_FILENAME,
+                src_dir_fd=image_root_descriptor,
+                dst_dir_fd=image_root_descriptor,
+            )
+            os.fsync(image_root_descriptor)
+        except OSError as error:
+            raise ImageRegistryError(f"cannot recover image registry {self._registry_path}") from error
 
     def _ensure_storage(self) -> None:
         try:
@@ -300,3 +448,18 @@ def _validate_image_alias(name: str) -> Identifier:
         return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
     except ValidationError as error:
         raise ImageRegistryError(f"invalid image alias {name!r}") from error
+
+
+def _get_target_lock_name(path: str) -> str:
+    digest = hashlib.sha256(path.encode("utf-8")).hexdigest()
+    return f"target-{digest}.lock"
+
+
+def _has_regular_marker(directory_descriptor: int, name: str) -> bool:
+    try:
+        marker_status = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISREG(marker_status.st_mode):
+        raise OSError(f"image registry transaction marker {name} is not a regular file")
+    return True

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -57,11 +57,11 @@ class VerifiedImageRegistry:
                 sqsh_sha256=inspection.sqsh_sha256,
                 inspection=inspection,
             )
-            verify = lambda _image: _verify_snapshot(image, snapshot)
+            verify_identity = lambda _image: _verify_snapshot_identity(image, snapshot)
             return self._registry.register(
                 image,
-                verify_before_publish=verify,
-                verify_after_publish=verify,
+                verify_before_publish=verify_identity,
+                verify_after_publish=verify_identity,
                 replace=replace,
             )
 
@@ -72,6 +72,7 @@ class VerifiedImageRegistry:
         candidate_path: Path,
         *,
         source_oci_digest: Sha256Digest,
+        candidate_directory_descriptor: int | None = None,
         replace: bool = False,
     ) -> RegisteredImage:
         """Publish one verified lifecycle-owned OCI import and register its alias.
@@ -85,6 +86,8 @@ class VerifiedImageRegistry:
             inspection: Package-owned facts bound to the imported SQSH digest.
             candidate_path: Lifecycle-owned SQSH candidate beneath workspace temporary storage.
             source_oci_digest: Resolved source digest carried by the lifecycle plan.
+            candidate_directory_descriptor: Optional verified lifecycle directory used to access the candidate
+                descriptor-relative.
             replace: Whether an existing alias may be replaced explicitly.
 
         Returns:
@@ -121,12 +124,18 @@ class VerifiedImageRegistry:
             inspection=inspection,
         )
         created_artifact_identity: tuple[int, int] | None = None
-        with _open_verified_sqsh(candidate_path) as candidate_snapshot, ExitStack() as final_stack:
+        with (
+            _open_verified_sqsh(
+                candidate_path,
+                directory_descriptor=candidate_directory_descriptor,
+            ) as candidate_snapshot,
+            ExitStack() as final_stack,
+        ):
             if candidate_snapshot.sha256 != inspection.sqsh_sha256:
                 raise ImageVerificationError("image inspection does not match the imported SQSH digest")
             final_snapshot: _VerifiedSqshSnapshot | None = None
 
-            def publish_before_registry(_image: RegisteredImage) -> None:
+            def prepare_before_registry(_image: RegisteredImage) -> None:
                 nonlocal created_artifact_identity, final_snapshot
                 _verify_snapshot(image, candidate_snapshot)
                 ensure_private_directory(artifact_directory, parents=False)
@@ -134,6 +143,7 @@ class VerifiedImageRegistry:
                     candidate_path,
                     artifact_path,
                     expected_identity=candidate_snapshot.facts[:2],
+                    candidate_directory_descriptor=candidate_directory_descriptor,
                 )
                 try:
                     final_snapshot = final_stack.enter_context(_open_verified_sqsh(artifact_path))
@@ -150,10 +160,15 @@ class VerifiedImageRegistry:
                 _sync_snapshot(final_snapshot)
                 _verify_snapshot(image, final_snapshot)
 
+            def verify_before_registry(_image: RegisteredImage) -> None:
+                if final_snapshot is None:
+                    raise ImageVerificationError("published SQSH artifact was not opened for verification")
+                _verify_snapshot_identity(image, final_snapshot)
+
             def verify_after_registry(_image: RegisteredImage) -> None:
                 if final_snapshot is None:
                     raise ImageVerificationError("published SQSH artifact was not opened for verification")
-                _verify_snapshot(image, final_snapshot)
+                _verify_snapshot_identity(image, final_snapshot)
 
             def rollback_after_failure(_image: RegisteredImage) -> None:
                 if created_artifact_identity is not None:
@@ -161,7 +176,8 @@ class VerifiedImageRegistry:
 
             return self._registry.register(
                 image,
-                verify_before_publish=publish_before_registry,
+                prepare_before_publish=prepare_before_registry,
+                verify_before_publish=verify_before_registry,
                 verify_after_publish=verify_after_registry,
                 rollback_after_failure=rollback_after_failure,
                 replace=replace,
@@ -229,43 +245,81 @@ class _VerifiedSqshSnapshot:
     descriptor: int
     facts: tuple[int, int, int, int]
     sha256: Sha256Digest
+    directory_descriptor: int | None = None
 
     def verify_unchanged(self) -> None:
         """Verify that the open bytes and their public path still match the snapshot."""
         descriptor_status = os.fstat(self.descriptor)
-        path_status = self.path.lstat()
+        if not stat.S_ISREG(descriptor_status.st_mode) or _get_file_facts(descriptor_status) != self.facts:
+            raise ImageVerificationError(f"image path {self.path} changed while it was being verified")
+        actual_sha256 = _hash_descriptor(self.descriptor)
+        descriptor_status = os.fstat(self.descriptor)
+        path_status = self._stat_path()
         if (
             not stat.S_ISREG(descriptor_status.st_mode)
             or not stat.S_ISREG(path_status.st_mode)
             or _get_file_facts(descriptor_status) != self.facts
             or _get_file_facts(path_status) != self.facts
-            or _hash_descriptor(self.descriptor) != self.sha256
+            or actual_sha256 != self.sha256
         ):
             raise ImageVerificationError(f"image path {self.path} changed while it was being verified")
 
+    def verify_identity_unchanged(self) -> None:
+        """Verify descriptor and path identity without rereading the SQSH bytes."""
+        descriptor_status = os.fstat(self.descriptor)
+        path_status = self._stat_path()
+        if (
+            not stat.S_ISREG(descriptor_status.st_mode)
+            or not stat.S_ISREG(path_status.st_mode)
+            or _get_file_facts(descriptor_status) != self.facts
+            or _get_file_facts(path_status) != self.facts
+        ):
+            raise ImageVerificationError(f"image path {self.path} changed while it was being verified")
+
+    def _stat_path(self) -> os.stat_result:
+        if self.directory_descriptor is None:
+            return self.path.lstat()
+        return os.stat(
+            self.path.name,
+            dir_fd=self.directory_descriptor,
+            follow_symlinks=False,
+        )
+
 
 @contextmanager
-def _open_verified_sqsh(path: Path) -> Iterator[_VerifiedSqshSnapshot]:
+def _open_verified_sqsh(
+    path: Path,
+    *,
+    directory_descriptor: int | None = None,
+) -> Iterator[_VerifiedSqshSnapshot]:
     descriptor: int | None = None
     try:
-        before_open = path.lstat()
+        before_open = (
+            path.lstat()
+            if directory_descriptor is None
+            else os.stat(path.name, dir_fd=directory_descriptor, follow_symlinks=False)
+        )
         if not stat.S_ISREG(before_open.st_mode):
             raise ImageVerificationError(f"image path {path} must be a regular non-symlink file")
+        open_path = path if directory_descriptor is None else Path(path.name)
         descriptor = os.open(
-            path,
+            open_path,
             os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=directory_descriptor,
         )
         after_open = os.fstat(descriptor)
         if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
             raise ImageVerificationError(f"image path {path} changed while it was being opened")
         facts = _get_file_facts(after_open)
+        sha256 = _hash_descriptor(descriptor)
         snapshot = _VerifiedSqshSnapshot(
             path=path,
             descriptor=descriptor,
             facts=facts,
-            sha256=_hash_descriptor(descriptor),
+            sha256=sha256,
+            directory_descriptor=directory_descriptor,
         )
-        snapshot.verify_unchanged()
+        snapshot.verify_identity_unchanged()
         yield snapshot
     except FileNotFoundError as error:
         raise ImageVerificationError(f"image path {path} does not exist") from error
@@ -302,17 +356,27 @@ def _verify_snapshot(image: RegisteredImage, snapshot: _VerifiedSqshSnapshot) ->
         raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")
 
 
+def _verify_snapshot_identity(image: RegisteredImage, snapshot: _VerifiedSqshSnapshot) -> None:
+    try:
+        snapshot.verify_identity_unchanged()
+    except ImageVerificationError as error:
+        raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest") from error
+    if snapshot.sha256 != image.sqsh_sha256:
+        raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")
+
+
 def _publish_candidate(
     candidate_path: Path,
     artifact_path: Path,
     *,
     expected_identity: tuple[int, int],
+    candidate_directory_descriptor: int | None = None,
 ) -> tuple[int, int] | None:
     try:
-        with (
-            open_verified_directory(candidate_path.parent) as candidate_directory_descriptor,
-            open_verified_directory(artifact_path.parent) as artifact_directory_descriptor,
-        ):
+        with ExitStack() as stack:
+            if candidate_directory_descriptor is None:
+                candidate_directory_descriptor = stack.enter_context(open_verified_directory(candidate_path.parent))
+            artifact_directory_descriptor = stack.enter_context(open_verified_directory(artifact_path.parent))
             candidate_status = os.stat(
                 candidate_path.name,
                 dir_fd=candidate_directory_descriptor,

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -8,17 +8,23 @@ from __future__ import annotations
 import hashlib
 import os
 import stat
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, ImageKind, ImageRef
 from data_designer.slurm.contracts import Sha256Digest
-from data_designer.slurm.images.errors import ImageVerificationError
+from data_designer.slurm.images.errors import ImageConflictError, ImageVerificationError
+from data_designer.slurm.images.filesystem import ensure_private_directory, open_verified_directory
 from data_designer.slurm.images.inspection import INSPECTOR_VERSION
 from data_designer.slurm.images.records import RegisteredImage
 from data_designer.slurm.images.registry import ImageRegistryStore
 from data_designer.slurm.planning import ResolvedImage
 
 _HASH_BLOCK_SIZE = 1024 * 1024
+_ARTIFACT_DIRECTORY_NAME = "artifacts"
+_TEMPORARY_DIRECTORY_NAME = ".tmp"
 
 
 class VerifiedImageRegistry:
@@ -38,15 +44,128 @@ class VerifiedImageRegistry:
         if not request.source.endswith(".sqsh"):
             raise ImageVerificationError("OCI image sources require the CPU Slurm image lifecycle")
         path = Path(request.source)
+        with _open_verified_sqsh(path) as snapshot:
+            _validate_inspection(
+                inspection,
+                expected_kind=ImageKind(request.kind),
+                expected_sha256=snapshot.sha256,
+            )
+            image = RegisteredImage(
+                schema_version=1,
+                name=request.name,
+                path=path.as_posix(),
+                sqsh_sha256=inspection.sqsh_sha256,
+                inspection=inspection,
+            )
+            verify = lambda _image: _verify_snapshot(image, snapshot)
+            return self._registry.register(
+                image,
+                verify_before_publish=verify,
+                verify_after_publish=verify,
+                replace=replace,
+            )
+
+    def publish_imported(
+        self,
+        request: ImageBuildRequest,
+        inspection: ImageInspectionRecord,
+        candidate_path: Path,
+        *,
+        source_oci_digest: Sha256Digest,
+        replace: bool = False,
+    ) -> RegisteredImage:
+        """Publish one verified lifecycle-owned OCI import and register its alias.
+
+        The candidate must live in this workspace's lifecycle temporary tree.
+        Publication keeps a prior alias or artifact intact unless replacement is
+        explicit and the new artifact is fully verified.
+
+        Args:
+            request: Authored digest-pinned OCI image request.
+            inspection: Package-owned facts bound to the imported SQSH digest.
+            candidate_path: Lifecycle-owned SQSH candidate beneath workspace temporary storage.
+            source_oci_digest: Resolved source digest carried by the lifecycle plan.
+            replace: Whether an existing alias may be replaced explicitly.
+
+        Returns:
+            The durable alias binding for the published artifact.
+
+        Raises:
+            ImageConflictError: If an alias or artifact collision is not identical.
+            ImageVerificationError: If source, candidate, inspection, or publication verification fails.
+            ImageRegistryError: If registry publication or recovery fails.
+        """
+        if request.source.endswith(".sqsh"):
+            raise ImageVerificationError("existing SQSH sources must be registered in place")
+        expected_source_digest = request.source.rpartition("@sha256:")[2]
+        if source_oci_digest != expected_source_digest:
+            raise ImageVerificationError("OCI source digest does not match the authored source")
+        temporary_root = self._registry.image_root / _TEMPORARY_DIRECTORY_NAME
+        if not candidate_path.is_absolute() or ".." in candidate_path.parts:
+            raise ImageVerificationError("imported SQSH candidate must belong to lifecycle temporary storage")
+        try:
+            candidate_path.relative_to(temporary_root)
+        except ValueError as error:
+            raise ImageVerificationError(
+                "imported SQSH candidate must belong to lifecycle temporary storage"
+            ) from error
         _validate_inspection(inspection, expected_kind=ImageKind(request.kind))
+        artifact_directory = self._registry.image_root / _ARTIFACT_DIRECTORY_NAME
+        artifact_path = artifact_directory / f"{request.name}-{inspection.sqsh_sha256}.sqsh"
         image = RegisteredImage(
             schema_version=1,
             name=request.name,
-            path=path.as_posix(),
+            path=artifact_path.as_posix(),
             sqsh_sha256=inspection.sqsh_sha256,
+            source_oci_digest=source_oci_digest,
             inspection=inspection,
         )
-        return self._registry.register(image, verify_before_publish=_verify_registered_image, replace=replace)
+        created_artifact_identity: tuple[int, int] | None = None
+        with _open_verified_sqsh(candidate_path) as candidate_snapshot, ExitStack() as final_stack:
+            if candidate_snapshot.sha256 != inspection.sqsh_sha256:
+                raise ImageVerificationError("image inspection does not match the imported SQSH digest")
+            final_snapshot: _VerifiedSqshSnapshot | None = None
+
+            def publish_before_registry(_image: RegisteredImage) -> None:
+                nonlocal created_artifact_identity, final_snapshot
+                _verify_snapshot(image, candidate_snapshot)
+                ensure_private_directory(artifact_directory, parents=False)
+                created_artifact_identity = _publish_candidate(
+                    candidate_path,
+                    artifact_path,
+                    expected_identity=candidate_snapshot.facts[:2],
+                )
+                try:
+                    final_snapshot = final_stack.enter_context(_open_verified_sqsh(artifact_path))
+                except ImageVerificationError as error:
+                    if created_artifact_identity is None:
+                        raise ImageConflictError(
+                            f"image artifact path {artifact_path!s} cannot be reused as a verified SQSH artifact"
+                        ) from error
+                    raise
+                if final_snapshot.sha256 != inspection.sqsh_sha256:
+                    if created_artifact_identity is not None:
+                        raise ImageVerificationError("published SQSH artifact does not match its inspection digest")
+                    raise ImageConflictError(f"image artifact path {artifact_path!s} contains conflicting bytes")
+                _sync_snapshot(final_snapshot)
+                _verify_snapshot(image, final_snapshot)
+
+            def verify_after_registry(_image: RegisteredImage) -> None:
+                if final_snapshot is None:
+                    raise ImageVerificationError("published SQSH artifact was not opened for verification")
+                _verify_snapshot(image, final_snapshot)
+
+            def rollback_after_failure(_image: RegisteredImage) -> None:
+                if created_artifact_identity is not None:
+                    _remove_artifact(artifact_path, expected_identity=created_artifact_identity)
+
+            return self._registry.register(
+                image,
+                verify_before_publish=publish_before_registry,
+                verify_after_publish=verify_after_registry,
+                rollback_after_failure=rollback_after_failure,
+                replace=replace,
+            )
 
     def list_images(self) -> tuple[RegisteredImage, ...]:
         """Return all registered aliases in deterministic order."""
@@ -79,56 +198,8 @@ class VerifiedImageRegistry:
 
 def compute_sqsh_file_sha256(path: Path) -> Sha256Digest:
     """Compute the SHA-256 of one regular, non-symlink SQSH file."""
-    descriptor: int | None = None
-    try:
-        before_open = path.lstat()
-        if not stat.S_ISREG(before_open.st_mode):
-            raise ImageVerificationError(f"image path {path} must be a regular non-symlink file")
-        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-        image_file = os.fdopen(descriptor, "rb")
-        descriptor = None
-        digest = hashlib.sha256()
-        with image_file:
-            before_read = os.fstat(image_file.fileno())
-            if (before_open.st_dev, before_open.st_ino) != (before_read.st_dev, before_read.st_ino):
-                raise ImageVerificationError(f"image path {path} changed while it was being opened")
-            while block := image_file.read(_HASH_BLOCK_SIZE):
-                digest.update(block)
-            after_read = os.fstat(image_file.fileno())
-            after_path = path.lstat()
-        before_facts = (
-            before_read.st_dev,
-            before_read.st_ino,
-            before_read.st_size,
-            before_read.st_mtime_ns,
-            before_read.st_ctime_ns,
-        )
-        after_facts = (
-            after_read.st_dev,
-            after_read.st_ino,
-            after_read.st_size,
-            after_read.st_mtime_ns,
-            after_read.st_ctime_ns,
-        )
-        if before_facts != after_facts:
-            raise ImageVerificationError(f"image path {path} changed while it was being verified")
-        path_facts = (
-            after_path.st_dev,
-            after_path.st_ino,
-            after_path.st_size,
-            after_path.st_mtime_ns,
-            after_path.st_ctime_ns,
-        )
-        if not stat.S_ISREG(after_path.st_mode) or path_facts != after_facts:
-            raise ImageVerificationError(f"image path {path} changed while it was being verified")
-        return digest.hexdigest()
-    except FileNotFoundError as error:
-        raise ImageVerificationError(f"image path {path} does not exist") from error
-    except OSError as error:
-        raise ImageVerificationError(f"cannot read image path {path}") from error
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
+    with _open_verified_sqsh(path) as snapshot:
+        return snapshot.sha256
 
 
 def _validate_inspection(
@@ -148,6 +219,199 @@ def _validate_inspection(
 
 
 def _verify_registered_image(image: RegisteredImage) -> None:
-    actual_sha256 = compute_sqsh_file_sha256(Path(image.path))
-    if actual_sha256 != image.sqsh_sha256:
+    with _open_verified_sqsh(Path(image.path)) as snapshot:
+        _verify_snapshot(image, snapshot)
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedSqshSnapshot:
+    path: Path
+    descriptor: int
+    facts: tuple[int, int, int, int]
+    sha256: Sha256Digest
+
+    def verify_unchanged(self) -> None:
+        """Verify that the open bytes and their public path still match the snapshot."""
+        descriptor_status = os.fstat(self.descriptor)
+        path_status = self.path.lstat()
+        if (
+            not stat.S_ISREG(descriptor_status.st_mode)
+            or not stat.S_ISREG(path_status.st_mode)
+            or _get_file_facts(descriptor_status) != self.facts
+            or _get_file_facts(path_status) != self.facts
+            or _hash_descriptor(self.descriptor) != self.sha256
+        ):
+            raise ImageVerificationError(f"image path {self.path} changed while it was being verified")
+
+
+@contextmanager
+def _open_verified_sqsh(path: Path) -> Iterator[_VerifiedSqshSnapshot]:
+    descriptor: int | None = None
+    try:
+        before_open = path.lstat()
+        if not stat.S_ISREG(before_open.st_mode):
+            raise ImageVerificationError(f"image path {path} must be a regular non-symlink file")
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+        )
+        after_open = os.fstat(descriptor)
+        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+            raise ImageVerificationError(f"image path {path} changed while it was being opened")
+        facts = _get_file_facts(after_open)
+        snapshot = _VerifiedSqshSnapshot(
+            path=path,
+            descriptor=descriptor,
+            facts=facts,
+            sha256=_hash_descriptor(descriptor),
+        )
+        snapshot.verify_unchanged()
+        yield snapshot
+    except FileNotFoundError as error:
+        raise ImageVerificationError(f"image path {path} does not exist") from error
+    except ImageVerificationError:
+        raise
+    except OSError as error:
+        raise ImageVerificationError(f"cannot read image path {path}") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _hash_descriptor(descriptor: int) -> Sha256Digest:
+    digest = hashlib.sha256()
+    offset = 0
+    while block := os.pread(descriptor, _HASH_BLOCK_SIZE, offset):
+        digest.update(block)
+        offset += len(block)
+    return digest.hexdigest()
+
+
+def _get_file_facts(status: os.stat_result) -> tuple[int, int, int, int]:
+    # Publishing through a hard link changes ctime without changing the verified
+    # inode or its bytes, so ctime cannot be part of the stable identity tuple.
+    return (status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns)
+
+
+def _verify_snapshot(image: RegisteredImage, snapshot: _VerifiedSqshSnapshot) -> None:
+    try:
+        snapshot.verify_unchanged()
+    except ImageVerificationError as error:
+        raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest") from error
+    if snapshot.sha256 != image.sqsh_sha256:
         raise ImageVerificationError(f"registered image {image.name!r} no longer matches its SQSH digest")
+
+
+def _publish_candidate(
+    candidate_path: Path,
+    artifact_path: Path,
+    *,
+    expected_identity: tuple[int, int],
+) -> tuple[int, int] | None:
+    try:
+        with (
+            open_verified_directory(candidate_path.parent) as candidate_directory_descriptor,
+            open_verified_directory(artifact_path.parent) as artifact_directory_descriptor,
+        ):
+            candidate_status = os.stat(
+                candidate_path.name,
+                dir_fd=candidate_directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(candidate_status.st_mode)
+                or (
+                    candidate_status.st_dev,
+                    candidate_status.st_ino,
+                )
+                != expected_identity
+            ):
+                raise OSError(f"imported SQSH candidate {candidate_path!s} changed before publication")
+            try:
+                os.link(
+                    candidate_path.name,
+                    artifact_path.name,
+                    src_dir_fd=candidate_directory_descriptor,
+                    dst_dir_fd=artifact_directory_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileExistsError:
+                return None
+            try:
+                published_status = os.stat(
+                    artifact_path.name,
+                    dir_fd=artifact_directory_descriptor,
+                    follow_symlinks=False,
+                )
+                published_identity = (published_status.st_dev, published_status.st_ino)
+                if published_identity != expected_identity:
+                    raise OSError(f"published SQSH artifact {artifact_path!s} has an unexpected identity")
+                os.fsync(artifact_directory_descriptor)
+                candidate_status = os.stat(
+                    candidate_path.name,
+                    dir_fd=candidate_directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (candidate_status.st_dev, candidate_status.st_ino) != published_identity:
+                    raise OSError(f"imported SQSH candidate {candidate_path!s} changed during publication")
+                os.unlink(candidate_path.name, dir_fd=candidate_directory_descriptor)
+                os.fsync(candidate_directory_descriptor)
+            except OSError:
+                _remove_created_artifact_from_directory(
+                    artifact_directory_descriptor,
+                    artifact_path.name,
+                )
+                raise
+            return published_identity
+    except OSError as error:
+        raise ImageVerificationError(f"cannot publish image artifact {artifact_path!s}") from error
+
+
+def _sync_snapshot(snapshot: _VerifiedSqshSnapshot) -> None:
+    try:
+        os.fsync(snapshot.descriptor)
+    except OSError as error:
+        raise ImageVerificationError(f"cannot synchronize image artifact {snapshot.path!s}") from error
+
+
+def _remove_artifact(artifact_path: Path, *, expected_identity: tuple[int, int]) -> None:
+    try:
+        with open_verified_directory(artifact_path.parent) as artifact_directory_descriptor:
+            _remove_artifact_from_directory(
+                artifact_directory_descriptor,
+                artifact_path.name,
+                expected_identity=expected_identity,
+            )
+    except OSError:
+        pass
+
+
+def _remove_artifact_from_directory(
+    artifact_directory_descriptor: int,
+    artifact_name: str,
+    *,
+    expected_identity: tuple[int, int],
+) -> None:
+    try:
+        artifact_status = os.stat(
+            artifact_name,
+            dir_fd=artifact_directory_descriptor,
+            follow_symlinks=False,
+        )
+        if (artifact_status.st_dev, artifact_status.st_ino) != expected_identity:
+            return
+        os.unlink(artifact_name, dir_fd=artifact_directory_descriptor)
+        os.fsync(artifact_directory_descriptor)
+    except OSError:
+        pass
+
+
+def _remove_created_artifact_from_directory(
+    artifact_directory_descriptor: int,
+    artifact_name: str,
+) -> None:
+    try:
+        os.unlink(artifact_name, dir_fd=artifact_directory_descriptor)
+        os.fsync(artifact_directory_descriptor)
+    except OSError:
+        pass

--- a/packages/data-designer-slurm/src/data_designer/slurm/serving/resolver.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/serving/resolver.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 
 from data_designer.slurm.config.images import ServingImageInspection
@@ -25,6 +27,11 @@ from data_designer.slurm.serving.vllm import (
 )
 from data_designer.slurm.types import Identifier
 
+_SUPPORTED_VLLM_RUNTIME_RELEASES = (
+    SpecifierSet("~=0.21.0"),
+    SpecifierSet("~=0.22.0"),
+)
+
 
 class VllmServerResolutionError(ValueError):
     """Raised when planner inputs cannot produce a supported vLLM server specification."""
@@ -34,12 +41,7 @@ def resolve_vllm_server(
     plan: ResolvedSlurmRunPlan,
     deployment_id: Identifier,
 ) -> ResolvedVllmServerDeployment:
-    """Resolve one vLLM deployment and endpoint derived from the same run plan.
-
-    Inspected runtime versions remain provenance. This resolver emits only the
-    baseline behavior required of every admitted vLLM image and therefore does not
-    maintain a package-version compatibility matrix.
-    """
+    """Resolve one vLLM deployment admitted by the tested runtime matrix."""
     try:
         return _resolve_vllm_server(plan, deployment_id)
     except ValidationError as error:
@@ -72,6 +74,7 @@ def _resolve_vllm_server(
     inspection = resolved_deployment.image.inspection_facts
     if not isinstance(inspection, ServingImageInspection) or inspection.server_type != server.type:
         raise VllmServerResolutionError("resolved serving image does not match the declared vLLM server")
+    _validate_vllm_runtime_version(inspection.runtime_version)
     if server.enable_expert_parallel and resolved_deployment.topology.pipeline_parallel > 1:
         raise VllmServerResolutionError("multi-node expert parallel is not supported in v1")
 
@@ -208,3 +211,14 @@ def _calculate_launch_delay_seconds(server: VllmServerConfig, deployment_replica
     return convert_duration_to_seconds(
         server.lead_boot_standoff
     ) + deployment_replica_index * convert_duration_to_seconds(server.rank_launch_stagger)
+
+
+def _validate_vllm_runtime_version(runtime_version: str) -> None:
+    try:
+        version = Version(runtime_version)
+    except InvalidVersion as error:
+        raise VllmServerResolutionError(f"unsupported vLLM runtime version {runtime_version!r}") from error
+    if not any(version in supported_release for supported_release in _SUPPORTED_VLLM_RUNTIME_RELEASES):
+        raise VllmServerResolutionError(
+            f"unsupported vLLM runtime version {runtime_version!r}; supported release lines are 0.21.x and 0.22.x"
+        )

--- a/packages/data-designer-slurm/tests/images/test_lifecycle.py
+++ b/packages/data-designer-slurm/tests/images/test_lifecycle.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import stat
 import subprocess
 from collections.abc import Sequence
@@ -20,6 +21,7 @@ import pytest
 from pydantic import ValidationError
 from slurm_test_fakes import FakeSlurmJob, FakeSlurmRunner
 
+import data_designer.slurm.images.lifecycle as image_lifecycle
 from data_designer.slurm.config import (
     ClientImageInspection,
     ImageBuildProfile,
@@ -509,6 +511,24 @@ def test_submit_rejects_modified_prepared_files(tmp_path: Path, artifact_name: s
         submit_prepared_image_lifecycle(prepared, SlurmCommandClient(FakeSlurmRunner()))
 
 
+def test_submit_rejects_recreated_prepared_job_directory(tmp_path: Path) -> None:
+    prepared = prepare_image_lifecycle_job(
+        ImageBuildRequest(name="client", kind="client", source=(tmp_path / "client.sqsh").as_posix()),
+        _get_selected_profile(tmp_path / "workspace"),
+        lifecycle_id="image-job-recreated-before-submit",
+    )
+    job_directory = Path(prepared.plan.job_directory)
+    detached_job_directory = job_directory.with_name("detached-before-submit")
+    job_directory.rename(detached_job_directory)
+    shutil.copytree(detached_job_directory, job_directory)
+    runner = FakeSlurmRunner()
+
+    with pytest.raises(ImageLifecycleError, match="directory no longer matches its identity"):
+        submit_prepared_image_lifecycle(prepared, SlurmCommandClient(runner))
+
+    assert runner.calls == []
+
+
 def test_submit_rejects_modified_script_even_when_artifact_digest_is_rebound(tmp_path: Path) -> None:
     prepared = prepare_image_lifecycle_job(
         ImageBuildRequest(name="client", kind="client", source=(tmp_path / "client.sqsh").as_posix()),
@@ -586,6 +606,79 @@ def test_publish_completed_lifecycle_registers_digest_bound_image_in_fresh_proce
     )
     assert resolved.path == expected_path.as_posix()
     assert resolved.sha256 == hashlib.sha256(content).hexdigest()
+
+
+def test_publish_rejects_recreated_job_directory_with_substituted_result(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="recreated-before-publication",
+        content=b"original",
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"original"))
+    job_directory = Path(prepared.plan.job_directory)
+    detached_job_directory = job_directory.with_name("detached-before-publication")
+    job_directory.rename(detached_job_directory)
+    shutil.copytree(detached_job_directory, job_directory)
+    Path(prepared.plan.sqsh_path).write_bytes(b"substituted")
+    _write_completed_inspection(prepared, _get_client_inspection(b"substituted"))
+
+    with pytest.raises(ImageLifecycleError, match="directory no longer matches its identity"):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert Path(prepared.plan.sqsh_path).read_bytes() == b"substituted"
+    assert detached_job_directory.is_dir()
+
+
+def test_publish_reads_original_job_descriptor_after_directory_replacement(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="replaced-during-publication",
+        content=b"original",
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"original"))
+    job_directory = Path(prepared.plan.job_directory)
+    detached_job_directory = job_directory.with_name("detached-during-publication")
+    original_read_regular_file = image_lifecycle._read_regular_file
+    replaced = False
+
+    def replace_job_directory_before_read(
+        directory_descriptor: int,
+        name: str,
+        display_path: Path,
+        *,
+        maximum_size: int | None = None,
+    ) -> bytes:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            job_directory.rename(detached_job_directory)
+            shutil.copytree(detached_job_directory, job_directory)
+            Path(prepared.plan.sqsh_path).write_bytes(b"substituted")
+            _write_completed_inspection(prepared, _get_client_inspection(b"substituted"))
+        return original_read_regular_file(
+            directory_descriptor,
+            name,
+            display_path,
+            maximum_size=maximum_size,
+        )
+
+    with (
+        patch(
+            "data_designer.slurm.images.lifecycle._read_regular_file",
+            side_effect=replace_job_directory_before_read,
+        ),
+        pytest.raises(ImageLifecycleError, match="cannot clean image lifecycle job"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    registered = VerifiedImageRegistry(workspace).list_images()
+    assert len(registered) == 1
+    assert Path(registered[0].path).read_bytes() == b"original"
+    assert Path(prepared.plan.sqsh_path).read_bytes() == b"substituted"
+    assert detached_job_directory.is_dir()
 
 
 @pytest.mark.parametrize(
@@ -1110,6 +1203,49 @@ def test_registry_directory_sync_failure_restores_prior_alias_and_artifact(tmp_p
     assert Path(original.path).read_bytes() == b"first"
     assert tuple((workspace / "images" / "artifacts").glob("*.sqsh")) == (Path(original.path),)
     assert not Path(second.plan.job_directory).exists()
+
+
+def test_committed_marker_sync_failure_preserves_artifact_for_recovery(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="committed-marker-sync-failure",
+        content=b"candidate",
+    )
+    inspection = _get_client_inspection(b"candidate")
+    _write_completed_inspection(prepared, inspection)
+    artifact_path = workspace / "images" / "artifacts" / f"client-{inspection.sqsh_sha256}.sqsh"
+    image_root = workspace / "images"
+    image_root_sync_count = 0
+    original_fsync = os.fsync
+
+    def fail_committed_marker_sync(descriptor: int) -> None:
+        nonlocal image_root_sync_count
+        descriptor_status = os.fstat(descriptor)
+        image_root_status = image_root.stat()
+        if (descriptor_status.st_dev, descriptor_status.st_ino) == (
+            image_root_status.st_dev,
+            image_root_status.st_ino,
+        ):
+            image_root_sync_count += 1
+            if image_root_sync_count == 3:
+                raise OSError("injected committed marker sync failure")
+        original_fsync(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.registry.os.fsync", side_effect=fail_committed_marker_sync),
+        pytest.raises(ImageRegistryError, match="commit state requires recovery"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    committed_marker = image_root / ".registry.committed.yaml"
+    assert committed_marker.is_file()
+    assert artifact_path.read_bytes() == b"candidate"
+    registered = VerifiedImageRegistry(workspace).list_images()
+    assert len(registered) == 1
+    assert registered[0].path == artifact_path.as_posix()
+    assert not committed_marker.exists()
+    assert not Path(prepared.plan.job_directory).exists()
 
 
 def test_existing_sqsh_replacement_after_registry_rename_rolls_back_alias(tmp_path: Path) -> None:

--- a/packages/data-designer-slurm/tests/images/test_lifecycle.py
+++ b/packages/data-designer-slurm/tests/images/test_lifecycle.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import stat
 import subprocess
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
+from threading import Barrier
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -18,23 +21,37 @@ from pydantic import ValidationError
 from slurm_test_fakes import FakeSlurmJob, FakeSlurmRunner
 
 from data_designer.slurm.config import (
+    ClientImageInspection,
     ImageBuildProfile,
     ImageBuildRequest,
     ImageInspectionRecord,
+    ImageKind,
+    ImageRef,
+    InstalledDistribution,
     SchedulerProfile,
     SelectedSlurmProfile,
+    ServingImageInspection,
     SlurmProfile,
     injected_profile,
 )
 from data_designer.slurm.contracts import ArtifactReference
-from data_designer.slurm.images.errors import ImageLifecycleError
+from data_designer.slurm.images.errors import (
+    ImageConflictError,
+    ImageLifecycleError,
+    ImageRegistryError,
+    ImageVerificationError,
+)
 from data_designer.slurm.images.lifecycle import (
+    PreparedImageLifecycleJob,
+    cleanup_prepared_image_lifecycle,
     prepare_image_lifecycle_job,
+    publish_completed_image_lifecycle,
     render_image_lifecycle_script,
     submit_prepared_image_lifecycle,
 )
 from data_designer.slurm.images.records import ImageLifecycleOperation, ImageLifecyclePlan
 from data_designer.slurm.images.resources import inspect_image as resource_inspector
+from data_designer.slurm.images.service import VerifiedImageRegistry
 from data_designer.slurm.launcher.client import SlurmCommandClient
 
 
@@ -90,6 +107,7 @@ def test_prepare_existing_sqsh_inspects_in_place_without_oci_identity(tmp_path: 
     assert "enroot start --root" in script
     assert "inspect_image.py:x-create=file,bind,ro" in script
     assert "/output:x-create=dir,bind" in script
+    assert f'DD_INSPECTION_SQSH="{prepared.plan.job_directory}/verified.sqsh"' in script
 
 
 def test_image_lifecycle_renderer_uses_explicit_cpu_profile_and_safe_mounts(tmp_path: Path) -> None:
@@ -320,12 +338,18 @@ def test_prepare_refuses_duplicate_and_invalid_lifecycle_ids(tmp_path: Path) -> 
     workspace = tmp_path / "workspace"
     profile = _get_selected_profile(workspace)
     request = ImageBuildRequest(name="client", kind="client", source=(tmp_path / "client.sqsh").as_posix())
-    prepare_image_lifecycle_job(request, profile, lifecycle_id="image-job-0004")
+    original = prepare_image_lifecycle_job(request, profile, lifecycle_id="image-job-0004")
+    original_job_directory = Path(original.plan.job_directory)
+    sentinel = original_job_directory / "keep-existing-job"
+    sentinel.write_text("active")
 
     with pytest.raises(ImageLifecycleError, match="cannot prepare"):
         prepare_image_lifecycle_job(request, profile, lifecycle_id="image-job-0004")
     with pytest.raises(ImageLifecycleError, match="ID is invalid"):
         prepare_image_lifecycle_job(request, profile, lifecycle_id="../escape")  # type: ignore[arg-type]
+    assert sentinel.read_text() == "active"
+    assert Path(original.plan_file.path).is_file()
+    assert Path(original.script_file.path).is_file()
     assert not (workspace / "images" / ".tmp" / "escape").exists()
 
 
@@ -524,6 +548,742 @@ def test_submit_uses_verified_script_bytes_when_path_changes_during_submission(t
     assert Path(prepared.script_file.path).read_text() == "replaced after verification\n"
 
 
+@pytest.mark.parametrize("source_kind", ("oci", "existing"), ids=("oci-import", "existing-sqsh"))
+def test_publish_completed_lifecycle_registers_digest_bound_image_in_fresh_process(
+    tmp_path: Path,
+    source_kind: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    content = f"{source_kind} image".encode()
+    if source_kind == "oci":
+        source_digest = "a" * 64
+        source = f"registry.example.test/client@sha256:{source_digest}"
+    else:
+        source_digest = None
+        source = (tmp_path / "external" / "client.sqsh").as_posix()
+    prepared = prepare_image_lifecycle_job(
+        ImageBuildRequest(name="client", kind="client", source=source),
+        _get_selected_profile(workspace),
+        lifecycle_id=f"publish-{source_kind}",
+    )
+    source_path = Path(prepared.plan.sqsh_path)
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(content)
+    _write_completed_inspection(prepared, _get_client_inspection(content))
+
+    registered = publish_completed_image_lifecycle(prepared)
+
+    expected_path = source_path
+    if source_kind == "oci":
+        expected_path = workspace / "images" / "artifacts" / f"client-{hashlib.sha256(content).hexdigest()}.sqsh"
+    assert registered.path == expected_path.as_posix()
+    assert registered.source_oci_digest == source_digest
+    assert expected_path.read_bytes() == content
+    assert not Path(prepared.plan.job_directory).exists()
+    resolved = VerifiedImageRegistry(workspace).resolve_for_planning(
+        ImageRef(name="client"),
+        expected_kind=ImageKind.CLIENT,
+    )
+    assert resolved.path == expected_path.as_posix()
+    assert resolved.sha256 == hashlib.sha256(content).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("inspection_payload", "match"),
+    (
+        (b"not-json\n", "invalid"),
+        (b"{}\n", "invalid"),
+        (b"x" * (1024 * 1024 + 1), "too large"),
+    ),
+    ids=("invalid-json", "incomplete-record", "oversized-record"),
+)
+def test_publish_rejects_invalid_inspection_and_cleans_temporary_state(
+    tmp_path: Path,
+    inspection_payload: bytes,
+    match: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="invalid-output", content=b"candidate")
+    Path(prepared.plan.inspection_output_path).write_bytes(inspection_payload)
+
+    with pytest.raises(ImageLifecycleError, match=match):
+        publish_completed_image_lifecycle(prepared)
+
+    assert not Path(prepared.plan.job_directory).exists()
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not (workspace / "images" / "artifacts").exists()
+
+
+def test_publish_rejects_fifo_inspection_without_blocking(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="fifo-inspection-output",
+        content=b"candidate",
+    )
+    os.mkfifo(prepared.plan.inspection_output_path)
+
+    with pytest.raises(ImageLifecycleError, match="not regular"):
+        publish_completed_image_lifecycle(prepared)
+
+    assert not Path(prepared.plan.job_directory).exists()
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+
+
+def test_publish_rejects_inspection_mutated_during_read(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="inspection-mutated-during-read",
+        content=b"candidate",
+    )
+    inspection_path = Path(prepared.plan.inspection_output_path)
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+    inspection_inode = inspection_path.stat().st_ino
+    original_fstat = os.fstat
+    inspection_fstat_count = 0
+
+    def mutate_before_final_inspection_fstat(descriptor: int) -> os.stat_result:
+        nonlocal inspection_fstat_count
+        status = original_fstat(descriptor)
+        if status.st_ino == inspection_inode:
+            inspection_fstat_count += 1
+            if inspection_fstat_count == 2:
+                inspection_path.write_text("mutated")
+                status = original_fstat(descriptor)
+        return status
+
+    with (
+        patch("data_designer.slurm.images.lifecycle.os.fstat", side_effect=mutate_before_final_inspection_fstat),
+        pytest.raises(ImageLifecycleError, match="changed while it was being read"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert not Path(prepared.plan.job_directory).exists()
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+
+
+def test_cleanup_failure_preserves_primary_publication_error_and_keeps_output_unusable(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="cleanup-failure", content=b"candidate")
+    Path(prepared.plan.inspection_output_path).write_text("not-json")
+
+    with (
+        patch("data_designer.slurm.images.lifecycle.os.listdir", side_effect=OSError("injected cleanup failure")),
+        pytest.raises(ImageLifecycleError, match="inspection output is invalid"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert Path(prepared.plan.job_directory).exists()
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not (workspace / "images" / "artifacts").exists()
+    cleanup_prepared_image_lifecycle(prepared)
+
+
+def test_explicit_cleanup_normalizes_failure(tmp_path: Path) -> None:
+    prepared = _prepare_completed_oci_lifecycle(
+        tmp_path / "workspace",
+        lifecycle_id="explicit-cleanup-failure",
+        content=b"candidate",
+    )
+
+    with (
+        patch("data_designer.slurm.images.lifecycle.os.listdir", side_effect=OSError("injected cleanup failure")),
+        pytest.raises(ImageLifecycleError, match="cannot clean image lifecycle job"),
+    ):
+        cleanup_prepared_image_lifecycle(prepared)
+
+    cleanup_prepared_image_lifecycle(prepared)
+
+
+def test_cleanup_refuses_replaced_job_directory(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="replaced-cleanup-directory",
+        content=b"candidate",
+    )
+    job_directory = Path(prepared.plan.job_directory)
+    detached_job_directory = job_directory.with_name("detached-cleanup-directory")
+    job_directory.rename(detached_job_directory)
+    job_directory.mkdir()
+    replacement_sentinel = job_directory / "must-not-delete"
+    replacement_sentinel.write_text("replacement")
+
+    with pytest.raises(ImageLifecycleError, match="cannot clean"):
+        cleanup_prepared_image_lifecycle(prepared)
+
+    assert replacement_sentinel.read_text() == "replacement"
+    assert detached_job_directory.is_dir()
+    replacement_sentinel.unlink()
+    job_directory.rmdir()
+    detached_job_directory.rename(job_directory)
+    cleanup_prepared_image_lifecycle(prepared)
+
+
+def test_cleanup_does_not_descend_into_directory_replaced_after_identity_check(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="replacement-during-cleanup",
+        content=b"candidate",
+    )
+    job_directory = Path(prepared.plan.job_directory)
+    detached_job_directory = job_directory.with_name("detached-during-cleanup")
+    replacement_sentinel = job_directory / "must-not-delete"
+    original_listdir = os.listdir
+    replaced = False
+
+    def replace_before_recursive_cleanup(directory_descriptor: int) -> list[str]:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            job_directory.rename(detached_job_directory)
+            job_directory.mkdir()
+            replacement_sentinel.write_text("replacement")
+        return original_listdir(directory_descriptor)
+
+    with (
+        patch("data_designer.slurm.images.lifecycle.os.listdir", side_effect=replace_before_recursive_cleanup),
+        pytest.raises(ImageLifecycleError, match="cannot clean"),
+    ):
+        cleanup_prepared_image_lifecycle(prepared)
+
+    assert replacement_sentinel.read_text() == "replacement"
+    assert detached_job_directory.is_dir()
+    replacement_sentinel.unlink()
+    job_directory.rmdir()
+    detached_job_directory.rename(job_directory)
+    cleanup_prepared_image_lifecycle(prepared)
+
+
+def test_successful_publication_reports_cleanup_failure_without_invalidating_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="successful-cleanup-failure",
+        content=b"candidate",
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+
+    with (
+        patch("data_designer.slurm.images.lifecycle.os.listdir", side_effect=OSError("injected cleanup failure")),
+        pytest.raises(ImageLifecycleError, match="cannot clean image lifecycle job"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert Path(prepared.plan.job_directory).exists()
+    resolved = VerifiedImageRegistry(workspace).resolve_for_planning(
+        ImageRef(name="client"),
+        expected_kind=ImageKind.CLIENT,
+    )
+    assert Path(resolved.path).read_bytes() == b"candidate"
+    cleanup_prepared_image_lifecycle(prepared)
+
+
+@pytest.mark.parametrize("mismatch", ("digest", "kind"))
+def test_publish_rejects_mismatched_inspection_without_exposing_artifact(
+    tmp_path: Path,
+    mismatch: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    content = b"candidate"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id=f"mismatch-{mismatch}", content=content)
+    inspection = (
+        _get_client_inspection(b"different") if mismatch == "digest" else _get_serving_inspection(content, "0.21.0")
+    )
+    _write_completed_inspection(prepared, inspection)
+
+    with pytest.raises(ImageVerificationError, match="digest|kind"):
+        publish_completed_image_lifecycle(prepared)
+
+    assert not Path(prepared.plan.job_directory).exists()
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not (workspace / "images" / "artifacts").exists()
+
+
+def test_publish_requires_explicit_alias_replacement_and_preserves_prior_state(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="first", content=b"first")
+    _write_completed_inspection(first, _get_client_inspection(b"first"))
+    original = publish_completed_image_lifecycle(first)
+    second = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="second", content=b"second")
+    _write_completed_inspection(second, _get_client_inspection(b"second"))
+
+    with pytest.raises(ImageConflictError, match="already registered"):
+        publish_completed_image_lifecycle(second)
+
+    resolved = VerifiedImageRegistry(workspace).resolve_for_planning(
+        ImageRef(name="client"),
+        expected_kind=ImageKind.CLIENT,
+    )
+    assert resolved.path == original.path
+    assert Path(original.path).read_bytes() == b"first"
+    assert not Path(second.plan.job_directory).exists()
+    assert tuple((workspace / "images" / "artifacts").glob("*.sqsh")) == (Path(original.path),)
+
+
+def test_explicit_alias_replacement_publishes_new_artifact_without_deleting_prior_artifact(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="first-replace", content=b"first")
+    _write_completed_inspection(first, _get_client_inspection(b"first"))
+    original = publish_completed_image_lifecycle(first)
+    second = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="second-replace", content=b"second")
+    _write_completed_inspection(second, _get_client_inspection(b"second"))
+
+    replacement = publish_completed_image_lifecycle(second, replace=True)
+
+    assert replacement.path != original.path
+    assert Path(replacement.path).read_bytes() == b"second"
+    assert Path(original.path).read_bytes() == b"first"
+    assert VerifiedImageRegistry(workspace).list_images() == (replacement,)
+
+
+@pytest.mark.parametrize("existing_content", (b"candidate", b"conflict"), ids=("identical", "conflicting"))
+def test_artifact_path_collision_is_deterministic(tmp_path: Path, existing_content: bytes) -> None:
+    workspace = tmp_path / "workspace"
+    content = b"candidate"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="artifact-collision", content=content)
+    inspection = _get_client_inspection(content)
+    _write_completed_inspection(prepared, inspection)
+    artifact_path = workspace / "images" / "artifacts" / f"client-{inspection.sqsh_sha256}.sqsh"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_bytes(existing_content)
+
+    if existing_content == content:
+        registered = publish_completed_image_lifecycle(prepared)
+        assert registered.path == artifact_path.as_posix()
+        assert artifact_path.read_bytes() == content
+    else:
+        with pytest.raises(ImageConflictError, match="conflicting bytes"):
+            publish_completed_image_lifecycle(prepared)
+        assert VerifiedImageRegistry(workspace).list_images() == ()
+        assert artifact_path.read_bytes() == existing_content
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+@pytest.mark.parametrize("collision_kind", ("directory", "fifo", "symlink"))
+def test_nonregular_artifact_path_collision_is_deterministic(tmp_path: Path, collision_kind: str) -> None:
+    workspace = tmp_path / "workspace"
+    content = b"candidate"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace, lifecycle_id="nonregular-artifact-collision", content=content
+    )
+    inspection = _get_client_inspection(content)
+    _write_completed_inspection(prepared, inspection)
+    artifact_path = workspace / "images" / "artifacts" / f"client-{inspection.sqsh_sha256}.sqsh"
+    artifact_path.parent.mkdir(parents=True)
+    if collision_kind == "directory":
+        artifact_path.mkdir()
+    elif collision_kind == "fifo":
+        os.mkfifo(artifact_path)
+    else:
+        symlink_target = tmp_path / "symlink-target.sqsh"
+        symlink_target.write_bytes(b"outside")
+        artifact_path.symlink_to(symlink_target)
+    original_status = artifact_path.lstat()
+
+    with pytest.raises(ImageConflictError, match="cannot be reused"):
+        publish_completed_image_lifecycle(prepared)
+
+    current_status = artifact_path.lstat()
+    assert (current_status.st_dev, current_status.st_ino, stat.S_IFMT(current_status.st_mode)) == (
+        original_status.st_dev,
+        original_status.st_ino,
+        stat.S_IFMT(original_status.st_mode),
+    )
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_registry_failure_rolls_back_new_artifact_and_keeps_alias_unpublished(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="registry-failure", content=b"candidate")
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+    original_replace = os.replace
+
+    def fail_registry_publish(source: str, destination: str, **kwargs: int) -> None:
+        if destination == "registry.yaml":
+            assert not Path(prepared.plan.sqsh_path).exists()
+            raise OSError("injected registry publication failure")
+        original_replace(source, destination, **kwargs)
+
+    with (
+        patch("data_designer.slurm.images.registry.os.replace", side_effect=fail_registry_publish),
+        pytest.raises(ImageRegistryError, match="cannot persist"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not tuple((workspace / "images" / "artifacts").glob("*.sqsh"))
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_registry_failure_does_not_remove_replaced_artifact_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="registry-failure-replaced-artifact",
+        content=b"candidate",
+    )
+    inspection = _get_client_inspection(b"candidate")
+    _write_completed_inspection(prepared, inspection)
+    artifact_path = workspace / "images" / "artifacts" / f"client-{inspection.sqsh_sha256}.sqsh"
+    original_replace = os.replace
+
+    def replace_artifact_before_registry_failure(source: str, destination: str, **kwargs: int) -> None:
+        if destination == "registry.yaml":
+            artifact_path.unlink()
+            artifact_path.write_bytes(b"replacement")
+            raise OSError("injected registry publication failure")
+        original_replace(source, destination, **kwargs)
+
+    with (
+        patch("data_designer.slurm.images.registry.os.replace", side_effect=replace_artifact_before_registry_failure),
+        pytest.raises(ImageRegistryError, match="cannot persist"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert artifact_path.read_bytes() == b"replacement"
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_artifact_directory_sync_failure_removes_new_artifact_and_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="artifact-sync-failure", content=b"candidate")
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+    artifact_directory = workspace / "images" / "artifacts"
+    original_fsync = os.fsync
+
+    def fail_artifact_directory_sync(descriptor: int) -> None:
+        descriptor_status = os.fstat(descriptor)
+        if artifact_directory.exists():
+            artifact_status = artifact_directory.stat()
+            if (descriptor_status.st_dev, descriptor_status.st_ino) == (
+                artifact_status.st_dev,
+                artifact_status.st_ino,
+            ):
+                raise OSError("injected sync failure")
+        original_fsync(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.service.os.fsync", side_effect=fail_artifact_directory_sync),
+        pytest.raises(ImageVerificationError, match="cannot publish image artifact"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not tuple((workspace / "images" / "artifacts").glob("*.sqsh"))
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_artifact_identity_lookup_failure_removes_new_artifact_and_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="artifact-identity-failure",
+        content=b"candidate",
+    )
+    inspection = _get_client_inspection(b"candidate")
+    _write_completed_inspection(prepared, inspection)
+    artifact_path = workspace / "images" / "artifacts" / f"client-{inspection.sqsh_sha256}.sqsh"
+    original_stat = os.stat
+    failed = False
+
+    def fail_artifact_identity_lookup(path: str, **kwargs: object) -> os.stat_result:
+        nonlocal failed
+        if path == artifact_path.name and not failed:
+            failed = True
+            raise OSError("injected artifact identity failure")
+        return original_stat(path, **kwargs)
+
+    with (
+        patch("data_designer.slurm.images.service.os.stat", side_effect=fail_artifact_identity_lookup),
+        pytest.raises(ImageVerificationError, match="cannot publish image artifact"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not artifact_path.exists()
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_candidate_directory_sync_failure_removes_new_artifact_and_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace,
+        lifecycle_id="candidate-sync-failure",
+        content=b"candidate",
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+    candidate_directory = Path(prepared.plan.sqsh_path).parent
+    original_fsync = os.fsync
+    failed = False
+
+    def fail_candidate_directory_sync(descriptor: int) -> None:
+        nonlocal failed
+        descriptor_status = os.fstat(descriptor)
+        candidate_directory_status = candidate_directory.stat()
+        if not failed and (descriptor_status.st_dev, descriptor_status.st_ino) == (
+            candidate_directory_status.st_dev,
+            candidate_directory_status.st_ino,
+        ):
+            failed = True
+            raise OSError("injected candidate sync failure")
+        original_fsync(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.service.os.fsync", side_effect=fail_candidate_directory_sync),
+        pytest.raises(ImageVerificationError, match="cannot publish image artifact"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not tuple((workspace / "images" / "artifacts").glob("*.sqsh"))
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_artifact_file_sync_failure_removes_new_artifact_and_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    prepared = _prepare_completed_oci_lifecycle(
+        workspace, lifecycle_id="artifact-file-sync-failure", content=b"candidate"
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"candidate"))
+    artifact_path = workspace / "images" / "artifacts" / f"client-{hashlib.sha256(b'candidate').hexdigest()}.sqsh"
+    original_fsync = os.fsync
+
+    def fail_regular_file_sync(descriptor: int) -> None:
+        descriptor_status = os.fstat(descriptor)
+        if artifact_path.exists():
+            artifact_status = artifact_path.stat()
+            if (descriptor_status.st_dev, descriptor_status.st_ino) == (
+                artifact_status.st_dev,
+                artifact_status.st_ino,
+            ):
+                raise OSError("injected file sync failure")
+        original_fsync(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.service.os.fsync", side_effect=fail_regular_file_sync),
+        pytest.raises(ImageVerificationError, match="cannot synchronize image artifact"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert not tuple((workspace / "images" / "artifacts").glob("*.sqsh"))
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_registry_directory_sync_failure_restores_prior_alias_and_artifact(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="before-registry-sync", content=b"first")
+    _write_completed_inspection(first, _get_client_inspection(b"first"))
+    original = publish_completed_image_lifecycle(first)
+    second = _prepare_completed_oci_lifecycle(workspace, lifecycle_id="registry-sync-failure", content=b"second")
+    _write_completed_inspection(second, _get_client_inspection(b"second"))
+    original_fsync = os.fsync
+    image_root = workspace / "images"
+    image_root_sync_count = 0
+
+    def fail_published_registry_sync(descriptor: int) -> None:
+        nonlocal image_root_sync_count
+        descriptor_status = os.fstat(descriptor)
+        image_root_status = image_root.stat()
+        if (descriptor_status.st_dev, descriptor_status.st_ino) == (
+            image_root_status.st_dev,
+            image_root_status.st_ino,
+        ):
+            image_root_sync_count += 1
+            if image_root_sync_count == 2:
+                raise OSError("injected registry sync failure")
+        original_fsync(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.registry.os.fsync", side_effect=fail_published_registry_sync),
+        pytest.raises(ImageRegistryError, match="cannot persist"),
+    ):
+        publish_completed_image_lifecycle(second, replace=True)
+
+    registry = VerifiedImageRegistry(workspace)
+    assert registry.list_images() == (original,)
+    assert Path(original.path).read_bytes() == b"first"
+    assert tuple((workspace / "images" / "artifacts").glob("*.sqsh")) == (Path(original.path),)
+    assert not Path(second.plan.job_directory).exists()
+
+
+def test_existing_sqsh_replacement_after_registry_rename_rolls_back_alias(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = tmp_path / "external" / "client.sqsh"
+    image_path.parent.mkdir()
+    image_path.write_bytes(b"client")
+    prepared = prepare_image_lifecycle_job(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _get_selected_profile(workspace),
+        lifecycle_id="existing-replacement",
+    )
+    _write_completed_inspection(prepared, _get_client_inspection(b"client"))
+    replacement = tmp_path / "replacement.sqsh"
+    replacement.write_bytes(b"replacement")
+    original_replace = os.replace
+
+    def replace_after_registry_publish(source: str, destination: str, **kwargs: int) -> None:
+        original_replace(source, destination, **kwargs)
+        if destination == "registry.yaml":
+            replacement.replace(image_path)
+
+    with (
+        patch("data_designer.slurm.images.registry.os.replace", side_effect=replace_after_registry_publish),
+        pytest.raises(ImageVerificationError, match="no longer matches"),
+    ):
+        publish_completed_image_lifecycle(prepared)
+
+    assert VerifiedImageRegistry(workspace).list_images() == ()
+    assert image_path.read_bytes() == b"replacement"
+    assert not Path(prepared.plan.job_directory).exists()
+
+
+def test_concurrent_same_alias_publications_have_one_consistent_winner(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    barrier = Barrier(2)
+
+    def publish(content: bytes) -> str:
+        prepared = _prepare_completed_oci_lifecycle(
+            workspace,
+            lifecycle_id=f"concurrent-{content.decode()}",
+            content=content,
+        )
+        _write_completed_inspection(prepared, _get_client_inspection(content))
+        barrier.wait()
+        return publish_completed_image_lifecycle(prepared).path
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(publish, content) for content in (b"first", b"second"))
+
+    successes = tuple(future.result() for future in futures if future.exception() is None)
+    failures = tuple(future.exception() for future in futures if future.exception() is not None)
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], ImageConflictError)
+    registered = VerifiedImageRegistry(workspace).list_images()
+    assert len(registered) == 1
+    assert registered[0].path == successes[0]
+    assert hashlib.sha256(Path(successes[0]).read_bytes()).hexdigest() == registered[0].sqsh_sha256
+    assert tuple((workspace / "images" / "artifacts").glob("*.sqsh")) == (Path(successes[0]),)
+
+
+def test_concurrent_aliases_for_same_existing_sqsh_preserve_both_bindings(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image_path = tmp_path / "external" / "shared.sqsh"
+    image_path.parent.mkdir()
+    image_path.write_bytes(b"shared")
+    inspection = _get_client_inspection(b"shared")
+    barrier = Barrier(2)
+
+    def publish(name: str) -> str:
+        prepared = prepare_image_lifecycle_job(
+            ImageBuildRequest(name=name, kind="client", source=image_path.as_posix()),
+            _get_selected_profile(workspace),
+            lifecycle_id=f"shared-{name}",
+        )
+        _write_completed_inspection(prepared, inspection)
+        barrier.wait()
+        return publish_completed_image_lifecycle(prepared).name
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        names = tuple(executor.map(publish, ("alpha", "beta")))
+
+    assert names == ("alpha", "beta")
+    registered = VerifiedImageRegistry(workspace).list_images()
+    assert tuple(image.name for image in registered) == ("alpha", "beta")
+    assert {image.path for image in registered} == {image_path.as_posix()}
+
+
+def test_two_supported_serving_images_publish_and_resolve_independently(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    expected_versions = {"vllm-021": "0.21.3", "vllm-022": "0.22.1"}
+
+    for name, runtime_version in expected_versions.items():
+        content = f"{name}-{runtime_version}".encode()
+        prepared = prepare_image_lifecycle_job(
+            ImageBuildRequest(
+                name=name,
+                kind="serving",
+                source=f"registry.example.test/{name}@sha256:{hashlib.sha256(name.encode()).hexdigest()}",
+            ),
+            _get_selected_profile(workspace),
+            lifecycle_id=f"publish-{name}",
+        )
+        Path(prepared.plan.sqsh_path).write_bytes(content)
+        _write_completed_inspection(prepared, _get_serving_inspection(content, runtime_version))
+        publish_completed_image_lifecycle(prepared)
+
+    registry = VerifiedImageRegistry(workspace)
+    resolved = {
+        name: registry.resolve_for_planning(ImageRef(name=name), expected_kind=ImageKind.SERVING)
+        for name in expected_versions
+    }
+    assert {name: image.inspection_facts.runtime_version for name, image in resolved.items()} == expected_versions
+    assert resolved["vllm-021"].path != resolved["vllm-022"].path
+    assert resolved["vllm-021"].sha256 != resolved["vllm-022"].sha256
+
+
+def test_rendered_existing_inspection_rejects_path_replacement_and_cleans_output(tmp_path: Path) -> None:
+    image_path = tmp_path / "client.sqsh"
+    image_path.write_bytes(b"client image")
+    replacement = tmp_path / "replacement.sqsh"
+    replacement.write_bytes(b"replacement image")
+    prepared = prepare_image_lifecycle_job(
+        ImageBuildRequest(name="client", kind="client", source=image_path.as_posix()),
+        _get_selected_profile(tmp_path / "workspace"),
+        lifecycle_id="existing-path-replacement",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_enroot = fake_bin / "enroot"
+    fake_enroot.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -Eeuo pipefail\n"
+        'if [[ "$1" == "version" ]]; then\n'
+        "    printf '%s\\n' '4.0.0'\n"
+        'elif [[ "$1" == "create" ]]; then\n'
+        '    cp "${@: -1}" "${DD_TEST_INSPECTED_SQSH}"\n'
+        '    mv "${DD_TEST_REPLACEMENT}" "${DD_TEST_SOURCE}"\n'
+        'elif [[ "$1" == "start" ]]; then\n'
+        "    printf '%s\\n' '{}' > \"${DD_TEST_INSPECTION_OUTPUT}\"\n"
+        "fi\n"
+    )
+    fake_enroot.chmod(0o700)
+    script = render_image_lifecycle_script(prepared.plan).replace(
+        'export PATH="',
+        f'export PATH="{fake_bin.as_posix()}:',
+        1,
+    )
+
+    completed = subprocess.run(
+        ("bash",),
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "DD_TEST_INSPECTION_OUTPUT": prepared.plan.inspection_output_path,
+            "DD_TEST_INSPECTED_SQSH": (tmp_path / "inspected.sqsh").as_posix(),
+            "DD_TEST_REPLACEMENT": replacement.as_posix(),
+            "DD_TEST_SOURCE": image_path.as_posix(),
+            "SLURM_CPUS_PER_TASK": "2",
+            "SLURM_JOB_ID": "5101",
+        },
+    )
+
+    assert completed.returncode == 74
+    assert "changed during inspection" in completed.stderr
+    assert (tmp_path / "inspected.sqsh").read_bytes() == b"client image"
+    assert image_path.read_bytes() == b"replacement image"
+    assert not Path(prepared.plan.inspection_output_path).exists()
+    assert not (Path(prepared.plan.job_directory) / "verified.sqsh").exists()
+
+
 def test_standalone_client_inspector_binds_pip_to_its_distribution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -642,6 +1402,72 @@ def _get_selected_profile(workspace: Path) -> SelectedSlurmProfile:
         ),
     )
     return injected_profile(profile)
+
+
+def _prepare_completed_oci_lifecycle(
+    workspace: Path,
+    *,
+    lifecycle_id: str,
+    content: bytes,
+) -> PreparedImageLifecycleJob:
+    prepared = prepare_image_lifecycle_job(
+        ImageBuildRequest(
+            name="client",
+            kind="client",
+            source=f"registry.example.test/client@sha256:{'a' * 64}",
+        ),
+        _get_selected_profile(workspace),
+        lifecycle_id=lifecycle_id,
+    )
+    Path(prepared.plan.sqsh_path).write_bytes(content)
+    return prepared
+
+
+def _write_completed_inspection(
+    prepared: PreparedImageLifecycleJob,
+    inspection: ImageInspectionRecord,
+) -> None:
+    Path(prepared.plan.inspection_output_path).write_text(inspection.model_dump_json())
+
+
+def _get_client_inspection(content: bytes) -> ImageInspectionRecord:
+    distributions = tuple(
+        InstalledDistribution(name=name, version="0.9.2")
+        for name in (
+            "data-designer",
+            "data-designer-config",
+            "data-designer-engine",
+            "data-designer-slurm",
+        )
+    ) + (InstalledDistribution(name="pip", version="26.1"),)
+    return ImageInspectionRecord(
+        schema_version=1,
+        inspector_version="inspector-1",
+        sqsh_sha256=hashlib.sha256(content).hexdigest(),
+        inspection=ClientImageInspection(
+            kind="client",
+            python_implementation="cpython",
+            python_version="3.13.3",
+            python_abi="cp313",
+            distributions=distributions,
+            installer_path="/usr/bin/pip",
+            installer_version="26.1",
+        ),
+    )
+
+
+def _get_serving_inspection(content: bytes, runtime_version: str) -> ImageInspectionRecord:
+    return ImageInspectionRecord(
+        schema_version=1,
+        inspector_version="inspector-1",
+        sqsh_sha256=hashlib.sha256(content).hexdigest(),
+        inspection=ServingImageInspection(
+            kind="serving",
+            server_type="vllm",
+            runtime_version=runtime_version,
+            executable_path="/usr/local/bin/vllm",
+        ),
+    )
 
 
 class _MutatingSubmissionRunner:

--- a/packages/data-designer-slurm/tests/images/test_registry_store.py
+++ b/packages/data-designer-slurm/tests/images/test_registry_store.py
@@ -3,18 +3,22 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
+import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier, Event
+from unittest.mock import patch
 
 import pytest
 import yaml
 from slurm_test_fakes import FakeInspectionEnvironment
 
 from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, InstalledDistribution
-from data_designer.slurm.images.errors import ImageConflictError, ImageRegistryError
+from data_designer.slurm.images.errors import ImageConflictError, ImageRegistryError, ImageVerificationError
 from data_designer.slurm.images.inspection import ClientImageInspector, ServingImageInspector
 from data_designer.slurm.images.records import RegisteredImage
 from data_designer.slurm.images.registry import ImageRegistryStore
@@ -180,6 +184,79 @@ def test_registry_rejects_nonregular_state_file_without_blocking(tmp_path: Path)
         ImageRegistryStore(workspace).list_images()
 
 
+def test_registry_rejects_fifo_substituted_between_check_and_open(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    store = ImageRegistryStore(workspace)
+    store.register(image, verify_before_publish=lambda _image: None)
+    registry_path = store.registry_path
+    original_stat = os.stat
+    replaced = False
+
+    def replace_registry_after_stat(path: str, **kwargs: object) -> os.stat_result:
+        nonlocal replaced
+        status = original_stat(path, **kwargs)
+        if path == "registry.yaml" and not replaced:
+            replaced = True
+            registry_path.unlink()
+            os.mkfifo(registry_path)
+        return status
+
+    with (
+        patch("data_designer.slurm.images.filesystem.os.stat", side_effect=replace_registry_after_stat),
+        pytest.raises(ImageRegistryError, match="cannot load"),
+    ):
+        store.list_images()
+
+
+def test_registry_rejects_state_mutated_during_read(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    store = ImageRegistryStore(workspace)
+    store.register(image, verify_before_publish=lambda _image: None)
+    registry_path = store.registry_path
+    registry_inode = registry_path.stat().st_ino
+    original_fstat = os.fstat
+    registry_fstat_count = 0
+
+    def mutate_before_final_registry_fstat(descriptor: int) -> os.stat_result:
+        nonlocal registry_fstat_count
+        status = original_fstat(descriptor)
+        if status.st_ino == registry_inode:
+            registry_fstat_count += 1
+            if registry_fstat_count == 2:
+                registry_path.write_text("mutated")
+                status = original_fstat(descriptor)
+        return status
+
+    with (
+        patch("data_designer.slurm.images.filesystem.os.fstat", side_effect=mutate_before_final_registry_fstat),
+        pytest.raises(ImageRegistryError, match="cannot load"),
+    ):
+        store.list_images()
+
+
+def test_sqsh_reader_rejects_fifo_substituted_between_check_and_open(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    original_lstat = Path.lstat
+    replaced = False
+
+    def replace_sqsh_after_lstat(path: Path) -> os.stat_result:
+        nonlocal replaced
+        status = original_lstat(path)
+        if path == image_path and not replaced:
+            replaced = True
+            image_path.unlink()
+            os.mkfifo(image_path)
+        return status
+
+    with (
+        patch.object(Path, "lstat", replace_sqsh_after_lstat),
+        pytest.raises(ImageVerificationError, match="changed while it was being opened"),
+    ):
+        compute_sqsh_file_sha256(image_path)
+
+
 def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     lock_directory = workspace / "images" / ".locks"
@@ -243,9 +320,11 @@ def test_registry_uses_restrictive_atomic_workspace_storage(tmp_path: Path) -> N
     assert stat.S_IMODE(image_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(lock_directory.stat().st_mode) == 0o700
     assert not tuple(registry_path.parent.glob(".registry.*.tmp"))
+    assert not (registry_path.parent / ".registry.rollback.yaml").exists()
+    assert not (registry_path.parent / ".registry.committed.yaml").exists()
 
 
-def test_registration_remains_unpublished_until_final_verification(tmp_path: Path) -> None:
+def test_registration_blocks_readers_until_final_verification(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     store = ImageRegistryStore(workspace)
@@ -256,18 +335,129 @@ def test_registration_remains_unpublished_until_final_verification(tmp_path: Pat
         verification_started.set()
         assert finish_verification.wait(timeout=5)
 
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(
             store.register,
             image,
             verify_before_publish=verify_before_publish,
         )
         assert verification_started.wait(timeout=5)
-        assert ImageRegistryStore(workspace).list_images() == ()
+        reader = executor.submit(ImageRegistryStore(workspace).list_images)
+        assert not reader.done()
         finish_verification.set()
-        assert future.result().name == "client"
+        assert writer.result().name == "client"
+        assert tuple(registered.name for registered in reader.result()) == ("client",)
 
     assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
+
+
+def test_failed_registration_runs_rollback_before_releasing_target_lock(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first = _get_registered_client_image(_write_sqsh(tmp_path / "shared.sqsh", b"shared"), name="first")
+    second = first.model_copy(update={"name": "second"})
+    store = ImageRegistryStore(workspace)
+    rollback_started = Event()
+    finish_rollback = Event()
+
+    def fail_after_publish(_image: RegisteredImage) -> None:
+        raise ImageVerificationError("injected post-publication failure")
+
+    def rollback_after_failure(_image: RegisteredImage) -> None:
+        rollback_started.set()
+        assert finish_rollback.wait(timeout=5)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        failed_writer = executor.submit(
+            store.register,
+            first,
+            verify_before_publish=lambda _image: None,
+            verify_after_publish=fail_after_publish,
+            rollback_after_failure=rollback_after_failure,
+        )
+        assert rollback_started.wait(timeout=5)
+        succeeding_writer = executor.submit(
+            store.register,
+            second,
+            verify_before_publish=lambda _image: None,
+        )
+        assert not succeeding_writer.done()
+        finish_rollback.set()
+        with pytest.raises(ImageVerificationError, match="injected post-publication failure"):
+            failed_writer.result()
+        assert succeeding_writer.result() == second
+
+    assert ImageRegistryStore(workspace).list_images() == (second,)
+
+
+def test_fresh_reader_recovers_previous_registry_after_interrupted_publication(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    original = _get_registered_client_image(_write_sqsh(tmp_path / "original.sqsh", b"original"))
+    replacement = _get_registered_client_image(_write_sqsh(tmp_path / "replacement.sqsh", b"replacement"))
+    store = ImageRegistryStore(workspace)
+    store.register(original, verify_before_publish=lambda _image: None)
+    registry_path = store.registry_path
+    previous_content = registry_path.read_bytes()
+    (registry_path.parent / ".registry.rollback.yaml").write_bytes(previous_content)
+    registry_path.write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "images": [replacement.model_dump(mode="json")]},
+            sort_keys=True,
+        )
+    )
+
+    assert _list_image_names_in_fresh_process(workspace) == (original.name,)
+    assert not (registry_path.parent / ".registry.rollback.yaml").exists()
+    assert ImageRegistryStore(workspace).list_images() == (original,)
+
+
+def test_fresh_reader_keeps_committed_registry_after_interrupted_marker_cleanup(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    original = _get_registered_client_image(_write_sqsh(tmp_path / "original.sqsh", b"original"))
+    replacement = _get_registered_client_image(_write_sqsh(tmp_path / "replacement.sqsh", b"replacement"))
+    store = ImageRegistryStore(workspace)
+    store.register(original, verify_before_publish=lambda _image: None)
+    registry_path = store.registry_path
+    (registry_path.parent / ".registry.committed.yaml").write_bytes(registry_path.read_bytes())
+    registry_path.write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "images": [replacement.model_dump(mode="json")]},
+            sort_keys=True,
+        )
+    )
+
+    assert _list_image_names_in_fresh_process(workspace) == (replacement.name,)
+    assert not (registry_path.parent / ".registry.committed.yaml").exists()
+    assert ImageRegistryStore(workspace).list_images() == (replacement,)
+
+
+def test_committed_marker_sync_failure_keeps_new_registry_for_fresh_process(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
+    store = ImageRegistryStore(workspace)
+    image_root_sync_count = 0
+    original_fsync = os.fsync
+
+    def fail_committed_marker_sync(descriptor: int) -> None:
+        nonlocal image_root_sync_count
+        descriptor_status = os.fstat(descriptor)
+        image_root_status = store.image_root.stat()
+        if (descriptor_status.st_dev, descriptor_status.st_ino) == (
+            image_root_status.st_dev,
+            image_root_status.st_ino,
+        ):
+            image_root_sync_count += 1
+            if image_root_sync_count == 3:
+                raise OSError("injected committed marker sync failure")
+        original_fsync(descriptor)
+
+    with patch("data_designer.slurm.images.registry.os.fsync", side_effect=fail_committed_marker_sync):
+        assert store.register(image, verify_before_publish=lambda _image: None) == image
+
+    committed_marker = store.image_root / ".registry.committed.yaml"
+    assert committed_marker.is_file()
+    assert _list_image_names_in_fresh_process(workspace) == (image.name,)
+    assert not committed_marker.exists()
+    assert store.list_images() == (image,)
 
 
 def test_registry_transaction_stays_bound_when_image_root_path_is_replaced(tmp_path: Path) -> None:
@@ -329,6 +519,26 @@ def _write_registry_content(workspace: Path, content: bytes) -> None:
     registry_path = _get_registry_path(workspace)
     registry_path.parent.mkdir(parents=True)
     registry_path.write_bytes(content)
+
+
+def _list_image_names_in_fresh_process(workspace: Path) -> tuple[str, ...]:
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-c",
+            (
+                "import json,sys; "
+                "from data_designer.slurm.images.registry import ImageRegistryStore; "
+                "print(json.dumps([image.name for image in ImageRegistryStore(sys.argv[1]).list_images()]))"
+            ),
+            workspace.as_posix(),
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return tuple(json.loads(completed.stdout))
 
 
 def _write_registry_images(workspace: Path, images: tuple[dict[str, object], ...]) -> None:

--- a/packages/data-designer-slurm/tests/images/test_registry_store.py
+++ b/packages/data-designer-slurm/tests/images/test_registry_store.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 from slurm_test_fakes import FakeInspectionEnvironment
 
+import data_designer.slurm.images.service as image_service
 from data_designer.slurm.config import ImageBuildRequest, ImageInspectionRecord, InstalledDistribution
 from data_designer.slurm.images.errors import ImageConflictError, ImageRegistryError, ImageVerificationError
 from data_designer.slurm.images.inspection import ClientImageInspector, ServingImageInspector
@@ -257,6 +258,23 @@ def test_sqsh_reader_rejects_fifo_substituted_between_check_and_open(tmp_path: P
         compute_sqsh_file_sha256(image_path)
 
 
+def test_sqsh_reader_rejects_path_replaced_during_hash(tmp_path: Path) -> None:
+    image_path = _write_sqsh(tmp_path / "client.sqsh", b"client")
+    replacement = _write_sqsh(tmp_path / "replacement.sqsh", b"replacement")
+    original_hash_descriptor = image_service._hash_descriptor
+
+    def replace_path_after_hash(descriptor: int) -> str:
+        digest = original_hash_descriptor(descriptor)
+        replacement.replace(image_path)
+        return digest
+
+    with (
+        patch("data_designer.slurm.images.service._hash_descriptor", side_effect=replace_path_after_hash),
+        pytest.raises(ImageVerificationError, match="changed while it was being verified"),
+    ):
+        compute_sqsh_file_sha256(image_path)
+
+
 def test_registry_rejects_symlinked_lock_file_without_changing_target(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     lock_directory = workspace / "images" / ".locks"
@@ -351,6 +369,44 @@ def test_registration_blocks_readers_until_final_verification(tmp_path: Path) ->
     assert tuple(registered.name for registered in ImageRegistryStore(workspace).list_images()) == ("client",)
 
 
+def test_existing_sqsh_hashing_does_not_block_registry_readers(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first_path = _write_sqsh(tmp_path / "first.sqsh", b"first")
+    second_path = _write_sqsh(tmp_path / "second.sqsh", b"second")
+    registry = VerifiedImageRegistry(workspace)
+    first = registry.register_existing(
+        ImageBuildRequest(name="first", kind="client", source=first_path.as_posix()),
+        _inspect_client(first_path),
+    )
+    second_inspection = _inspect_client(second_path)
+    hash_started = Event()
+    finish_hash = Event()
+    original_hash_descriptor = image_service._hash_descriptor
+
+    def block_second_hash(descriptor: int) -> str:
+        descriptor_status = os.fstat(descriptor)
+        second_status = second_path.stat()
+        if (descriptor_status.st_dev, descriptor_status.st_ino) == (second_status.st_dev, second_status.st_ino):
+            hash_started.set()
+            assert finish_hash.wait(timeout=5)
+        return original_hash_descriptor(descriptor)
+
+    with (
+        patch("data_designer.slurm.images.service._hash_descriptor", side_effect=block_second_hash),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        writer = executor.submit(
+            registry.register_existing,
+            ImageBuildRequest(name="second", kind="client", source=second_path.as_posix()),
+            second_inspection,
+        )
+        assert hash_started.wait(timeout=5)
+        reader = executor.submit(VerifiedImageRegistry(workspace).list_images)
+        assert reader.result(timeout=5) == (first,)
+        finish_hash.set()
+        assert writer.result(timeout=5).name == "second"
+
+
 def test_failed_registration_runs_rollback_before_releasing_target_lock(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     first = _get_registered_client_image(_write_sqsh(tmp_path / "shared.sqsh", b"shared"), name="first")
@@ -430,7 +486,7 @@ def test_fresh_reader_keeps_committed_registry_after_interrupted_marker_cleanup(
     assert ImageRegistryStore(workspace).list_images() == (replacement,)
 
 
-def test_committed_marker_sync_failure_keeps_new_registry_for_fresh_process(tmp_path: Path) -> None:
+def test_committed_marker_sync_failure_reports_failure_and_keeps_recovery_state(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     image = _get_registered_client_image(_write_sqsh(tmp_path / "client.sqsh", b"client"))
     store = ImageRegistryStore(workspace)
@@ -450,8 +506,11 @@ def test_committed_marker_sync_failure_keeps_new_registry_for_fresh_process(tmp_
                 raise OSError("injected committed marker sync failure")
         original_fsync(descriptor)
 
-    with patch("data_designer.slurm.images.registry.os.fsync", side_effect=fail_committed_marker_sync):
-        assert store.register(image, verify_before_publish=lambda _image: None) == image
+    with (
+        patch("data_designer.slurm.images.registry.os.fsync", side_effect=fail_committed_marker_sync),
+        pytest.raises(ImageRegistryError, match="commit state requires recovery"),
+    ):
+        store.register(image, verify_before_publish=lambda _image: None)
 
     committed_marker = store.image_root / ".registry.committed.yaml"
     assert committed_marker.is_file()

--- a/packages/data-designer-slurm/tests/serving/test_resolver.py
+++ b/packages/data-designer-slurm/tests/serving/test_resolver.py
@@ -112,13 +112,30 @@ def test_two_deployments_keep_images_and_endpoint_identities_isolated(
 
 def test_resolution_preserves_inspected_runtime_version_as_provenance(single_node_plan: ResolvedSlurmRunPlan) -> None:
     payload = single_node_plan.deployments[0].model_dump(mode="json")
-    payload["image"]["inspection"]["inspection"]["runtime_version"] = "vendor-vllm-build"
+    payload["image"]["inspection"]["inspection"]["runtime_version"] = "0.22.0+vendor.1"
     placement = ResolvedDeployment.model_validate_json(json.dumps(payload))
     plan = _plan_with_placement(single_node_plan, placement)
 
     resolved = _resolve(plan, placement.deployment_id)
 
-    assert resolved.image.inspection_facts.runtime_version == "vendor-vllm-build"
+    assert resolved.image.inspection_facts.runtime_version == "0.22.0+vendor.1"
+
+
+@pytest.mark.parametrize(
+    "runtime_version",
+    ("vendor-vllm-build", "0.20.9", "0.22.0rc1", "0.23.0"),
+)
+def test_resolution_rejects_unsupported_runtime_versions(
+    single_node_plan: ResolvedSlurmRunPlan,
+    runtime_version: str,
+) -> None:
+    payload = single_node_plan.deployments[0].model_dump(mode="json")
+    payload["image"]["inspection"]["inspection"]["runtime_version"] = runtime_version
+    placement = ResolvedDeployment.model_validate_json(json.dumps(payload))
+    plan = _plan_with_placement(single_node_plan, placement)
+
+    with pytest.raises(VllmServerResolutionError, match="unsupported vLLM runtime version"):
+        _resolve(plan, placement.deployment_id)
 
 
 def test_resolution_rejects_image_inspection_mismatch(single_node_plan: ResolvedSlurmRunPlan) -> None:


### PR DESCRIPTION
## 📋 Summary

Hardens Slurm image publication so imported artifacts, digest-bound inspection facts, and registry aliases become visible as one recoverable transaction. This closes inherited replacement, collision, concurrency, durability, and cleanup gaps while preserving in-place registration for existing SQSH images.

> [!IMPORTANT]
> This is a stacked PR based on the branch for #896 (867#2). **PR #896 must merge first; do not merge this PR before #896.** After #896 merges, this PR can be retargeted or rebased onto the integration branch.

## 🔗 Related Issue

- Part of #867
- Depends on #896

## 🔄 Changes

- Publish OCI artifacts and registry metadata through a lock-ordered, fsync-backed transaction with fresh-process recovery.
- Bind imported and existing SQSH inspection to verified file descriptors and reject mutation, replacement, symlink, FIFO, and nonregular-file races.
- Make alias and artifact collisions explicit and deterministic without overwriting prior state.
- Roll back package-created artifacts and lifecycle state by verified inode identity while preserving existing paths and the primary failure.
- Complete supported/rejected serving-image compatibility coverage and independent multi-image resolution.
- Add adversarial tests for concurrent writers, durability faults, recovery markers, cleanup races, and hostile filesystem substitutions.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the transaction and filesystem boundaries:

- [`service.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/codex/867-image-publication-hardening/packages/data-designer-slurm/src/data_designer/slurm/images/service.py) — verified artifact promotion, collision handling, and rollback.
- [`registry.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/codex/867-image-publication-hardening/packages/data-designer-slurm/src/data_designer/slurm/images/registry.py) — lock order, durability markers, and crash recovery.
- [`lifecycle.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/codex/867-image-publication-hardening/packages/data-designer-slurm/src/data_designer/slurm/images/lifecycle.py) — descriptor-bound staging, publication, and cleanup.

## 🧪 Testing

- [x] `make check-slurm` passes
- [x] `make test-slurm` passes (1,063 tests)
- [x] `make test-slurm-wheel-install` passes
- [x] Changed source compiles with Python 3.10
- [x] Unit tests added/updated
- [x] E2E tests: N/A — covered by deterministic Slurm fakes and isolated wheel validation

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated: N/A — no architecture contract changed
