### PR TITLE
feat: add one-node Slurm runtime

### DIFF
--- a/packages/data-designer-slurm/src/data_designer/slurm/integration.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/integration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import posixpath
 
 from data_designer.slurm.client import ClientOutcome, ClientResult
+from data_designer.slurm.contracts import ArtifactReference
 from data_designer.slurm.planning import PlannedShard
 from data_designer.slurm.state.execution import (
     AttemptLifecycleState,
@@ -35,38 +36,69 @@ class PlanStateValidator(PersistedPlanStateValidator):
         winner: ShardWinner,
     ) -> ShardWinner:
         """Validate a complete semantic result through immutable winner publication."""
-        self.validate_planned_attempt(planned_shard, attempt)
+        self.validate_client_candidate(planned_shard, attempt, client_result, candidate)
         _require(attempt.state is AttemptLifecycleState.SUCCEEDED, "only successful attempts may be finalized")
         _require(
             attempt.terminal_classification is AttemptTerminalClassification.SUCCEEDED,
             "only successfully classified attempts may be finalized",
         )
+        self._validate_winner(planned_shard, attempt, client_result, winner)
+        _require(
+            attempt.updated_at >= client_result.completed_at, "attempt completion cannot precede client completion"
+        )
+        _require(winner.published_at >= attempt.updated_at, "winner publication cannot precede attempt completion")
+        return winner
+
+    def validate_client_candidate(
+        self,
+        planned_shard: PlannedShard,
+        attempt: AttemptManifest,
+        client_result: ClientResult,
+        candidate: CandidateOutputManifest,
+    ) -> CandidateOutputManifest:
+        """Validate a complete client result and candidate before terminal publication."""
+        self.validate_planned_attempt(planned_shard, attempt)
         _require(client_result.outcome is ClientOutcome.COMPLETE, "only complete client results may be finalized")
         _require(candidate.winner_eligible, "only complete candidate outputs may be finalized")
+        self._validate_candidate_identities(planned_shard, attempt, client_result, candidate)
+        self._validate_candidate_counts(planned_shard, client_result, candidate)
+        self._validate_candidate_location(planned_shard, attempt, client_result, candidate)
+        _require(candidate.created_at >= attempt.created_at, "candidate creation cannot precede attempt creation")
+        _require(
+            client_result.completed_at >= candidate.created_at,
+            "client completion cannot precede candidate creation",
+        )
+        return candidate
 
-        for record_name, run_id in (
-            ("client result", client_result.run_id),
-            ("candidate", candidate.run_id),
-            ("winner", winner.run_id),
-        ):
+    def _validate_candidate_identities(
+        self,
+        planned_shard: PlannedShard,
+        attempt: AttemptManifest,
+        client_result: ClientResult,
+        candidate: CandidateOutputManifest,
+    ) -> None:
+        for record_name, run_id in (("client result", client_result.run_id), ("candidate", candidate.run_id)):
             _require(run_id == self.plan.run_id, f"{record_name} run_id does not match the resolved plan")
         for record_name, shard_id in (
             ("client result", client_result.shard_id),
             ("candidate", candidate.shard_id),
-            ("winner", winner.shard_id),
         ):
             _require(shard_id == planned_shard.shard_id, f"{record_name} shard_id does not match the planned shard")
         for record_name, attempt_id in (
             ("client result", client_result.attempt_id),
             ("candidate", candidate.attempt_id),
-            ("winner", winner.attempt_id),
         ):
             _require(attempt_id == attempt.attempt_id, f"{record_name} attempt_id does not match the attempt")
-
         _require(
-            candidate.attempt_ordinal == attempt.attempt_ordinal == winner.attempt_ordinal,
-            "candidate and winner attempt ordinals must match the attempt",
+            candidate.attempt_ordinal == attempt.attempt_ordinal, "candidate attempt ordinal does not match attempt"
         )
+
+    @staticmethod
+    def _validate_candidate_counts(
+        planned_shard: PlannedShard,
+        client_result: ClientResult,
+        candidate: CandidateOutputManifest,
+    ) -> None:
         _require(
             client_result.requested_records == candidate.requested_records == planned_shard.requested_records,
             "client and candidate requested records must match the planned shard",
@@ -75,11 +107,18 @@ class PlanStateValidator(PersistedPlanStateValidator):
             client_result.actual_records == candidate.actual_records == planned_shard.requested_records,
             "client and candidate actual records must complete the planned shard",
         )
+
+    def _validate_candidate_location(
+        self,
+        planned_shard: PlannedShard,
+        attempt: AttemptManifest,
+        client_result: ClientResult,
+        candidate: CandidateOutputManifest,
+    ) -> None:
         _require(
             client_result.requested_resume_mode == self.plan.invocation.authored.resume,
             "client requested resume mode does not match the resolved plan",
         )
-
         expected_dataset_path = self._get_expected_dataset_path(planned_shard, attempt, client_result)
         _require(
             client_result.dataset_path == expected_dataset_path, "client dataset path does not match planned intent"
@@ -87,23 +126,33 @@ class PlanStateValidator(PersistedPlanStateValidator):
         _require(
             candidate.dataset_path == expected_dataset_path, "candidate dataset path does not match planned intent"
         )
-
+        candidate_reference = self._get_candidate_reference(client_result)
         expected_manifest_path = posixpath.join(
             posixpath.dirname(planned_shard.resume_workspace.path),
             "attempts",
             attempt.attempt_id,
             "output-manifest.json",
         )
-        candidate_reference = client_result.candidate_output_manifest
-        _require(candidate_reference is not None, "complete client result has no candidate manifest reference")
         _require(
-            candidate_reference.path == expected_manifest_path,
-            "candidate manifest path does not match planned intent",
+            candidate_reference.path == expected_manifest_path, "candidate manifest path does not match planned intent"
         )
         _require(
             candidate_reference.sha256 == candidate.compute_sha256(),
             "client candidate digest does not match the manifest",
         )
+
+    def _validate_winner(
+        self,
+        planned_shard: PlannedShard,
+        attempt: AttemptManifest,
+        client_result: ClientResult,
+        winner: ShardWinner,
+    ) -> None:
+        candidate_reference = self._get_candidate_reference(client_result)
+        _require(winner.run_id == self.plan.run_id, "winner run_id does not match the resolved plan")
+        _require(winner.shard_id == planned_shard.shard_id, "winner shard_id does not match the planned shard")
+        _require(winner.attempt_id == attempt.attempt_id, "winner attempt_id does not match the attempt")
+        _require(winner.attempt_ordinal == attempt.attempt_ordinal, "winner attempt ordinal does not match the attempt")
         _require(
             attempt.candidate_output == candidate_reference,
             "attempt candidate reference does not match client result",
@@ -113,16 +162,11 @@ class PlanStateValidator(PersistedPlanStateValidator):
             "winner candidate reference does not match client result",
         )
 
-        _require(candidate.created_at >= attempt.created_at, "candidate creation cannot precede attempt creation")
-        _require(
-            client_result.completed_at >= candidate.created_at,
-            "client completion cannot precede candidate creation",
-        )
-        _require(
-            attempt.updated_at >= client_result.completed_at, "attempt completion cannot precede client completion"
-        )
-        _require(winner.published_at >= attempt.updated_at, "winner publication cannot precede attempt completion")
-        return winner
+    @staticmethod
+    def _get_candidate_reference(client_result: ClientResult) -> ArtifactReference:
+        candidate_reference = client_result.candidate_output_manifest
+        _require(candidate_reference is not None, "complete client result has no candidate manifest reference")
+        return candidate_reference
 
     @staticmethod
     def _get_expected_dataset_path(

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allocation-local runtime primitives for resolved Slurm plans."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_designer.slurm.runtime.bundle import stage_runtime_bundle  # noqa: F401
+    from data_designer.slurm.runtime.controller import OneNodeAllocationController  # noqa: F401
+    from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode  # noqa: F401
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "OneNodeAllocationController": (
+        "data_designer.slurm.runtime.controller",
+        "OneNodeAllocationController",
+    ),
+    "SlurmRuntimeError": ("data_designer.slurm.runtime.errors", "SlurmRuntimeError"),
+    "SlurmRuntimeErrorCode": ("data_designer.slurm.runtime.errors", "SlurmRuntimeErrorCode"),
+    "stage_runtime_bundle": ("data_designer.slurm.runtime.bundle", "stage_runtime_bundle"),
+}
+
+__all__ = [
+    "OneNodeAllocationController",
+    "SlurmRuntimeError",
+    "SlurmRuntimeErrorCode",
+    "stage_runtime_bundle",
+]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily load orchestration dependencies only when requested."""
+    if name in _LAZY_IMPORTS:
+        module_name, attribute_name = _LAZY_IMPORTS[name]
+        attribute = getattr(importlib.import_module(module_name), attribute_name)
+        globals()[name] = attribute
+        return attribute
+    raise AttributeError(f"module 'data_designer.slurm.runtime' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return public runtime exports for interactive discovery."""
+    return __all__

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic content-addressed staging for the allocation runtime bundle."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import os
+import secrets
+import stat
+import tarfile
+from contextlib import suppress
+from pathlib import Path
+
+from data_designer.slurm.contracts import ArtifactReference, validate_absolute_path
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+
+_DIRECTORY_MODE = 0o700
+_FILE_MODE = 0o600
+_ENTRYPOINT_MODE = 0o500
+_SOURCE_MODE = 0o400
+_MAXIMUM_SOURCE_SIZE = 16 * 1024 * 1024
+_ENTRYPOINT_NAME = "entrypoint.sh"
+_SLURM_PACKAGE_NAME = "data_designer/slurm/__init__.py"
+_SLURM_PACKAGE_SHIM = (
+    b"# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+    b"# SPDX-License-Identifier: Apache-2.0\n\n"
+    b'"""Runtime-bundle package shim that extends into the installed Slurm package."""\n\n'
+    b"from __future__ import annotations\n\n"
+    b"from pkgutil import extend_path\n\n"
+    b"__path__ = extend_path(__path__, __name__)\n"
+)
+_ENTRYPOINT = b"""#!/usr/bin/env bash
+set -Eeuo pipefail
+
+dd_slurm_run_allocation() {
+    if [[ $# -ne 2 ]]; then
+        printf '%s\\n' 'allocation runtime requires plan and attempt directory arguments' >&2
+        return 64
+    fi
+    local runtime_root
+    runtime_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+    PYTHONNOUSERSITE=1 PYTHONSAFEPATH=1 PYTHONPATH="${runtime_root}" \
+        python3 -m data_designer.slurm.runtime.entrypoint --plan "$1" --attempt-dir "$2"
+}
+"""
+
+
+def stage_runtime_bundle(workspace_root: str | Path) -> ArtifactReference:
+    """Convergently stage the versioned allocation entrypoint by content digest.
+
+    Raises:
+        SlurmRuntimeError: If the workspace or runtime artifact is unsafe or cannot be staged.
+    """
+    try:
+        normalized_workspace = Path(validate_absolute_path(Path(workspace_root).as_posix()))
+    except ValueError as error:
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime workspace is invalid") from error
+    try:
+        archive = _build_runtime_archive()
+        digest = hashlib.sha256(archive).hexdigest()
+        runtime_root = normalized_workspace / "runtime"
+        archive_path = runtime_root / f"{digest}.tar.gz"
+        _ensure_private_runtime_directory(normalized_workspace, runtime_root)
+        _publish_archive(runtime_root, archive_path.name, archive)
+    except OSError as error:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.PREFLIGHT_FAILED, "cannot stage allocation runtime bundle"
+        ) from error
+    return ArtifactReference(path=archive_path.as_posix(), sha256=digest)
+
+
+def _build_runtime_archive() -> bytes:
+    output = io.BytesIO()
+    with (
+        gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as compressed,
+        tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive,
+    ):
+        _add_archive_file(archive, _ENTRYPOINT_NAME, _ENTRYPOINT, mode=_ENTRYPOINT_MODE)
+        _add_archive_file(archive, _SLURM_PACKAGE_NAME, _SLURM_PACKAGE_SHIM, mode=_SOURCE_MODE)
+        source_root = Path(__file__).parent
+        for source_path in sorted(source_root.glob("*.py")):
+            archive_name = f"data_designer/slurm/runtime/{source_path.name}"
+            _add_archive_file(archive, archive_name, _read_runtime_source(source_path), mode=_SOURCE_MODE)
+    return output.getvalue()
+
+
+def _add_archive_file(archive: tarfile.TarFile, name: str, content: bytes, *, mode: int) -> None:
+    entry = tarfile.TarInfo(name)
+    entry.size = len(content)
+    entry.mode = mode
+    entry.uid = 0
+    entry.gid = 0
+    entry.uname = ""
+    entry.gname = ""
+    entry.mtime = 0
+    archive.addfile(entry, io.BytesIO(content))
+
+
+def _read_runtime_source(path: Path) -> bytes:
+    before = path.lstat()
+    if not stat.S_ISREG(before.st_mode) or before.st_size > _MAXIMUM_SOURCE_SIZE:
+        raise OSError(f"allocation runtime source {path} is not a bounded regular file")
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
+    try:
+        opened = os.fstat(descriptor)
+        if _file_identity(before) != _file_identity(opened):
+            raise OSError(f"allocation runtime source {path} changed while it was opened")
+        chunks: list[bytes] = []
+        content_size = 0
+        while chunk := os.read(descriptor, min(1024 * 1024, _MAXIMUM_SOURCE_SIZE + 1 - content_size)):
+            chunks.append(chunk)
+            content_size += len(chunk)
+            if content_size > _MAXIMUM_SOURCE_SIZE:
+                raise OSError(f"allocation runtime source {path} exceeds its size limit")
+        after = os.fstat(descriptor)
+        if _file_identity(opened) != _file_identity(after):
+            raise OSError(f"allocation runtime source {path} changed while it was read")
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def _ensure_private_runtime_directory(workspace_root: Path, runtime_root: Path) -> None:
+    workspace_status = workspace_root.lstat()
+    if not stat.S_ISDIR(workspace_status.st_mode) or workspace_status.st_mode & 0o022:
+        raise OSError(f"runtime workspace {workspace_root} is not a private directory")
+    runtime_root.mkdir(mode=_DIRECTORY_MODE, exist_ok=True)
+    runtime_status = runtime_root.lstat()
+    if not stat.S_ISDIR(runtime_status.st_mode):
+        raise OSError(f"runtime root {runtime_root} is not a directory")
+    descriptor = os.open(
+        runtime_root,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        opened_status = os.fstat(descriptor)
+        if (runtime_status.st_dev, runtime_status.st_ino) != (opened_status.st_dev, opened_status.st_ino):
+            raise OSError(f"runtime root {runtime_root} changed while it was opened")
+        os.fchmod(descriptor, _DIRECTORY_MODE)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _publish_archive(runtime_root: Path, name: str, content: bytes) -> None:
+    directory_descriptor = os.open(
+        runtime_root,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    temporary_name: str | None = None
+    descriptor: int | None = None
+    try:
+        expected_size = len(content)
+        existing = _read_existing_archive(directory_descriptor, name, expected_size=expected_size)
+        if existing is not None:
+            if existing != content:
+                raise OSError("content-addressed runtime bundle contains different bytes")
+            return
+        for _ in range(100):
+            temporary_name = f".runtime.{secrets.token_hex(8)}.tmp"
+            try:
+                descriptor = os.open(
+                    temporary_name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                    _FILE_MODE,
+                    dir_fd=directory_descriptor,
+                )
+            except FileExistsError:
+                continue
+            break
+        if descriptor is None:
+            raise OSError("cannot allocate a unique runtime bundle temporary name")
+        os.fchmod(descriptor, _FILE_MODE)
+        with os.fdopen(descriptor, "wb") as output:
+            descriptor = None
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        try:
+            os.link(
+                temporary_name,
+                name,
+                src_dir_fd=directory_descriptor,
+                dst_dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileExistsError:
+            if _read_existing_archive(directory_descriptor, name, expected_size=expected_size) != content:
+                raise OSError("content-addressed runtime bundle contains different bytes") from None
+        os.unlink(temporary_name, dir_fd=directory_descriptor)
+        temporary_name = None
+        os.fsync(directory_descriptor)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary_name is not None:
+            with suppress(OSError):
+                os.unlink(temporary_name, dir_fd=directory_descriptor)
+        os.close(directory_descriptor)
+
+
+def _read_existing_archive(directory_descriptor: int, name: str, *, expected_size: int) -> bytes | None:
+    try:
+        before = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 1
+        or before.st_mode & 0o077
+        or before.st_size != expected_size
+    ):
+        raise OSError("runtime bundle is not a restrictive single-link regular file")
+    descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+        dir_fd=directory_descriptor,
+    )
+    try:
+        after_open = os.fstat(descriptor)
+        if _file_identity(before) != _file_identity(after_open):
+            raise OSError("runtime bundle changed while it was opened")
+        with os.fdopen(descriptor, "rb") as existing:
+            descriptor = -1
+            content = existing.read(expected_size + 1)
+            after_read = os.fstat(existing.fileno())
+        if _file_identity(after_open) != _file_identity(after_read):
+            raise OSError("runtime bundle changed while it was read")
+        return content
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _file_identity(status: os.stat_result) -> tuple[int, int, int, int, int]:
+    return status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns, status.st_ctime_ns

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
@@ -26,17 +26,8 @@ _SOURCE_MODE = 0o400
 _MAXIMUM_SOURCE_SIZE = 16 * 1024 * 1024
 _TEMPORARY_NAME_PATTERN = re.compile(r"^\.runtime\.[0-9a-f]{16}\.tmp$")
 _ENTRYPOINT_NAME = "entrypoint.sh"
-_SLURM_PACKAGE_NAME = "data_designer/slurm/__init__.py"
-_RUNTIME_PACKAGE_ROOT = "data_designer/slurm/runtime"
-_SOURCE_MANIFEST_NAME = f"{_RUNTIME_PACKAGE_ROOT}/runtime-sources.txt"
-_SLURM_PACKAGE_SHIM = (
-    b"# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
-    b"# SPDX-License-Identifier: Apache-2.0\n\n"
-    b'"""Runtime-bundle package shim that extends into the installed Slurm package."""\n\n'
-    b"from __future__ import annotations\n\n"
-    b"from pkgutil import extend_path\n\n"
-    b"__path__ = extend_path(__path__, __name__)\n"
-)
+_SLURM_PACKAGE_ROOT = "data_designer/slurm"
+_SOURCE_MANIFEST_NAME = f"{_SLURM_PACKAGE_ROOT}/runtime/slurm-sources.txt"
 _ENTRYPOINT = b"""#!/usr/bin/env bash
 set -Eeuo pipefail
 
@@ -78,14 +69,13 @@ def stage_runtime_bundle(workspace_root: str | Path) -> ArtifactReference:
 
 
 def _build_runtime_archive() -> bytes:
-    sources = _collect_runtime_sources(Path(__file__).parent)
+    sources = _collect_slurm_sources(Path(__file__).parents[1])
     output = io.BytesIO()
     with (
         gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as compressed,
         tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive,
     ):
         _add_archive_file(archive, _ENTRYPOINT_NAME, _ENTRYPOINT, mode=_ENTRYPOINT_MODE)
-        _add_archive_file(archive, _SLURM_PACKAGE_NAME, _SLURM_PACKAGE_SHIM, mode=_SOURCE_MODE)
         manifest = "".join(f"{archive_name}\n" for archive_name, _ in sources).encode()
         _add_archive_file(archive, _SOURCE_MANIFEST_NAME, manifest, mode=_SOURCE_MODE)
         for archive_name, source_path in sources:
@@ -93,13 +83,13 @@ def _build_runtime_archive() -> bytes:
     return output.getvalue()
 
 
-def _collect_runtime_sources(source_root: Path) -> tuple[tuple[str, Path], ...]:
+def _collect_slurm_sources(source_root: Path) -> tuple[tuple[str, Path], ...]:
     relative_sources = sorted(
         (path.relative_to(source_root) for path in source_root.rglob("*.py")),
         key=lambda path: path.as_posix(),
     )
     return tuple(
-        (f"{_RUNTIME_PACKAGE_ROOT}/{relative.as_posix()}", source_root / relative) for relative in relative_sources
+        (f"{_SLURM_PACKAGE_ROOT}/{relative.as_posix()}", source_root / relative) for relative in relative_sources
     )
 
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
@@ -9,6 +9,7 @@ import gzip
 import hashlib
 import io
 import os
+import re
 import secrets
 import stat
 import tarfile
@@ -23,6 +24,7 @@ _FILE_MODE = 0o600
 _ENTRYPOINT_MODE = 0o500
 _SOURCE_MODE = 0o400
 _MAXIMUM_SOURCE_SIZE = 16 * 1024 * 1024
+_TEMPORARY_NAME_PATTERN = re.compile(r"^\.runtime\.[0-9a-f]{16}\.tmp$")
 _ENTRYPOINT_NAME = "entrypoint.sh"
 _SLURM_PACKAGE_NAME = "data_designer/slurm/__init__.py"
 _SLURM_PACKAGE_SHIM = (
@@ -191,7 +193,10 @@ def _publish_archive(runtime_root: Path, name: str, content: bytes) -> None:
         except FileExistsError:
             if _read_existing_archive(directory_descriptor, name, expected_size=expected_size) != content:
                 raise OSError("content-addressed runtime bundle contains different bytes") from None
-        os.unlink(temporary_name, dir_fd=directory_descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=directory_descriptor)
+        except FileNotFoundError:
+            pass
         temporary_name = None
         os.fsync(directory_descriptor)
     finally:
@@ -208,6 +213,7 @@ def _read_existing_archive(directory_descriptor: int, name: str, *, expected_siz
         before = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
     except FileNotFoundError:
         return None
+    before = _repair_interrupted_archive_publication(directory_descriptor, name, before)
     if (
         not stat.S_ISREG(before.st_mode)
         or before.st_nlink != 1
@@ -238,3 +244,40 @@ def _read_existing_archive(directory_descriptor: int, name: str, *, expected_siz
 
 def _file_identity(status: os.stat_result) -> tuple[int, int, int, int, int]:
     return status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns, status.st_ctime_ns
+
+
+def _repair_interrupted_archive_publication(
+    directory_descriptor: int,
+    name: str,
+    status: os.stat_result,
+) -> os.stat_result:
+    if status.st_nlink == 1:
+        return status
+    if not stat.S_ISREG(status.st_mode) or status.st_mode & 0o077 or status.st_nlink != 2:
+        return status
+    matching_names: list[str] = []
+    for candidate in os.listdir(directory_descriptor):
+        if _TEMPORARY_NAME_PATTERN.fullmatch(candidate) is None:
+            continue
+        try:
+            candidate_status = os.stat(candidate, dir_fd=directory_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        if (candidate_status.st_dev, candidate_status.st_ino) == (status.st_dev, status.st_ino):
+            matching_names.append(candidate)
+    if len(matching_names) != 1:
+        return status
+    try:
+        os.unlink(matching_names[0], dir_fd=directory_descriptor)
+        os.fsync(directory_descriptor)
+    except FileNotFoundError:
+        pass
+    repaired = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    if (
+        (repaired.st_dev, repaired.st_ino) != (status.st_dev, status.st_ino)
+        or not stat.S_ISREG(repaired.st_mode)
+        or repaired.st_nlink != 1
+        or repaired.st_mode & 0o077
+    ):
+        raise OSError("runtime bundle changed while recovering interrupted publication")
+    return repaired

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
@@ -67,7 +67,7 @@ def stage_runtime_bundle(workspace_root: str | Path) -> ArtifactReference:
         runtime_root = normalized_workspace / "runtime"
         archive_path = runtime_root / f"{digest}.tar.gz"
         _ensure_private_runtime_directory(normalized_workspace, runtime_root)
-        _publish_archive(runtime_root, archive_path.name, archive)
+        _ArchivePublisher(runtime_root).publish(archive_path.name, archive)
     except OSError as error:
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.PREFLIGHT_FAILED, "cannot stage allocation runtime bundle"
@@ -148,40 +148,68 @@ def _ensure_private_runtime_directory(workspace_root: Path, runtime_root: Path) 
         os.close(descriptor)
 
 
-def _publish_archive(runtime_root: Path, name: str, content: bytes) -> None:
-    directory_descriptor = os.open(
-        runtime_root,
-        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
-    )
-    temporary_name: str | None = None
-    descriptor: int | None = None
-    try:
-        expected_size = len(content)
-        existing = _read_existing_archive(directory_descriptor, name, expected_size=expected_size)
+class _ArchivePublisher:
+    """Own descriptor-bound publication of immutable runtime archives."""
+
+    def __init__(self, runtime_root: Path) -> None:
+        self._runtime_root = runtime_root
+
+    def publish(self, name: str, content: bytes) -> None:
+        """Publish one archive or confirm an identical durable publication."""
+        directory_descriptor = os.open(
+            self._runtime_root,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            self._publish_in_directory(directory_descriptor, name, content)
+        finally:
+            os.close(directory_descriptor)
+
+    def _publish_in_directory(self, directory_descriptor: int, name: str, content: bytes) -> None:
+        existing = _read_existing_archive(directory_descriptor, name, expected_size=len(content))
         if existing is not None:
-            if existing != content:
-                raise OSError("content-addressed runtime bundle contains different bytes")
+            self._accept_existing(directory_descriptor, existing, content)
             return
-        for _ in range(100):
-            temporary_name = f".runtime.{secrets.token_hex(8)}.tmp"
-            try:
-                descriptor = os.open(
-                    temporary_name,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-                    _FILE_MODE,
-                    dir_fd=directory_descriptor,
-                )
-            except FileExistsError:
-                continue
-            break
-        if descriptor is None:
-            raise OSError("cannot allocate a unique runtime bundle temporary name")
-        os.fchmod(descriptor, _FILE_MODE)
-        with os.fdopen(descriptor, "wb") as output:
-            descriptor = None
-            output.write(content)
-            output.flush()
-            os.fsync(output.fileno())
+        temporary_name = self._write_temporary(directory_descriptor, content)
+        try:
+            self._link_or_accept_existing(directory_descriptor, temporary_name, name, content)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary_name, dir_fd=directory_descriptor)
+        os.fsync(directory_descriptor)
+
+    @staticmethod
+    def _accept_existing(directory_descriptor: int, existing: bytes, content: bytes) -> None:
+        if existing != content:
+            raise OSError("content-addressed runtime bundle contains different bytes")
+        os.fsync(directory_descriptor)
+
+    @staticmethod
+    def _write_temporary(directory_descriptor: int, content: bytes) -> str:
+        temporary_name, descriptor = _create_temporary_archive(directory_descriptor)
+        try:
+            os.fchmod(descriptor, _FILE_MODE)
+            with os.fdopen(descriptor, "wb") as output:
+                descriptor = -1
+                output.write(content)
+                output.flush()
+                os.fsync(output.fileno())
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(temporary_name, dir_fd=directory_descriptor)
+            raise
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        return temporary_name
+
+    @staticmethod
+    def _link_or_accept_existing(
+        directory_descriptor: int,
+        temporary_name: str,
+        name: str,
+        content: bytes,
+    ) -> None:
         try:
             os.link(
                 temporary_name,
@@ -191,21 +219,25 @@ def _publish_archive(runtime_root: Path, name: str, content: bytes) -> None:
                 follow_symlinks=False,
             )
         except FileExistsError:
-            if _read_existing_archive(directory_descriptor, name, expected_size=expected_size) != content:
+            existing = _read_existing_archive(directory_descriptor, name, expected_size=len(content))
+            if existing != content:
                 raise OSError("content-addressed runtime bundle contains different bytes") from None
+
+
+def _create_temporary_archive(directory_descriptor: int) -> tuple[str, int]:
+    for _ in range(100):
+        temporary_name = f".runtime.{secrets.token_hex(8)}.tmp"
         try:
-            os.unlink(temporary_name, dir_fd=directory_descriptor)
-        except FileNotFoundError:
-            pass
-        temporary_name = None
-        os.fsync(directory_descriptor)
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
-        if temporary_name is not None:
-            with suppress(OSError):
-                os.unlink(temporary_name, dir_fd=directory_descriptor)
-        os.close(directory_descriptor)
+            descriptor = os.open(
+                temporary_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                _FILE_MODE,
+                dir_fd=directory_descriptor,
+            )
+        except FileExistsError:
+            continue
+        return temporary_name, descriptor
+    raise OSError("cannot allocate a unique runtime bundle temporary name")
 
 
 def _read_existing_archive(directory_descriptor: int, name: str, *, expected_size: int) -> bytes | None:
@@ -214,13 +246,17 @@ def _read_existing_archive(directory_descriptor: int, name: str, *, expected_siz
     except FileNotFoundError:
         return None
     before = _repair_interrupted_archive_publication(directory_descriptor, name, before)
-    if (
-        not stat.S_ISREG(before.st_mode)
-        or before.st_nlink != 1
-        or before.st_mode & 0o077
-        or before.st_size != expected_size
-    ):
+    if not _is_valid_archive_status(before, expected_size):
         raise OSError("runtime bundle is not a restrictive single-link regular file")
+    return _read_bound_archive(directory_descriptor, name, before, expected_size)
+
+
+def _read_bound_archive(
+    directory_descriptor: int,
+    name: str,
+    before: os.stat_result,
+    expected_size: int,
+) -> bytes:
     descriptor = os.open(
         name,
         os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
@@ -240,6 +276,15 @@ def _read_existing_archive(directory_descriptor: int, name: str, *, expected_siz
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+
+
+def _is_valid_archive_status(status: os.stat_result, expected_size: int) -> bool:
+    return (
+        stat.S_ISREG(status.st_mode)
+        and status.st_nlink == 1
+        and not status.st_mode & 0o077
+        and status.st_size == expected_size
+    )
 
 
 def _file_identity(status: os.stat_result) -> tuple[int, int, int, int, int]:
@@ -266,18 +311,13 @@ def _repair_interrupted_archive_publication(
         if (candidate_status.st_dev, candidate_status.st_ino) == (status.st_dev, status.st_ino):
             matching_names.append(candidate)
     if len(matching_names) != 1:
-        return status
+        return os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
     try:
         os.unlink(matching_names[0], dir_fd=directory_descriptor)
         os.fsync(directory_descriptor)
     except FileNotFoundError:
         pass
     repaired = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
-    if (
-        (repaired.st_dev, repaired.st_ino) != (status.st_dev, status.st_ino)
-        or not stat.S_ISREG(repaired.st_mode)
-        or repaired.st_nlink != 1
-        or repaired.st_mode & 0o077
-    ):
+    if not stat.S_ISREG(repaired.st_mode) or repaired.st_nlink != 1 or repaired.st_mode & 0o077:
         raise OSError("runtime bundle changed while recovering interrupted publication")
     return repaired

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/bundle.py
@@ -27,6 +27,8 @@ _MAXIMUM_SOURCE_SIZE = 16 * 1024 * 1024
 _TEMPORARY_NAME_PATTERN = re.compile(r"^\.runtime\.[0-9a-f]{16}\.tmp$")
 _ENTRYPOINT_NAME = "entrypoint.sh"
 _SLURM_PACKAGE_NAME = "data_designer/slurm/__init__.py"
+_RUNTIME_PACKAGE_ROOT = "data_designer/slurm/runtime"
+_SOURCE_MANIFEST_NAME = f"{_RUNTIME_PACKAGE_ROOT}/runtime-sources.txt"
 _SLURM_PACKAGE_SHIM = (
     b"# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
     b"# SPDX-License-Identifier: Apache-2.0\n\n"
@@ -76,6 +78,7 @@ def stage_runtime_bundle(workspace_root: str | Path) -> ArtifactReference:
 
 
 def _build_runtime_archive() -> bytes:
+    sources = _collect_runtime_sources(Path(__file__).parent)
     output = io.BytesIO()
     with (
         gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as compressed,
@@ -83,11 +86,21 @@ def _build_runtime_archive() -> bytes:
     ):
         _add_archive_file(archive, _ENTRYPOINT_NAME, _ENTRYPOINT, mode=_ENTRYPOINT_MODE)
         _add_archive_file(archive, _SLURM_PACKAGE_NAME, _SLURM_PACKAGE_SHIM, mode=_SOURCE_MODE)
-        source_root = Path(__file__).parent
-        for source_path in sorted(source_root.glob("*.py")):
-            archive_name = f"data_designer/slurm/runtime/{source_path.name}"
+        manifest = "".join(f"{archive_name}\n" for archive_name, _ in sources).encode()
+        _add_archive_file(archive, _SOURCE_MANIFEST_NAME, manifest, mode=_SOURCE_MODE)
+        for archive_name, source_path in sources:
             _add_archive_file(archive, archive_name, _read_runtime_source(source_path), mode=_SOURCE_MODE)
     return output.getvalue()
+
+
+def _collect_runtime_sources(source_root: Path) -> tuple[tuple[str, Path], ...]:
+    relative_sources = sorted(
+        (path.relative_to(source_root) for path in source_root.rglob("*.py")),
+        key=lambda path: path.as_posix(),
+    )
+    return tuple(
+        (f"{_RUNTIME_PACKAGE_ROOT}/{relative.as_posix()}", source_root / relative) for relative in relative_sources
+    )
 
 
 def _add_archive_file(archive: tarfile.TarFile, name: str, content: bytes, *, mode: int) -> None:

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -14,6 +14,7 @@ from typing import Protocol
 
 from data_designer.slurm.contracts import ArtifactReference
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.logs import bind_execution_logs, execution_log_directory
 from data_designer.slurm.runtime.models import AllocationContext, RuntimeEndpoint, RuntimeStep
 from data_designer.slurm.runtime.preflight import AllocationPreflight
 from data_designer.slurm.runtime.probes import ReadinessProber
@@ -41,6 +42,7 @@ from data_designer.slurm.state import (
 
 _READINESS_PROGRESS = {
     ReadinessState.PENDING: 0,
+    ReadinessState.RESTARTING: 0,
     ReadinessState.STARTING: 1,
     ReadinessState.READY: 2,
 }
@@ -120,6 +122,7 @@ class OneNodeAllocationController:
         self._attempt = context.attempt
         self._readiness: AttemptReadiness | None = None
         self._statuses: list[_DeploymentStatus] = []
+        self._log_directory: Path | None = None
 
     def run(self) -> AttemptManifest:
         """Run the allocation and persist one terminal attempt on every owned path."""
@@ -200,37 +203,59 @@ class OneNodeAllocationController:
         return self._run_client(topology.endpoints, required_processes)
 
     def _prepare_runtime(self) -> _RuntimeTopology:
-        self._preflight.verify(self._context, self._environment)
         self._validate_attempt_state()
-        self._mark_attempt_running()
         deployments = tuple(
             resolve_vllm_server(self._context.plan, deployment.deployment_id)
             for deployment in self._context.plan.deployments
         )
-        self._statuses = self._initialize_statuses(deployments)
-        self._publish_readiness(ReadinessState.PENDING)
-        endpoint_steps = build_endpoint_steps(
-            deployments,
-            self._context.plan,
-            self._context.attempt_directory,
-            self._environment,
-            self._runtime_proxy_path,
+        restarting = self._readiness is not None
+        if restarting:
+            self._begin_execution(deployments, ReadinessState.RESTARTING)
+        self._preflight.verify(self._context, self._environment)
+        self._mark_attempt_running()
+        if not restarting:
+            self._begin_execution(deployments, ReadinessState.PENDING)
+        endpoint_steps = tuple(
+            (self._bind_logs(step), endpoint)
+            for step, endpoint in build_endpoint_steps(
+                deployments,
+                self._context.plan,
+                self._context.attempt_directory,
+                self._environment,
+                self._runtime_proxy_path,
+            )
         )
         endpoints = tuple(endpoint for _, endpoint in endpoint_steps)
-        client_preflight = self._client_steps.build_preflight_step(
-            self._context.plan,
-            self._context.shard,
-            self._attempt,
-            self._context.attempt_directory,
-            endpoints,
-            self._environment,
+        client_preflight = self._bind_logs(
+            self._client_steps.build_preflight_step(
+                self._context.plan,
+                self._context.shard,
+                self._attempt,
+                self._context.attempt_directory,
+                endpoints,
+                self._environment,
+            )
         )
         self._supervisor.wait(self._supervisor.start(client_preflight))
         return _RuntimeTopology(deployments, endpoint_steps, endpoints)
 
+    def _begin_execution(
+        self,
+        deployments: tuple[ResolvedVllmServerDeployment, ...],
+        state: ReadinessState,
+    ) -> None:
+        self._statuses = [_DeploymentStatus(deployment, state=state) for deployment in deployments]
+        self._publish_readiness(state)
+        if self._readiness is None:  # pragma: no cover - persistence returns the published snapshot
+            raise AssertionError("runtime readiness was not published")
+        self._log_directory = execution_log_directory(
+            self._context.attempt_directory,
+            self._readiness.revision,
+        )
+
     def _start_runtime(self, topology: _RuntimeTopology) -> tuple[ManagedStep, ...]:
         for status in self._statuses:
-            if status.state is ReadinessState.PENDING:
+            if status.state in {ReadinessState.PENDING, ReadinessState.RESTARTING}:
                 status.state = ReadinessState.STARTING
         self._publish_readiness(ReadinessState.STARTING)
         server_processes = self._start_servers(topology.deployments)
@@ -252,13 +277,15 @@ class OneNodeAllocationController:
         endpoints: tuple[RuntimeEndpoint, ...],
         required_processes: tuple[ManagedStep, ...],
     ) -> tuple[ArtifactReference, datetime]:
-        generation = self._client_steps.build_generation_step(
-            self._context.plan,
-            self._context.shard,
-            self._attempt,
-            self._context.attempt_directory,
-            endpoints,
-            self._environment,
+        generation = self._bind_logs(
+            self._client_steps.build_generation_step(
+                self._context.plan,
+                self._context.shard,
+                self._attempt,
+                self._context.attempt_directory,
+                endpoints,
+                self._environment,
+            )
         )
         generation_started_at = self._now()
         self._supervisor.wait(self._supervisor.start(generation), required=required_processes)
@@ -315,31 +342,6 @@ class OneNodeAllocationController:
             )
         self._readiness = readiness
 
-    def _initialize_statuses(
-        self,
-        deployments: tuple[ResolvedVllmServerDeployment, ...],
-    ) -> list[_DeploymentStatus]:
-        if self._readiness is None:
-            return [_DeploymentStatus(deployment) for deployment in deployments]
-        readiness_by_id = {deployment.deployment_id: deployment for deployment in self._readiness.deployments}
-        return [
-            self._restore_deployment_status(deployment, readiness_by_id[deployment.deployment_id])
-            for deployment in deployments
-        ]
-
-    @staticmethod
-    def _restore_deployment_status(
-        deployment: ResolvedVllmServerDeployment,
-        readiness: DeploymentReadiness,
-    ) -> _DeploymentStatus:
-        return _DeploymentStatus(
-            deployment=deployment,
-            state=readiness.state,
-            ready_backends=readiness.ready_backends,
-            endpoint_publication=readiness.endpoint_publication,
-            last_probe=readiness.last_probe,
-        )
-
     def _mark_attempt_running(self) -> None:
         if self._attempt.state is AttemptLifecycleState.RUNNING:
             return
@@ -358,11 +360,14 @@ class OneNodeAllocationController:
         for deployment in deployments:
             started_at = self._clock.monotonic()
             managed: list[ManagedStep] = []
-            steps = build_vllm_steps(
-                deployment,
-                self._context.plan,
-                self._context.attempt_directory,
-                self._environment,
+            steps = tuple(
+                self._bind_logs(step)
+                for step in build_vllm_steps(
+                    deployment,
+                    self._context.plan,
+                    self._context.attempt_directory,
+                    self._environment,
+                )
             )
             for process, step in zip(deployment.processes, steps, strict=True):
                 self._supervisor.require_running(tuple(managed))
@@ -551,6 +556,11 @@ class OneNodeAllocationController:
             raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime clock moved backward")
         return value
 
+    def _bind_logs(self, step: RuntimeStep) -> RuntimeStep:
+        if self._log_directory is None:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime log directory is unavailable")
+        return bind_execution_logs(step, self._log_directory)
+
 
 def _copy_attempt(attempt: AttemptManifest, **updates: object) -> AttemptManifest:
     payload = attempt.model_dump(mode="python")
@@ -573,6 +583,8 @@ def _probe_evidence(
 
 
 def _can_advance_readiness(previous: ReadinessState, current: ReadinessState) -> bool:
+    if current is ReadinessState.RESTARTING:
+        return previous not in {ReadinessState.FAILED, ReadinessState.STOPPED}
     previous_progress = _READINESS_PROGRESS.get(previous)
     current_progress = _READINESS_PROGRESS.get(current)
     if previous_progress is None or current_progress is None:

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -232,7 +232,6 @@ class OneNodeAllocationController:
         if self._attempt.state not in {
             AttemptLifecycleState.SUBMITTED,
             AttemptLifecycleState.PENDING,
-            AttemptLifecycleState.RUNNING,
         }:
             raise SlurmRuntimeError(
                 SlurmRuntimeErrorCode.INVALID_CONTEXT,

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -1,0 +1,471 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One-node allocation orchestration with one process and cleanup owner."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Protocol
+
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import AllocationContext, RuntimeEndpoint
+from data_designer.slurm.runtime.preflight import AllocationPreflight
+from data_designer.slurm.runtime.probes import ReadinessProber
+from data_designer.slurm.runtime.records import load_complete_client_candidate
+from data_designer.slurm.runtime.steps import (
+    ClientStepBuilder,
+    build_endpoint_steps,
+    build_vllm_steps,
+)
+from data_designer.slurm.runtime.supervisor import ManagedStep, RuntimeClock, StepSupervisor
+from data_designer.slurm.serving.deployment import ResolvedVllmServerDeployment
+from data_designer.slurm.serving.resolver import resolve_vllm_server
+from data_designer.slurm.state import (
+    AttemptLifecycleState,
+    AttemptManifest,
+    AttemptReadiness,
+    AttemptTerminalClassification,
+    DeploymentReadiness,
+    EndpointPublicationState,
+    ProbeEvidence,
+    ProbeOutcome,
+    ReadinessState,
+)
+
+
+class RuntimeStateStore(Protocol):
+    """State-writer operations required by one allocation."""
+
+    def update_attempt(self, attempt: AttemptManifest) -> AttemptManifest:
+        """Persist a monotonic attempt update."""
+        ...
+
+    def write_readiness(self, readiness: AttemptReadiness) -> AttemptReadiness:
+        """Persist the exact next readiness revision."""
+        ...
+
+
+@dataclass(slots=True)
+class _DeploymentStatus:
+    deployment: ResolvedVllmServerDeployment
+    state: ReadinessState = ReadinessState.PENDING
+    ready_backends: int = 0
+    endpoint_publication: EndpointPublicationState = EndpointPublicationState.PENDING
+    last_probe: ProbeEvidence | None = None
+
+
+class OneNodeAllocationController:
+    """Execute one planned shard attempt and finalize only complete candidates."""
+
+    def __init__(
+        self,
+        context: AllocationContext,
+        *,
+        runtime_proxy_path: Path,
+        state: RuntimeStateStore,
+        supervisor: StepSupervisor,
+        preflight: AllocationPreflight,
+        client_steps: ClientStepBuilder,
+        prober: ReadinessProber,
+        clock: RuntimeClock,
+        environment: Mapping[str, str],
+        poll_interval_seconds: float = 0.5,
+        probe_timeout_seconds: float = 1.0,
+    ) -> None:
+        if poll_interval_seconds <= 0 or probe_timeout_seconds <= 0:
+            raise ValueError("runtime probe intervals must be positive")
+        self._context = context
+        self._runtime_proxy_path = runtime_proxy_path
+        self._state = state
+        self._supervisor = supervisor
+        self._preflight = preflight
+        self._client_steps = client_steps
+        self._prober = prober
+        self._clock = clock
+        self._environment = environment
+        self._poll_interval_seconds = poll_interval_seconds
+        self._probe_timeout_seconds = probe_timeout_seconds
+        self._attempt = context.attempt
+        self._readiness: AttemptReadiness | None = None
+        self._statuses: list[_DeploymentStatus] = []
+
+    def run(self) -> AttemptManifest:
+        """Run the allocation and persist one terminal attempt on every owned path."""
+        failure: SlurmRuntimeError | None = None
+        failure_cause: BaseException | None = None
+        candidate_reference: ArtifactReference | None = None
+        client_completed_at: datetime | None = None
+        try:
+            candidate_reference, client_completed_at = self._execute()
+        except BaseException as error:
+            failure, failure_cause = _normalize_failure(error), error
+
+        if failure is not None:
+            failure = self._record_failed_readiness(failure)
+        try:
+            self._supervisor.cleanup()
+        except BaseException as error:
+            if failure is None:
+                failure, failure_cause = _normalize_failure(error), error
+                failure = self._record_failed_readiness(failure)
+            else:
+                failure.add_note(f"cleanup also failed: {type(error).__name__}")
+        if self._readiness is not None:
+            try:
+                self._publish_stopped_readiness()
+            except BaseException as error:
+                if failure is None:
+                    failure, failure_cause = _normalize_failure(error), error
+                else:
+                    failure.add_note(f"stopped readiness could not be persisted: {type(error).__name__}")
+        try:
+            terminal = self._publish_terminal_attempt(
+                failure=failure,
+                candidate_reference=candidate_reference,
+                client_completed_at=client_completed_at,
+            )
+        except BaseException as error:
+            terminal_failure = _normalize_failure(error)
+            if failure is None:
+                failure, failure_cause = terminal_failure, error
+                try:
+                    terminal = self._publish_terminal_attempt(
+                        failure=failure,
+                        candidate_reference=None,
+                        client_completed_at=None,
+                    )
+                except BaseException as retry_error:
+                    failure.add_note(f"failed terminal attempt could not be persisted: {type(retry_error).__name__}")
+                    terminal = self._attempt
+            else:
+                failure.add_note(f"terminal attempt could not be persisted: {type(error).__name__}")
+                terminal = self._attempt
+        if failure is not None:
+            if failure_cause is failure:
+                raise failure
+            raise failure from failure_cause
+        return terminal
+
+    def _execute(self) -> tuple[ArtifactReference, datetime]:
+        self._preflight.verify(self._context, self._environment)
+        self._validate_attempt_state()
+        self._mark_attempt_running()
+        deployments = tuple(
+            resolve_vllm_server(self._context.plan, deployment.deployment_id)
+            for deployment in self._context.plan.deployments
+        )
+        self._statuses = [_DeploymentStatus(deployment) for deployment in deployments]
+        self._publish_readiness(ReadinessState.PENDING)
+
+        endpoint_steps = build_endpoint_steps(
+            deployments,
+            self._context.plan,
+            self._context.attempt_directory,
+            self._environment,
+            self._runtime_proxy_path,
+        )
+        endpoints = tuple(endpoint for _, endpoint in endpoint_steps)
+        client_preflight = self._client_steps.build_preflight_step(
+            self._context.plan,
+            self._context.shard,
+            self._attempt,
+            self._context.attempt_directory,
+            endpoints,
+            self._environment,
+        )
+        self._supervisor.wait(self._supervisor.start(client_preflight))
+
+        for status in self._statuses:
+            status.state = ReadinessState.STARTING
+        self._publish_readiness(ReadinessState.STARTING)
+        server_processes = self._start_servers(deployments)
+        for status, required in zip(self._statuses, server_processes, strict=True):
+            self._wait_for_backends(status, required)
+        self._publish_readiness(ReadinessState.STARTING)
+
+        endpoint_processes = tuple(self._supervisor.start(step) for step, _ in endpoint_steps)
+        required_processes = tuple(process for group in server_processes for process in group) + endpoint_processes
+        self._wait_for_endpoints(endpoints, required_processes)
+        for status in self._statuses:
+            status.state = ReadinessState.READY
+            status.endpoint_publication = EndpointPublicationState.PUBLISHED
+            status.last_probe = _probe_evidence(self._now(), ProbeOutcome.SUCCESS, "endpoint_ready", "endpoint ready")
+        self._publish_readiness(ReadinessState.READY)
+
+        generation = self._client_steps.build_generation_step(
+            self._context.plan,
+            self._context.shard,
+            self._attempt,
+            self._context.attempt_directory,
+            endpoints,
+            self._environment,
+        )
+        generation_started_at = self._now()
+        self._supervisor.wait(self._supervisor.start(generation), required=required_processes)
+        self._supervisor.require_running(required_processes)
+        client_result, candidate = load_complete_client_candidate(self._context)
+        if candidate.created_at < generation_started_at or client_result.completed_at < generation_started_at:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                "client result predates the current generation step",
+            )
+        if client_result.completed_at > self._now():
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                "client completion timestamp is later than the allocation clock",
+            )
+        candidate_reference = client_result.candidate_output_manifest
+        if candidate_reference is None:  # pragma: no cover - the record contract requires this for complete results
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                "complete client result has no candidate reference",
+            )
+        return candidate_reference, client_result.completed_at
+
+    def _validate_attempt_state(self) -> None:
+        if self._attempt.state not in {
+            AttemptLifecycleState.SUBMITTED,
+            AttemptLifecycleState.PENDING,
+            AttemptLifecycleState.RUNNING,
+        }:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "allocation attempt is not executable",
+            )
+
+    def _mark_attempt_running(self) -> None:
+        if self._attempt.state is AttemptLifecycleState.RUNNING:
+            return
+        self._attempt = _copy_attempt(
+            self._attempt,
+            state=AttemptLifecycleState.RUNNING,
+            updated_at=self._now(),
+        )
+        self._attempt = self._state.update_attempt(self._attempt)
+
+    def _start_servers(
+        self,
+        deployments: tuple[ResolvedVllmServerDeployment, ...],
+    ) -> tuple[tuple[ManagedStep, ...], ...]:
+        all_managed: list[tuple[ManagedStep, ...]] = []
+        for deployment in deployments:
+            started_at = self._clock.monotonic()
+            managed: list[ManagedStep] = []
+            steps = build_vllm_steps(
+                deployment,
+                self._context.plan,
+                self._context.attempt_directory,
+                self._environment,
+            )
+            for process, step in zip(deployment.processes, steps, strict=True):
+                self._supervisor.require_running(tuple(managed))
+                remaining_delay = process.launch_delay_seconds - (self._clock.monotonic() - started_at)
+                if remaining_delay > 0:
+                    self._clock.sleep(remaining_delay)
+                managed.append(self._supervisor.start(step))
+            all_managed.append(tuple(managed))
+        return tuple(all_managed)
+
+    def _wait_for_backends(self, status: _DeploymentStatus, required: tuple[ManagedStep, ...]) -> None:
+        probes = status.deployment.readiness_probes
+        deadline = self._clock.monotonic() + max(probe.deadline_seconds for probe in probes)
+        previous_ready = -1
+        while True:
+            self._supervisor.require_running(required)
+            ready = sum(
+                self._prober.is_ready(
+                    "127.0.0.1",
+                    probe.port,
+                    probe.path,
+                    timeout_seconds=self._probe_timeout_seconds,
+                )
+                for probe in probes
+            )
+            if ready != previous_ready:
+                status.ready_backends = ready
+                status.last_probe = _probe_evidence(
+                    self._now(),
+                    ProbeOutcome.SUCCESS if ready == len(probes) else ProbeOutcome.FAILURE,
+                    "backend_ready" if ready == len(probes) else "backend_starting",
+                    f"{ready} of {len(probes)} backends ready",
+                )
+                self._publish_readiness(ReadinessState.STARTING)
+                previous_ready = ready
+            if ready == len(probes):
+                return
+            if self._clock.monotonic() >= deadline:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.READINESS_TIMEOUT,
+                    f"deployment {status.deployment.deployment_id!r} readiness timed out",
+                )
+            self._clock.sleep(self._poll_interval_seconds)
+
+    def _wait_for_endpoints(
+        self,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        required: tuple[ManagedStep, ...],
+    ) -> None:
+        timeout = max(status.deployment.launch_policy.startup_timeout_seconds for status in self._statuses)
+        deadline = self._clock.monotonic() + timeout
+        while True:
+            self._supervisor.require_running(required)
+            if all(
+                self._prober.is_ready(
+                    endpoint.host,
+                    endpoint.port,
+                    "/health",
+                    timeout_seconds=self._probe_timeout_seconds,
+                )
+                for endpoint in endpoints
+            ):
+                return
+            if self._clock.monotonic() >= deadline:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.READINESS_TIMEOUT,
+                    "logical endpoint readiness timed out",
+                )
+            self._clock.sleep(self._poll_interval_seconds)
+
+    def _publish_readiness(self, state: ReadinessState) -> None:
+        revision = 1 if self._readiness is None else self._readiness.revision + 1
+        readiness = AttemptReadiness(
+            schema_version=1,
+            run_id=self._attempt.run_id,
+            shard_id=self._attempt.shard_id,
+            attempt_id=self._attempt.attempt_id,
+            revision=revision,
+            updated_at=self._now(),
+            state=state,
+            deployments=tuple(
+                DeploymentReadiness(
+                    deployment_id=status.deployment.deployment_id,
+                    model_alias=status.deployment.model_alias,
+                    state=status.state,
+                    expected_backends=len(status.deployment.backend_endpoints),
+                    ready_backends=status.ready_backends,
+                    endpoint_publication=status.endpoint_publication,
+                    last_probe=status.last_probe,
+                )
+                for status in self._statuses
+            ),
+        )
+        self._readiness = self._state.write_readiness(readiness)
+
+    def _record_failed_readiness(self, failure: SlurmRuntimeError) -> SlurmRuntimeError:
+        if self._readiness is None:
+            return failure
+        try:
+            for status in self._statuses:
+                status.state = ReadinessState.FAILED
+                status.ready_backends = 0
+                if status.endpoint_publication is EndpointPublicationState.PENDING:
+                    status.endpoint_publication = EndpointPublicationState.FAILED
+                status.last_probe = _probe_evidence(
+                    self._now(),
+                    ProbeOutcome.FAILURE,
+                    failure.code.value,
+                    "allocation runtime failed",
+                )
+            self._publish_readiness(ReadinessState.FAILED)
+        except Exception as error:
+            failure.add_note(f"failed readiness could not be persisted: {type(error).__name__}")
+        return failure
+
+    def _publish_stopped_readiness(self) -> None:
+        for status in self._statuses:
+            status.state = ReadinessState.STOPPED
+            status.ready_backends = 0
+            status.last_probe = _probe_evidence(
+                self._now(),
+                ProbeOutcome.SUCCESS,
+                "runtime_stopped",
+                "allocation processes stopped",
+            )
+        self._publish_readiness(ReadinessState.STOPPED)
+
+    def _publish_terminal_attempt(
+        self,
+        *,
+        failure: SlurmRuntimeError | None,
+        candidate_reference: ArtifactReference | None,
+        client_completed_at: datetime | None,
+    ) -> AttemptManifest:
+        timestamp = self._now()
+        if client_completed_at is not None and client_completed_at > timestamp:
+            timestamp = client_completed_at
+        if failure is None:
+            if candidate_reference is None:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                    "successful allocation has no candidate reference",
+                )
+            terminal = _copy_attempt(
+                self._attempt,
+                state=AttemptLifecycleState.SUCCEEDED,
+                terminal_classification=AttemptTerminalClassification.SUCCEEDED,
+                candidate_output=candidate_reference,
+                updated_at=timestamp,
+            )
+        else:
+            terminal = _copy_attempt(
+                self._attempt,
+                state=AttemptLifecycleState.FAILED,
+                terminal_classification=AttemptTerminalClassification.FAILED,
+                candidate_output=None,
+                updated_at=timestamp,
+            )
+        self._attempt = self._state.update_attempt(terminal)
+        return self._attempt
+
+    def _now(self) -> datetime:
+        value = self._clock.now()
+        if value.tzinfo is None or value.utcoffset() != timedelta(0):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime clock is not UTC")
+        minimum = self._attempt.updated_at
+        if self._readiness is not None and self._readiness.updated_at > minimum:
+            minimum = self._readiness.updated_at
+        if value < minimum:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime clock moved backward")
+        return value
+
+
+def _copy_attempt(attempt: AttemptManifest, **updates: object) -> AttemptManifest:
+    payload = attempt.model_dump(mode="python")
+    payload.update(updates)
+    return AttemptManifest.model_validate(payload)
+
+
+def _probe_evidence(
+    observed_at: datetime,
+    outcome: ProbeOutcome,
+    reason_code: str,
+    message: str,
+) -> ProbeEvidence:
+    return ProbeEvidence(
+        observed_at=observed_at,
+        outcome=outcome,
+        reason_code=reason_code,
+        redacted_message=message,
+    )
+
+
+def _normalize_failure(error: BaseException) -> SlurmRuntimeError:
+    if isinstance(error, SlurmRuntimeError):
+        return error
+    if isinstance(error, (OSError, subprocess.SubprocessError)):
+        return SlurmRuntimeError(SlurmRuntimeErrorCode.STEP_FAILED, "allocation process operation failed")
+    if isinstance(error, KeyboardInterrupt):
+        return SlurmRuntimeError(SlurmRuntimeErrorCode.CLIENT_FAILED, "allocation execution was interrupted")
+    return SlurmRuntimeError(
+        SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+        "allocation runtime failed at an internal boundary",
+    )
+
+
+__all__ = ["OneNodeAllocationController", "RuntimeStateStore"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -14,7 +14,7 @@ from typing import Protocol
 
 from data_designer.slurm.contracts import ArtifactReference
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
-from data_designer.slurm.runtime.models import AllocationContext, RuntimeEndpoint
+from data_designer.slurm.runtime.models import AllocationContext, RuntimeEndpoint, RuntimeStep
 from data_designer.slurm.runtime.preflight import AllocationPreflight
 from data_designer.slurm.runtime.probes import ReadinessProber
 from data_designer.slurm.runtime.records import load_complete_client_candidate
@@ -60,6 +60,21 @@ class _DeploymentStatus:
     last_probe: ProbeEvidence | None = None
 
 
+@dataclass(slots=True)
+class _RunOutcome:
+    candidate_reference: ArtifactReference | None = None
+    client_completed_at: datetime | None = None
+    failure: SlurmRuntimeError | None = None
+    failure_cause: BaseException | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeTopology:
+    deployments: tuple[ResolvedVllmServerDeployment, ...]
+    endpoint_steps: tuple[tuple[RuntimeStep, RuntimeEndpoint], ...]
+    endpoints: tuple[RuntimeEndpoint, ...]
+
+
 class OneNodeAllocationController:
     """Execute one planned shard attempt and finalize only complete candidates."""
 
@@ -97,62 +112,83 @@ class OneNodeAllocationController:
 
     def run(self) -> AttemptManifest:
         """Run the allocation and persist one terminal attempt on every owned path."""
-        failure: SlurmRuntimeError | None = None
-        failure_cause: BaseException | None = None
-        candidate_reference: ArtifactReference | None = None
-        client_completed_at: datetime | None = None
-        try:
-            candidate_reference, client_completed_at = self._execute()
-        except BaseException as error:
-            failure, failure_cause = _normalize_failure(error), error
+        outcome = self._capture_execution()
+        self._record_outcome_failure(outcome)
+        self._cleanup_runtime(outcome)
+        self._record_stopped_readiness(outcome)
+        terminal = self._persist_terminal_outcome(outcome)
+        if outcome.failure is not None:
+            if outcome.failure_cause is outcome.failure:
+                raise outcome.failure
+            raise outcome.failure from outcome.failure_cause
+        return terminal
 
-        if failure is not None:
-            failure = self._record_failed_readiness(failure)
+    def _capture_execution(self) -> _RunOutcome:
+        try:
+            candidate_reference, completed_at = self._execute()
+            return _RunOutcome(candidate_reference=candidate_reference, client_completed_at=completed_at)
+        except BaseException as error:
+            return _RunOutcome(failure=_normalize_failure(error), failure_cause=error)
+
+    def _record_outcome_failure(self, outcome: _RunOutcome) -> None:
+        if outcome.failure is not None:
+            outcome.failure = self._record_failed_readiness(outcome.failure)
+
+    def _cleanup_runtime(self, outcome: _RunOutcome) -> None:
         try:
             self._supervisor.cleanup()
         except BaseException as error:
-            if failure is None:
-                failure, failure_cause = _normalize_failure(error), error
-                failure = self._record_failed_readiness(failure)
+            if outcome.failure is None:
+                outcome.failure = _normalize_failure(error)
+                outcome.failure_cause = error
+                outcome.failure = self._record_failed_readiness(outcome.failure)
             else:
-                failure.add_note(f"cleanup also failed: {type(error).__name__}")
-        if self._readiness is not None:
-            try:
-                self._publish_stopped_readiness()
-            except BaseException as error:
-                if failure is None:
-                    failure, failure_cause = _normalize_failure(error), error
-                else:
-                    failure.add_note(f"stopped readiness could not be persisted: {type(error).__name__}")
+                outcome.failure.add_note(f"cleanup also failed: {type(error).__name__}")
+
+    def _record_stopped_readiness(self, outcome: _RunOutcome) -> None:
+        if self._readiness is None or not self._supervisor.cleanup_complete:
+            return
         try:
-            terminal = self._publish_terminal_attempt(
-                failure=failure,
-                candidate_reference=candidate_reference,
-                client_completed_at=client_completed_at,
+            self._publish_stopped_readiness()
+        except BaseException as error:
+            if outcome.failure is None:
+                outcome.failure = _normalize_failure(error)
+                outcome.failure_cause = error
+            else:
+                outcome.failure.add_note(f"stopped readiness could not be persisted: {type(error).__name__}")
+
+    def _persist_terminal_outcome(self, outcome: _RunOutcome) -> AttemptManifest:
+        try:
+            return self._publish_terminal_attempt(
+                failure=outcome.failure,
+                candidate_reference=outcome.candidate_reference,
+                client_completed_at=outcome.client_completed_at,
             )
         except BaseException as error:
             terminal_failure = _normalize_failure(error)
-            if failure is None:
-                failure, failure_cause = terminal_failure, error
+            if outcome.failure is None:
+                outcome.failure = terminal_failure
+                outcome.failure_cause = error
                 try:
-                    terminal = self._publish_terminal_attempt(
-                        failure=failure,
+                    return self._publish_terminal_attempt(
+                        failure=outcome.failure,
                         candidate_reference=None,
                         client_completed_at=None,
                     )
                 except BaseException as retry_error:
-                    failure.add_note(f"failed terminal attempt could not be persisted: {type(retry_error).__name__}")
-                    terminal = self._attempt
-            else:
-                failure.add_note(f"terminal attempt could not be persisted: {type(error).__name__}")
-                terminal = self._attempt
-        if failure is not None:
-            if failure_cause is failure:
-                raise failure
-            raise failure from failure_cause
-        return terminal
+                    outcome.failure.add_note(
+                        f"failed terminal attempt could not be persisted: {type(retry_error).__name__}"
+                    )
+                    return self._attempt
+            outcome.failure.add_note(f"terminal attempt could not be persisted: {type(error).__name__}")
+            return self._attempt
 
     def _execute(self) -> tuple[ArtifactReference, datetime]:
+        topology = self._prepare_runtime()
+        required_processes = self._start_runtime(topology)
+        return self._run_client(topology.endpoints, required_processes)
+
+    def _prepare_runtime(self) -> _RuntimeTopology:
         self._preflight.verify(self._context, self._environment)
         self._validate_attempt_state()
         self._mark_attempt_running()
@@ -162,7 +198,6 @@ class OneNodeAllocationController:
         )
         self._statuses = [_DeploymentStatus(deployment) for deployment in deployments]
         self._publish_readiness(ReadinessState.PENDING)
-
         endpoint_steps = build_endpoint_steps(
             deployments,
             self._context.plan,
@@ -180,24 +215,31 @@ class OneNodeAllocationController:
             self._environment,
         )
         self._supervisor.wait(self._supervisor.start(client_preflight))
+        return _RuntimeTopology(deployments, endpoint_steps, endpoints)
 
+    def _start_runtime(self, topology: _RuntimeTopology) -> tuple[ManagedStep, ...]:
         for status in self._statuses:
             status.state = ReadinessState.STARTING
         self._publish_readiness(ReadinessState.STARTING)
-        server_processes = self._start_servers(deployments)
+        server_processes = self._start_servers(topology.deployments)
         for status, required in zip(self._statuses, server_processes, strict=True):
             self._wait_for_backends(status, required)
         self._publish_readiness(ReadinessState.STARTING)
-
-        endpoint_processes = tuple(self._supervisor.start(step) for step, _ in endpoint_steps)
+        endpoint_processes = tuple(self._supervisor.start(step) for step, _ in topology.endpoint_steps)
         required_processes = tuple(process for group in server_processes for process in group) + endpoint_processes
-        self._wait_for_endpoints(endpoints, required_processes)
+        self._wait_for_endpoints(topology.endpoints, required_processes)
         for status in self._statuses:
             status.state = ReadinessState.READY
             status.endpoint_publication = EndpointPublicationState.PUBLISHED
             status.last_probe = _probe_evidence(self._now(), ProbeOutcome.SUCCESS, "endpoint_ready", "endpoint ready")
         self._publish_readiness(ReadinessState.READY)
+        return required_processes
 
+    def _run_client(
+        self,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        required_processes: tuple[ManagedStep, ...],
+    ) -> tuple[ArtifactReference, datetime]:
         generation = self._client_steps.build_generation_step(
             self._context.plan,
             self._context.shard,
@@ -210,16 +252,7 @@ class OneNodeAllocationController:
         self._supervisor.wait(self._supervisor.start(generation), required=required_processes)
         self._supervisor.require_running(required_processes)
         client_result, candidate = load_complete_client_candidate(self._context)
-        if candidate.created_at < generation_started_at or client_result.completed_at < generation_started_at:
-            raise SlurmRuntimeError(
-                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-                "client result predates the current generation step",
-            )
-        if client_result.completed_at > self._now():
-            raise SlurmRuntimeError(
-                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-                "client completion timestamp is later than the allocation clock",
-            )
+        self._validate_client_timestamps(candidate.created_at, client_result.completed_at, generation_started_at)
         candidate_reference = client_result.candidate_output_manifest
         if candidate_reference is None:  # pragma: no cover - the record contract requires this for complete results
             raise SlurmRuntimeError(
@@ -227,6 +260,23 @@ class OneNodeAllocationController:
                 "complete client result has no candidate reference",
             )
         return candidate_reference, client_result.completed_at
+
+    def _validate_client_timestamps(
+        self,
+        candidate_created_at: datetime,
+        client_completed_at: datetime,
+        generation_started_at: datetime,
+    ) -> None:
+        if candidate_created_at < generation_started_at or client_completed_at < generation_started_at:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                "client result predates the current generation step",
+            )
+        if client_completed_at > self._now():
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+                "client completion timestamp is later than the allocation clock",
+            )
 
     def _validate_attempt_state(self) -> None:
         if self._attempt.state not in {
@@ -287,14 +337,7 @@ class OneNodeAllocationController:
                 for probe in probes
             )
             if ready != previous_ready:
-                status.ready_backends = ready
-                status.last_probe = _probe_evidence(
-                    self._now(),
-                    ProbeOutcome.SUCCESS if ready == len(probes) else ProbeOutcome.FAILURE,
-                    "backend_ready" if ready == len(probes) else "backend_starting",
-                    f"{ready} of {len(probes)} backends ready",
-                )
-                self._publish_readiness(ReadinessState.STARTING)
+                self._record_backend_probe(status, ready, len(probes))
                 previous_ready = ready
             if ready == len(probes):
                 return
@@ -304,6 +347,16 @@ class OneNodeAllocationController:
                     f"deployment {status.deployment.deployment_id!r} readiness timed out",
                 )
             self._clock.sleep(self._poll_interval_seconds)
+
+    def _record_backend_probe(self, status: _DeploymentStatus, ready: int, expected: int) -> None:
+        status.ready_backends = ready
+        status.last_probe = _probe_evidence(
+            self._now(),
+            ProbeOutcome.SUCCESS if ready == expected else ProbeOutcome.FAILURE,
+            "backend_ready" if ready == expected else "backend_starting",
+            f"{ready} of {expected} backends ready",
+        )
+        self._publish_readiness(ReadinessState.STARTING)
 
     def _wait_for_endpoints(
         self,
@@ -398,6 +451,16 @@ class OneNodeAllocationController:
         timestamp = self._now()
         if client_completed_at is not None and client_completed_at > timestamp:
             timestamp = client_completed_at
+        terminal = self._build_terminal_attempt(failure, candidate_reference, timestamp)
+        self._attempt = self._state.update_attempt(terminal)
+        return self._attempt
+
+    def _build_terminal_attempt(
+        self,
+        failure: SlurmRuntimeError | None,
+        candidate_reference: ArtifactReference | None,
+        timestamp: datetime,
+    ) -> AttemptManifest:
         if failure is None:
             if candidate_reference is None:
                 raise SlurmRuntimeError(
@@ -419,8 +482,7 @@ class OneNodeAllocationController:
                 candidate_output=None,
                 updated_at=timestamp,
             )
-        self._attempt = self._state.update_attempt(terminal)
-        return self._attempt
+        return terminal
 
     def _now(self) -> datetime:
         value = self._clock.now()

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -36,7 +36,14 @@ from data_designer.slurm.state import (
     ProbeEvidence,
     ProbeOutcome,
     ReadinessState,
+    StateNotFoundError,
 )
+
+_READINESS_PROGRESS = {
+    ReadinessState.PENDING: 0,
+    ReadinessState.STARTING: 1,
+    ReadinessState.READY: 2,
+}
 
 
 class RuntimeStateStore(Protocol):
@@ -48,6 +55,10 @@ class RuntimeStateStore(Protocol):
 
     def write_readiness(self, readiness: AttemptReadiness) -> AttemptReadiness:
         """Persist the exact next readiness revision."""
+        ...
+
+    def load_readiness(self, shard_id: str, attempt_id: str) -> AttemptReadiness:
+        """Load the latest readiness revision for restart recovery."""
         ...
 
 
@@ -196,7 +207,7 @@ class OneNodeAllocationController:
             resolve_vllm_server(self._context.plan, deployment.deployment_id)
             for deployment in self._context.plan.deployments
         )
-        self._statuses = [_DeploymentStatus(deployment) for deployment in deployments]
+        self._statuses = self._initialize_statuses(deployments)
         self._publish_readiness(ReadinessState.PENDING)
         endpoint_steps = build_endpoint_steps(
             deployments,
@@ -219,7 +230,8 @@ class OneNodeAllocationController:
 
     def _start_runtime(self, topology: _RuntimeTopology) -> tuple[ManagedStep, ...]:
         for status in self._statuses:
-            status.state = ReadinessState.STARTING
+            if status.state is ReadinessState.PENDING:
+                status.state = ReadinessState.STARTING
         self._publish_readiness(ReadinessState.STARTING)
         server_processes = self._start_servers(topology.deployments)
         for status, required in zip(self._statuses, server_processes, strict=True):
@@ -282,11 +294,51 @@ class OneNodeAllocationController:
         if self._attempt.state not in {
             AttemptLifecycleState.SUBMITTED,
             AttemptLifecycleState.PENDING,
+            AttemptLifecycleState.RUNNING,
         }:
             raise SlurmRuntimeError(
                 SlurmRuntimeErrorCode.INVALID_CONTEXT,
                 "allocation attempt is not executable",
             )
+        if self._attempt.state is AttemptLifecycleState.RUNNING:
+            self._load_restart_readiness()
+
+    def _load_restart_readiness(self) -> None:
+        try:
+            readiness = self._state.load_readiness(self._attempt.shard_id, self._attempt.attempt_id)
+        except StateNotFoundError:
+            return
+        if readiness.state in {ReadinessState.FAILED, ReadinessState.STOPPED}:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "allocation attempt has terminal readiness and cannot be restarted",
+            )
+        self._readiness = readiness
+
+    def _initialize_statuses(
+        self,
+        deployments: tuple[ResolvedVllmServerDeployment, ...],
+    ) -> list[_DeploymentStatus]:
+        if self._readiness is None:
+            return [_DeploymentStatus(deployment) for deployment in deployments]
+        readiness_by_id = {deployment.deployment_id: deployment for deployment in self._readiness.deployments}
+        return [
+            self._restore_deployment_status(deployment, readiness_by_id[deployment.deployment_id])
+            for deployment in deployments
+        ]
+
+    @staticmethod
+    def _restore_deployment_status(
+        deployment: ResolvedVllmServerDeployment,
+        readiness: DeploymentReadiness,
+    ) -> _DeploymentStatus:
+        return _DeploymentStatus(
+            deployment=deployment,
+            state=readiness.state,
+            ready_backends=readiness.ready_backends,
+            endpoint_publication=readiness.endpoint_publication,
+            last_probe=readiness.last_probe,
+        )
 
     def _mark_attempt_running(self) -> None:
         if self._attempt.state is AttemptLifecycleState.RUNNING:
@@ -349,6 +401,8 @@ class OneNodeAllocationController:
             self._clock.sleep(self._poll_interval_seconds)
 
     def _record_backend_probe(self, status: _DeploymentStatus, ready: int, expected: int) -> None:
+        if status.state is ReadinessState.READY and ready != expected:
+            return
         status.ready_backends = ready
         status.last_probe = _probe_evidence(
             self._now(),
@@ -385,6 +439,8 @@ class OneNodeAllocationController:
             self._clock.sleep(self._poll_interval_seconds)
 
     def _publish_readiness(self, state: ReadinessState) -> None:
+        if self._readiness is not None and not _can_advance_readiness(self._readiness.state, state):
+            return
         revision = 1 if self._readiness is None else self._readiness.revision + 1
         readiness = AttemptReadiness(
             schema_version=1,
@@ -514,6 +570,14 @@ def _probe_evidence(
         reason_code=reason_code,
         redacted_message=message,
     )
+
+
+def _can_advance_readiness(previous: ReadinessState, current: ReadinessState) -> bool:
+    previous_progress = _READINESS_PROGRESS.get(previous)
+    current_progress = _READINESS_PROGRESS.get(current)
+    if previous_progress is None or current_progress is None:
+        return True
+    return current_progress >= previous_progress
 
 
 def _normalize_failure(error: BaseException) -> SlurmRuntimeError:

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/controller.py
@@ -372,7 +372,7 @@ class OneNodeAllocationController:
                     "allocation runtime failed",
                 )
             self._publish_readiness(ReadinessState.FAILED)
-        except Exception as error:
+        except BaseException as error:
             failure.add_note(f"failed readiness could not be persisted: {type(error).__name__}")
         return failure
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from types import FrameType
 from typing import Callable, Iterator
 
+from data_designer.slurm.planning import PlannedShard
 from data_designer.slurm.runtime.controller import OneNodeAllocationController
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
 from data_designer.slurm.runtime.models import AllocationContext
@@ -48,41 +49,7 @@ def main(arguments: Sequence[str] | None = None) -> int:
 
 
 def _run(plan_path: Path, attempt_directory: Path, environment: Mapping[str, str]) -> None:
-    if not plan_path.is_absolute() or not attempt_directory.is_absolute():
-        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime paths must be absolute")
-    if plan_path.name != "resolved-plan.json" or plan_path.parent.parent.name != "runs":
-        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "resolved plan path is invalid")
-    workspace_root = plan_path.parent.parent.parent
-    run_id = plan_path.parent.name
-    writer = SlurmStateWriter(workspace_root, run_id)
-    plan = writer.load_resolved_plan()
-    expected_plan_path = Path(plan.authored_config.path).with_name("resolved-plan.json")
-    if plan_path != expected_plan_path:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.INVALID_CONTEXT,
-            "runtime plan path does not match persisted run intent",
-        )
-    task_id = _scheduler_task_id(environment.get("SLURM_ARRAY_TASK_ID"))
-    shards = tuple(shard for shard in plan.shards if shard.array_task_index == task_id)
-    if len(shards) != 1:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.INVALID_CONTEXT,
-            "scheduler array task does not identify exactly one planned shard",
-        )
-    shard = shards[0]
-    expected_attempt_root = plan_path.parent / "shards" / shard.shard_id / "attempts"
-    if attempt_directory.parent != expected_attempt_root:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.INVALID_CONTEXT,
-            "attempt directory does not match the scheduler array task",
-        )
-    attempt = writer.load_attempt(shard.shard_id, attempt_directory.name)
-    context = AllocationContext(
-        plan=plan,
-        shard=shard,
-        attempt=attempt,
-        attempt_directory=attempt_directory,
-    )
+    context, writer = _load_allocation_context(plan_path, attempt_directory, environment)
     clock = SystemRuntimeClock()
     supervisor = StepSupervisor(SubprocessStepRunner(), clock=clock)
     controller = OneNodeAllocationController(
@@ -98,6 +65,50 @@ def _run(plan_path: Path, attempt_directory: Path, environment: Mapping[str, str
     )
     with _interrupt_on_termination(supervisor.cleanup):
         controller.run()
+
+
+def _load_allocation_context(
+    plan_path: Path,
+    attempt_directory: Path,
+    environment: Mapping[str, str],
+) -> tuple[AllocationContext, SlurmStateWriter]:
+    writer = _load_state_writer(plan_path, attempt_directory)
+    plan = writer.load_resolved_plan()
+    expected_plan_path = Path(plan.authored_config.path).with_name("resolved-plan.json")
+    if plan_path != expected_plan_path:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "runtime plan path does not match persisted run intent",
+        )
+    shard = _select_shard(plan.shards, _scheduler_task_id(environment.get("SLURM_ARRAY_TASK_ID")))
+    expected_attempt_root = plan_path.parent / "shards" / shard.shard_id / "attempts"
+    if attempt_directory.parent != expected_attempt_root:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "attempt directory does not match the scheduler array task",
+        )
+    attempt = writer.load_attempt(shard.shard_id, attempt_directory.name)
+    return AllocationContext(plan, shard, attempt, attempt_directory), writer
+
+
+def _load_state_writer(plan_path: Path, attempt_directory: Path) -> SlurmStateWriter:
+    if not plan_path.is_absolute() or not attempt_directory.is_absolute():
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime paths must be absolute")
+    if plan_path.name != "resolved-plan.json" or plan_path.parent.parent.name != "runs":
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "resolved plan path is invalid")
+    workspace_root = plan_path.parent.parent.parent
+    run_id = plan_path.parent.name
+    return SlurmStateWriter(workspace_root, run_id)
+
+
+def _select_shard(shards: tuple[PlannedShard, ...], task_id: int) -> PlannedShard:
+    selected = tuple(shard for shard in shards if shard.array_task_index == task_id)
+    if len(selected) != 1:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "scheduler array task does not identify exactly one planned shard",
+        )
+    return selected[0]
 
 
 def _scheduler_task_id(value: str | None) -> int:

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
@@ -7,13 +7,9 @@ from __future__ import annotations
 
 import argparse
 import os
-import signal
 import sys
 from collections.abc import Mapping, Sequence
-from contextlib import contextmanager
 from pathlib import Path
-from types import FrameType
-from typing import Callable, Iterator
 
 from data_designer.slurm.planning import PlannedShard
 from data_designer.slurm.runtime.controller import OneNodeAllocationController
@@ -21,6 +17,7 @@ from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeEr
 from data_designer.slurm.runtime.models import AllocationContext
 from data_designer.slurm.runtime.preflight import SystemAllocationPreflight
 from data_designer.slurm.runtime.probes import HttpReadinessProber
+from data_designer.slurm.runtime.signals import TerminationSignalCoordinator
 from data_designer.slurm.runtime.steps import DefaultClientStepBuilder
 from data_designer.slurm.runtime.supervisor import StepSupervisor, SubprocessStepRunner, SystemRuntimeClock
 from data_designer.slurm.state import SlurmStateWriter
@@ -51,7 +48,8 @@ def main(arguments: Sequence[str] | None = None) -> int:
 def _run(plan_path: Path, attempt_directory: Path, environment: Mapping[str, str]) -> None:
     context, writer = _load_allocation_context(plan_path, attempt_directory, environment)
     clock = SystemRuntimeClock()
-    supervisor = StepSupervisor(SubprocessStepRunner(), clock=clock)
+    signals = TerminationSignalCoordinator()
+    supervisor = StepSupervisor(SubprocessStepRunner(), signals=signals, clock=clock)
     controller = OneNodeAllocationController(
         context,
         runtime_proxy_path=Path(__file__).with_name("proxy.py"),
@@ -63,7 +61,7 @@ def _run(plan_path: Path, attempt_directory: Path, environment: Mapping[str, str
         clock=clock,
         environment=environment,
     )
-    with _interrupt_on_termination(supervisor.cleanup):
+    with signals.interrupt_on_termination(supervisor.cleanup):
         controller.run()
 
 
@@ -118,32 +116,6 @@ def _scheduler_task_id(value: str | None) -> int:
             "SLURM_ARRAY_TASK_ID must be a non-negative integer",
         )
     return int(value)
-
-
-@contextmanager
-def _interrupt_on_termination(cleanup: Callable[[], None]) -> Iterator[None]:
-    previous: dict[signal.Signals, signal.Handlers] = {}
-    interrupted = False
-
-    def interrupt(signum: int, frame: FrameType | None) -> None:
-        nonlocal interrupted
-        del signum, frame
-        if interrupted:
-            return
-        interrupted = True
-        try:
-            cleanup()
-        finally:
-            raise KeyboardInterrupt
-
-    for selected in (signal.SIGINT, signal.SIGTERM):
-        previous[selected] = signal.getsignal(selected)
-        signal.signal(selected, interrupt)
-    try:
-        yield
-    finally:
-        for selected, handler in previous.items():
-            signal.signal(selected, handler)
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised through the installed module

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/entrypoint.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allocation-local command entrypoint loaded from the checksummed runtime bundle."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from types import FrameType
+from typing import Callable, Iterator
+
+from data_designer.slurm.runtime.controller import OneNodeAllocationController
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import AllocationContext
+from data_designer.slurm.runtime.preflight import SystemAllocationPreflight
+from data_designer.slurm.runtime.probes import HttpReadinessProber
+from data_designer.slurm.runtime.steps import DefaultClientStepBuilder
+from data_designer.slurm.runtime.supervisor import StepSupervisor, SubprocessStepRunner, SystemRuntimeClock
+from data_designer.slurm.state import SlurmStateWriter
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Execute one allocation and return a bounded process status."""
+    parser = argparse.ArgumentParser(prog="data-designer-slurm-runtime")
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--attempt-dir", required=True)
+    parsed = parser.parse_args(arguments)
+    try:
+        _run(Path(parsed.plan), Path(parsed.attempt_dir), os.environ)
+    except SlurmRuntimeError as error:
+        print(f"allocation runtime failed ({error.code.value}): {error}", file=sys.stderr)
+        return (
+            64 if error.code in {SlurmRuntimeErrorCode.INVALID_CONTEXT, SlurmRuntimeErrorCode.PREFLIGHT_FAILED} else 70
+        )
+    except KeyboardInterrupt:
+        print("allocation runtime interrupted", file=sys.stderr)
+        return 130
+    except Exception:
+        print("allocation runtime failed at an internal boundary", file=sys.stderr)
+        return 70
+    return 0
+
+
+def _run(plan_path: Path, attempt_directory: Path, environment: Mapping[str, str]) -> None:
+    if not plan_path.is_absolute() or not attempt_directory.is_absolute():
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime paths must be absolute")
+    if plan_path.name != "resolved-plan.json" or plan_path.parent.parent.name != "runs":
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "resolved plan path is invalid")
+    workspace_root = plan_path.parent.parent.parent
+    run_id = plan_path.parent.name
+    writer = SlurmStateWriter(workspace_root, run_id)
+    plan = writer.load_resolved_plan()
+    expected_plan_path = Path(plan.authored_config.path).with_name("resolved-plan.json")
+    if plan_path != expected_plan_path:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "runtime plan path does not match persisted run intent",
+        )
+    task_id = _scheduler_task_id(environment.get("SLURM_ARRAY_TASK_ID"))
+    shards = tuple(shard for shard in plan.shards if shard.array_task_index == task_id)
+    if len(shards) != 1:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "scheduler array task does not identify exactly one planned shard",
+        )
+    shard = shards[0]
+    expected_attempt_root = plan_path.parent / "shards" / shard.shard_id / "attempts"
+    if attempt_directory.parent != expected_attempt_root:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "attempt directory does not match the scheduler array task",
+        )
+    attempt = writer.load_attempt(shard.shard_id, attempt_directory.name)
+    context = AllocationContext(
+        plan=plan,
+        shard=shard,
+        attempt=attempt,
+        attempt_directory=attempt_directory,
+    )
+    clock = SystemRuntimeClock()
+    supervisor = StepSupervisor(SubprocessStepRunner(), clock=clock)
+    controller = OneNodeAllocationController(
+        context,
+        runtime_proxy_path=Path(__file__).with_name("proxy.py"),
+        state=writer,
+        supervisor=supervisor,
+        preflight=SystemAllocationPreflight(),
+        client_steps=DefaultClientStepBuilder(),
+        prober=HttpReadinessProber(),
+        clock=clock,
+        environment=environment,
+    )
+    with _interrupt_on_termination(supervisor.cleanup):
+        controller.run()
+
+
+def _scheduler_task_id(value: str | None) -> int:
+    if value is None or not value.isascii() or not value.isdigit():
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "SLURM_ARRAY_TASK_ID must be a non-negative integer",
+        )
+    return int(value)
+
+
+@contextmanager
+def _interrupt_on_termination(cleanup: Callable[[], None]) -> Iterator[None]:
+    previous: dict[signal.Signals, signal.Handlers] = {}
+    interrupted = False
+
+    def interrupt(signum: int, frame: FrameType | None) -> None:
+        nonlocal interrupted
+        del signum, frame
+        if interrupted:
+            return
+        interrupted = True
+        try:
+            cleanup()
+        finally:
+            raise KeyboardInterrupt
+
+    for selected in (signal.SIGINT, signal.SIGTERM):
+        previous[selected] = signal.getsignal(selected)
+        signal.signal(selected, interrupt)
+    try:
+        yield
+    finally:
+        for selected, handler in previous.items():
+            signal.signal(selected, handler)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the installed module
+    raise SystemExit(main())

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/errors.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/errors.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalized failures for allocation-local Slurm execution."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SlurmRuntimeErrorCode(str, Enum):
+    """Stable allocation-runtime failure categories."""
+
+    INVALID_CONTEXT = "invalid_context"
+    PREFLIGHT_FAILED = "preflight_failed"
+    STEP_FAILED = "step_failed"
+    READINESS_TIMEOUT = "readiness_timeout"
+    CLIENT_FAILED = "client_failed"
+    FINALIZATION_FAILED = "finalization_failed"
+    CLEANUP_FAILED = "cleanup_failed"
+
+
+class SlurmRuntimeError(RuntimeError):
+    """Bounded allocation-runtime error safe for persisted diagnostics."""
+
+    def __init__(self, code: SlurmRuntimeErrorCode, message: str) -> None:
+        if not isinstance(code, SlurmRuntimeErrorCode):
+            raise TypeError("code must be a SlurmRuntimeErrorCode")
+        if type(message) is not str or not message or len(message) > 512:
+            raise ValueError("runtime error message must contain 1 to 512 characters")
+        if any(ord(character) < 32 or ord(character) == 127 for character in message):
+            raise ValueError("runtime error message must not contain control characters")
+        self.code = code
+        super().__init__(message)

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/logs.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/logs.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execution-scoped runtime log paths and restrictive file creation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import replace
+from pathlib import Path
+
+from data_designer.slurm.runtime.models import RuntimeStep
+from data_designer.slurm.state.filesystem import (
+    ensure_private_child_directory,
+    open_verified_child_directory,
+    open_verified_directory,
+)
+
+_LOG_DIRECTORY_NAME = "logs"
+_EXECUTION_DIRECTORY_PREFIX = "execution-"
+
+
+def execution_log_directory(attempt_directory: Path, readiness_revision: int) -> Path:
+    """Return the package-owned log directory for one execution epoch."""
+    if type(readiness_revision) is not int or readiness_revision < 1:
+        raise ValueError("execution readiness revision must be positive")
+    return attempt_directory / _LOG_DIRECTORY_NAME / f"{_EXECUTION_DIRECTORY_PREFIX}{readiness_revision:08d}"
+
+
+def bind_execution_logs(step: RuntimeStep, log_directory: Path) -> RuntimeStep:
+    """Bind one immutable step specification to its execution-scoped logs."""
+    return replace(
+        step,
+        stdout_path=log_directory / f"{step.step_id}.out",
+        stderr_path=log_directory / f"{step.step_id}.err",
+    )
+
+
+@contextmanager
+def open_step_logs(step: RuntimeStep) -> Iterator[tuple[int, int]]:
+    """Create and open one step's restrictive logs below verified directories."""
+    log_directory = step.stdout_path.parent
+    logs_root = log_directory.parent
+    attempt_directory = logs_root.parent
+    if logs_root.name != _LOG_DIRECTORY_NAME or not log_directory.name.startswith(_EXECUTION_DIRECTORY_PREFIX):
+        raise OSError("runtime logs must use a package-owned execution directory")
+
+    with open_verified_directory(attempt_directory, require_private=True) as attempt_descriptor:
+        ensure_private_child_directory(attempt_descriptor, _LOG_DIRECTORY_NAME, logs_root)
+    with open_verified_directory(logs_root, require_private=True) as logs_descriptor:
+        ensure_private_child_directory(logs_descriptor, log_directory.name, log_directory)
+        with open_verified_child_directory(logs_descriptor, log_directory.name, log_directory) as directory_descriptor:
+            with ExitStack() as resources:
+                stdout_descriptor = _create_log_file(directory_descriptor, step.stdout_path.name)
+                resources.callback(os.close, stdout_descriptor)
+                stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
+                resources.callback(os.close, stderr_descriptor)
+                yield stdout_descriptor, stderr_descriptor
+
+
+def _create_log_file(directory_descriptor: int, name: str) -> int:
+    return os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=directory_descriptor,
+    )
+
+
+__all__ = ["bind_execution_logs", "execution_log_directory", "open_step_logs"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/models.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/models.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transient typed values for allocation-local process execution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+
+from pydantic import TypeAdapter, ValidationError
+
+from data_designer.slurm.contracts import Identifier
+from data_designer.slurm.planning import PlannedShard, ResolvedSlurmRunPlan
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.state import AttemptManifest
+
+_IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
+
+
+class RuntimeStepRole(str, Enum):
+    """Lifecycle role of one allocation-local Slurm step."""
+
+    CLIENT_PREFLIGHT = "client_preflight"
+    SERVER = "server"
+    ENDPOINT = "endpoint"
+    CLIENT = "client"
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeStep:
+    """One shell-free process specification owned by the common step runner."""
+
+    step_id: Identifier
+    role: RuntimeStepRole
+    command: tuple[str, ...]
+    environment: Mapping[str, str]
+    stdout_path: Path
+    stderr_path: Path
+
+    def __post_init__(self) -> None:
+        try:
+            normalized_step_id = _IDENTIFIER_ADAPTER.validate_python(self.step_id, strict=True)
+        except ValidationError as error:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is invalid"
+            ) from error
+        if normalized_step_id != self.step_id:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is not canonical")
+        if not isinstance(self.role, RuntimeStepRole):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step role is invalid")
+        if not self.command or any(
+            type(argument) is not str or not argument or "\0" in argument for argument in self.command
+        ):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step command is invalid")
+        if not isinstance(self.environment, Mapping):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment is invalid")
+        normalized_environment: dict[str, str] = {}
+        for name, value in self.environment.items():
+            if type(name) is not str or not name or "=" in name or "\0" in name:
+                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment name is invalid")
+            if type(value) is not str or "\0" in value:
+                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment value is invalid")
+            normalized_environment[name] = value
+        for path in (self.stdout_path, self.stderr_path):
+            if not path.is_absolute():
+                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime log paths must be absolute")
+        if self.stdout_path.parent != self.stderr_path.parent or self.stdout_path == self.stderr_path:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "runtime log paths must be distinct children of one directory",
+            )
+        object.__setattr__(self, "environment", MappingProxyType(normalized_environment))
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeEndpoint:
+    """Client-visible logical endpoint published inside one allocation."""
+
+    model_alias: str
+    served_model_name: str
+    host: str
+    port: int
+
+    def __post_init__(self) -> None:
+        if type(self.model_alias) is not str or not self.model_alias:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "endpoint model alias is invalid")
+        if type(self.served_model_name) is not str or not self.served_model_name:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "endpoint model name is invalid")
+        if self.host != "127.0.0.1":
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "one-node endpoints must use loopback")
+        if type(self.port) is not int or not 1 <= self.port <= 65535:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "endpoint port is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationContext:
+    """Verified plan, shard, attempt, and package-owned attempt directory."""
+
+    plan: ResolvedSlurmRunPlan
+    shard: PlannedShard
+    attempt: AttemptManifest
+    attempt_directory: Path
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan, ResolvedSlurmRunPlan):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "allocation plan is invalid")
+        if not isinstance(self.shard, PlannedShard) or self.shard not in self.plan.shards:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "allocation shard is not in the plan")
+        if not isinstance(self.attempt, AttemptManifest):
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "allocation attempt is invalid")
+        expected_directory = (
+            Path(self.plan.authored_config.path).parent
+            / "shards"
+            / self.shard.shard_id
+            / "attempts"
+            / self.attempt.attempt_id
+        )
+        if self.attempt_directory != expected_directory:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "allocation attempt directory does not match persisted identity",
+            )
+        if (
+            self.attempt.run_id != self.plan.run_id
+            or self.attempt.shard_id != self.shard.shard_id
+            or self.attempt.scheduler is None
+            or self.attempt.scheduler.array_task_id != self.shard.array_task_index
+        ):
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "allocation attempt does not match its planned scheduler task",
+            )

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/models.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/models.py
@@ -42,38 +42,51 @@ class RuntimeStep:
     stderr_path: Path
 
     def __post_init__(self) -> None:
-        try:
-            normalized_step_id = _IDENTIFIER_ADAPTER.validate_python(self.step_id, strict=True)
-        except ValidationError as error:
-            raise SlurmRuntimeError(
-                SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is invalid"
-            ) from error
-        if normalized_step_id != self.step_id:
-            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is not canonical")
+        _validate_step_identity(self.step_id)
         if not isinstance(self.role, RuntimeStepRole):
             raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step role is invalid")
-        if not self.command or any(
-            type(argument) is not str or not argument or "\0" in argument for argument in self.command
-        ):
-            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step command is invalid")
-        if not isinstance(self.environment, Mapping):
-            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment is invalid")
-        normalized_environment: dict[str, str] = {}
-        for name, value in self.environment.items():
-            if type(name) is not str or not name or "=" in name or "\0" in name:
-                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment name is invalid")
-            if type(value) is not str or "\0" in value:
-                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment value is invalid")
-            normalized_environment[name] = value
-        for path in (self.stdout_path, self.stderr_path):
-            if not path.is_absolute():
-                raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime log paths must be absolute")
-        if self.stdout_path.parent != self.stderr_path.parent or self.stdout_path == self.stderr_path:
-            raise SlurmRuntimeError(
-                SlurmRuntimeErrorCode.INVALID_CONTEXT,
-                "runtime log paths must be distinct children of one directory",
-            )
+        _validate_step_command(self.command)
+        normalized_environment = _validate_step_environment(self.environment)
+        _validate_step_log_paths(self.stdout_path, self.stderr_path)
         object.__setattr__(self, "environment", MappingProxyType(normalized_environment))
+
+
+def _validate_step_identity(step_id: Identifier) -> None:
+    try:
+        normalized_step_id = _IDENTIFIER_ADAPTER.validate_python(step_id, strict=True)
+    except ValidationError as error:
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is invalid") from error
+    if normalized_step_id != step_id:
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step identity is not canonical")
+
+
+def _validate_step_command(command: tuple[str, ...]) -> None:
+    if not command or any(type(argument) is not str or not argument or "\0" in argument for argument in command):
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime step command is invalid")
+
+
+def _validate_step_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    if not isinstance(environment, Mapping):
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment is invalid")
+    normalized_environment: dict[str, str] = {}
+    for name, value in environment.items():
+        if type(name) is not str or not name or "=" in name or "\0" in name:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment name is invalid")
+        if type(value) is not str or "\0" in value:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime environment value is invalid")
+        normalized_environment[name] = value
+    return normalized_environment
+
+
+def _validate_step_log_paths(stdout_path: Path, stderr_path: Path) -> None:
+    for path in (stdout_path, stderr_path):
+        if not path.is_absolute():
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime log paths must be absolute")
+    if stdout_path.parent != stderr_path.parent or stdout_path == stderr_path:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "runtime log paths must be distinct children of one directory",
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/paths.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/paths.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate reviewed host paths through resolved container mounts."""
+
+from __future__ import annotations
+
+import posixpath
+
+from data_designer.slurm.contracts import validate_absolute_path
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+
+
+def get_container_path(
+    plan: ResolvedSlurmRunPlan,
+    host_path: str,
+    *,
+    require_writable: bool = False,
+) -> str:
+    """Map one absolute host path through the most specific resolved mount."""
+    try:
+        normalized = validate_absolute_path(host_path)
+    except ValueError as error:
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.INVALID_CONTEXT, "runtime host path is invalid") from error
+    candidates = tuple(
+        mount
+        for mount in plan.container_mounts
+        if normalized == mount.source or normalized.startswith(f"{mount.source}/")
+    )
+    if not candidates:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+            "runtime path is not available through a resolved container mount",
+        )
+    mount = max(candidates, key=lambda value: len(value.source))
+    if require_writable and mount.read_only:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+            "runtime path requires a writable resolved container mount",
+        )
+    relative_path = posixpath.relpath(normalized, mount.source)
+    mapped = mount.target if relative_path == "." else posixpath.join(mount.target, relative_path)
+    return validate_absolute_path(mapped)
+
+
+__all__ = ["get_container_path"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
@@ -154,6 +154,9 @@ def _verify_artifact(reference: ArtifactReference) -> None:
             raise OSError(f"artifact {path} changed while it was read")
         if digest.hexdigest() != reference.sha256:
             raise OSError(f"artifact {path} digest does not match the plan")
+        current = path.lstat()
+        if not stat.S_ISREG(current.st_mode) or _file_identity(after) != _file_identity(current):
+            raise OSError(f"artifact {path} was replaced while it was verified")
     finally:
         os.close(descriptor)
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-fast allocation checks performed before any child process starts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import socket
+import stat
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol
+
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import AllocationContext
+from data_designer.slurm.runtime.paths import get_container_path
+
+_DIGEST_CHUNK_SIZE = 1024 * 1024
+_GPU_COUNT_PATTERN = re.compile(r"^(?:gpu(?::[^:]+)?):([0-9]+)$")
+
+
+class AllocationPreflight(Protocol):
+    """Verify one allocation without starting package-managed processes."""
+
+    def verify(self, context: AllocationContext, environment: Mapping[str, str]) -> None:
+        """Raise a normalized error when allocation facts disagree with the plan."""
+        ...
+
+
+class SystemAllocationPreflight:
+    """Production verification of scheduler, filesystem, GPU, and port facts."""
+
+    def verify(self, context: AllocationContext, environment: Mapping[str, str]) -> None:
+        """Verify every launch-critical fact before model services start."""
+        try:
+            self._verify_scheduler(context, environment)
+            self._verify_attempt_directory(context.attempt_directory)
+            get_container_path(context.plan, context.attempt_directory.as_posix(), require_writable=True)
+            self._verify_artifacts(context)
+            self._verify_ports(context)
+        except SlurmRuntimeError:
+            raise
+        except (OSError, ValueError) as error:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                "allocation preflight could not verify launch inputs",
+            ) from error
+
+    @staticmethod
+    def _verify_scheduler(context: AllocationContext, environment: Mapping[str, str]) -> None:
+        node_indices = {
+            context.plan.client.host_node_index,
+            *(index for deployment in context.plan.deployments for index in deployment.node_indices),
+        }
+        if node_indices != {0}:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                "one-node runtime received a multi-node execution plan",
+            )
+        expected = {
+            "SLURM_ARRAY_JOB_ID": context.attempt.scheduler.array_job_id,
+            "SLURM_ARRAY_TASK_ID": context.shard.array_task_index,
+            "SLURM_JOB_NUM_NODES": 1,
+            "SLURM_NODEID": 0,
+        }
+        for name, value in expected.items():
+            if _parse_non_negative_integer(environment.get(name), name) != value:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                    f"scheduler environment {name!r} does not match the resolved plan",
+                )
+        visible_gpus = environment.get("CUDA_VISIBLE_DEVICES") or environment.get("SLURM_JOB_GPUS")
+        if _parse_gpu_count(visible_gpus) != context.plan.resolved_gpus_per_node:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                "allocation GPU visibility does not match the resolved plan",
+            )
+
+    @staticmethod
+    def _verify_attempt_directory(attempt_directory: Path) -> None:
+        status = attempt_directory.lstat()
+        if not stat.S_ISDIR(status.st_mode) or status.st_mode & 0o077:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                "attempt workspace is not a restrictive directory",
+            )
+
+    @staticmethod
+    def _verify_artifacts(context: AllocationContext) -> None:
+        plan = context.plan
+        references = [
+            ArtifactReference(
+                path=Path(plan.authored_config.path).with_name("resolved-plan.json").as_posix(),
+                sha256=plan.compute_sha256(),
+            ),
+            plan.runtime_bundle,
+            plan.client.dependency_lock,
+            ArtifactReference(path=plan.client.image.path, sha256=plan.client.image.sha256),
+            *(
+                ArtifactReference(path=deployment.image.path, sha256=deployment.image.sha256)
+                for deployment in plan.deployments
+            ),
+        ]
+        optional_references = [
+            plan.builder.source,
+            context.shard.input_partition,
+        ]
+        references.extend(reference for reference in optional_references if reference is not None)
+        unique_references = {(reference.path, reference.sha256): reference for reference in references}
+        for reference in unique_references.values():
+            _verify_artifact(reference)
+
+    @staticmethod
+    def _verify_ports(context: AllocationContext) -> None:
+        ports = tuple(port.port for port in context.plan.client.ports) + tuple(
+            port.port for deployment in context.plan.deployments for port in deployment.ports
+        )
+        reservations: list[socket.socket] = []
+        try:
+            for port in ports:
+                reservation = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                reservation.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+                reservation.bind(("127.0.0.1", port))
+                reservations.append(reservation)
+        except OSError as error:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                "one or more resolved allocation ports are unavailable",
+            ) from error
+        finally:
+            for reservation in reservations:
+                reservation.close()
+
+
+def _verify_artifact(reference: ArtifactReference) -> None:
+    path = Path(reference.path)
+    before = path.lstat()
+    if not stat.S_ISREG(before.st_mode):
+        raise OSError(f"artifact {path} is not a regular file")
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
+    try:
+        opened = os.fstat(descriptor)
+        if _file_identity(before) != _file_identity(opened):
+            raise OSError(f"artifact {path} changed while it was opened")
+        digest = hashlib.sha256()
+        while chunk := os.read(descriptor, _DIGEST_CHUNK_SIZE):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        if _file_identity(opened) != _file_identity(after):
+            raise OSError(f"artifact {path} changed while it was read")
+        if digest.hexdigest() != reference.sha256:
+            raise OSError(f"artifact {path} digest does not match the plan")
+    finally:
+        os.close(descriptor)
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
+
+
+def _parse_non_negative_integer(value: str | None, name: str) -> int:
+    if value is None or not value.isascii() or not value.isdigit():
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+            f"scheduler environment {name!r} is unavailable or invalid",
+        )
+    return int(value)
+
+
+def _parse_gpu_count(value: str | None) -> int:
+    if value is None or not value.strip():
+        return 0
+    normalized = value.strip()
+    match = _GPU_COUNT_PATTERN.fullmatch(normalized)
+    if match is not None:
+        return int(match.group(1))
+    values = tuple(item.strip() for item in normalized.split(","))
+    if not all(values) or len(values) != len(set(values)):
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.PREFLIGHT_FAILED, "GPU visibility is invalid")
+    return len(values)
+
+
+__all__ = ["AllocationPreflight", "SystemAllocationPreflight"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/preflight.py
@@ -123,9 +123,9 @@ class SystemAllocationPreflight:
         try:
             for port in ports:
                 reservation = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                reservations.append(reservation)
                 reservation.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
                 reservation.bind(("127.0.0.1", port))
-                reservations.append(reservation)
         except OSError as error:
             raise SlurmRuntimeError(
                 SlurmRuntimeErrorCode.PREFLIGHT_FAILED,

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/probes.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/probes.py
@@ -28,7 +28,6 @@ class HttpReadinessProber:
         try:
             connection.request("GET", path, headers={"Connection": "close"})
             response = connection.getresponse()
-            response.read()
             return response.status == 200
         except (OSError, http.client.HTTPException):
             return False

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/probes.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/probes.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded loopback readiness probes for allocation-local endpoints."""
+
+from __future__ import annotations
+
+import http.client
+from typing import Protocol
+
+
+class ReadinessProber(Protocol):
+    """Probe one loopback HTTP endpoint."""
+
+    def is_ready(self, host: str, port: int, path: str, *, timeout_seconds: float) -> bool:
+        """Return whether the endpoint produced HTTP 200 within the timeout."""
+        ...
+
+
+class HttpReadinessProber:
+    """Production stdlib HTTP prober with no redirect or proxy behavior."""
+
+    def is_ready(self, host: str, port: int, path: str, *, timeout_seconds: float) -> bool:
+        """Probe a reviewed loopback address and fully close the connection."""
+        if host != "127.0.0.1" or not path.startswith("/") or timeout_seconds <= 0:
+            return False
+        connection = http.client.HTTPConnection(host, port, timeout=timeout_seconds)
+        try:
+            connection.request("GET", path, headers={"Connection": "close"})
+            response = connection.getresponse()
+            response.read()
+            return response.status == 200
+        except (OSError, http.client.HTTPException):
+            return False
+        finally:
+            connection.close()
+
+
+__all__ = ["HttpReadinessProber", "ReadinessProber"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
@@ -15,6 +15,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import SplitResult, urlsplit
 
 _MAXIMUM_REQUEST_BYTES = 64 * 1024 * 1024
+_MAXIMUM_RESPONSE_BYTES = 64 * 1024 * 1024
 _HOP_HEADERS = frozenset(
     {
         "connection",
@@ -182,7 +183,9 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         try:
             connection.request(self.command, self.path, body=body, headers=headers)
             response = connection.getresponse()
-            payload = response.read()
+            payload = response.read(_MAXIMUM_RESPONSE_BYTES + 1)
+            if len(payload) > _MAXIMUM_RESPONSE_BYTES:
+                return 502, b'{"error":"backend response too large"}\n', {"Content-Type": "application/json"}
             response_headers = {
                 name: value
                 for name, value in response.getheaders()

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
@@ -22,6 +22,7 @@ _HOP_HEADERS = frozenset(
         "keep-alive",
         "proxy-authenticate",
         "proxy-authorization",
+        "proxy-connection",
         "te",
         "trailer",
         "transfer-encoding",
@@ -173,10 +174,12 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         return content
 
     def _request_backend(self, backend: _Backend, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        request_headers = tuple(self.headers.items())
+        hop_headers = _get_hop_headers(request_headers)
         headers = {
             name: value
-            for name, value in self.headers.items()
-            if name.lower() not in _HOP_HEADERS and name.lower() not in {"host", "content-length"}
+            for name, value in request_headers
+            if name.lower() not in hop_headers and name.lower() not in {"host", "content-length"}
         }
         headers["Content-Length"] = str(len(body))
         connection = http.client.HTTPConnection(backend.host, backend.port, timeout=300)
@@ -186,10 +189,12 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             payload = response.read(_MAXIMUM_RESPONSE_BYTES + 1)
             if len(payload) > _MAXIMUM_RESPONSE_BYTES:
                 return 502, b'{"error":"backend response too large"}\n', {"Content-Type": "application/json"}
+            raw_response_headers = tuple(response.getheaders())
+            response_hop_headers = _get_hop_headers(raw_response_headers)
             response_headers = {
                 name: value
-                for name, value in response.getheaders()
-                if name.lower() not in _HOP_HEADERS and name.lower() != "content-length"
+                for name, value in raw_response_headers
+                if name.lower() not in response_hop_headers and name.lower() != "content-length"
             }
             return response.status, payload, response_headers
         except (OSError, http.client.HTTPException):
@@ -253,6 +258,17 @@ def _retry_after_headers(headers: dict[str, str], retry_after_seconds: int | Non
     if retry_after_seconds is not None:
         selected["Retry-After"] = str(retry_after_seconds)
     return selected
+
+
+def _get_hop_headers(headers: Sequence[tuple[str, str]]) -> frozenset[str]:
+    nominated = {
+        token.strip().lower()
+        for name, value in headers
+        if name.lower() == "connection"
+        for token in value.split(",")
+        if token.strip()
+    }
+    return _HOP_HEADERS | nominated
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised as a managed step

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import argparse
 import http.client
 import threading
-import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -38,12 +37,10 @@ class _Backend:
 
 
 class _BackendPool:
-    def __init__(self, backends: tuple[_Backend, ...], max_waiting: int, retry_after_seconds: int | None) -> None:
+    def __init__(self, backends: tuple[_Backend, ...], retry_after_seconds: int | None) -> None:
         self.backends = backends
-        self.max_waiting = max_waiting
         self.retry_after_seconds = retry_after_seconds
         self._active = [0] * len(backends)
-        self._waiting = 0
         self._cursor = 0
         self._lock = threading.Lock()
 
@@ -62,17 +59,6 @@ class _BackendPool:
     def release(self, index: int) -> None:
         with self._lock:
             self._active[index] -= 1
-
-    def begin_wait(self) -> bool:
-        with self._lock:
-            if self._waiting >= self.max_waiting:
-                return False
-            self._waiting += 1
-            return True
-
-    def end_wait(self) -> None:
-        with self._lock:
-            self._waiting -= 1
 
 
 class _ProxyServer(ThreadingHTTPServer):
@@ -112,29 +98,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         request_body = self._read_request_body()
         if request_body is None:
             return
-        waiting = False
-        try:
-            while True:
-                final_response = self._try_backends(request_body)
-                if final_response is None:
-                    self.send_error(503)
-                    return
-                if final_response[0] != 429:
-                    self._write_response(*final_response)
-                    return
-                if not waiting:
-                    if not self.server.pool.begin_wait():
-                        headers = _retry_after_headers(
-                            final_response[2],
-                            self.server.pool.retry_after_seconds,
-                        )
-                        self._write_response(429, final_response[1], headers)
-                        return
-                    waiting = True
-                time.sleep(self.server.pool.retry_after_seconds or 1)
-        finally:
-            if waiting:
-                self.server.pool.end_wait()
+        final_response = self._try_backends(request_body)
+        if final_response is None:
+            self.send_error(503)
+            return
+        if final_response[0] == 429:
+            final_response = (
+                final_response[0],
+                final_response[1],
+                _retry_after_headers(final_response[2], self.server.pool.retry_after_seconds),
+            )
+        self._write_response(*final_response)
 
     def _try_backends(self, request_body: bytes) -> tuple[int, bytes, dict[str, str]] | None:
         excluded: set[int] = set()
@@ -217,17 +191,14 @@ def main(arguments: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="data-designer-slurm-proxy")
     parser.add_argument("--listen-port", required=True, type=int)
     parser.add_argument("--backend", action="append", required=True)
-    parser.add_argument("--max-waiting-requests", required=True, type=int)
     parser.add_argument("--retry-after-seconds", type=int)
     parsed = parser.parse_args(arguments)
     backends = tuple(_parse_backend(value) for value in parsed.backend)
     if not 1 <= parsed.listen_port <= 65535:
         parser.error("listen port must be between 1 and 65535")
-    if parsed.max_waiting_requests < 0:
-        parser.error("maximum waiting requests must be non-negative")
     if parsed.retry_after_seconds is not None and parsed.retry_after_seconds <= 0:
         parser.error("retry-after seconds must be positive")
-    pool = _BackendPool(backends, parsed.max_waiting_requests, parsed.retry_after_seconds)
+    pool = _BackendPool(backends, parsed.retry_after_seconds)
     with _ProxyServer(("127.0.0.1", parsed.listen_port), pool) as server:
         server.serve_forever(poll_interval=0.1)
     return 0

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/proxy.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allocation-local least-connections HTTP endpoint for one model alias."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import threading
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import SplitResult, urlsplit
+
+_MAXIMUM_REQUEST_BYTES = 64 * 1024 * 1024
+_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Backend:
+    host: str
+    port: int
+
+
+class _BackendPool:
+    def __init__(self, backends: tuple[_Backend, ...], max_waiting: int, retry_after_seconds: int | None) -> None:
+        self.backends = backends
+        self.max_waiting = max_waiting
+        self.retry_after_seconds = retry_after_seconds
+        self._active = [0] * len(backends)
+        self._waiting = 0
+        self._cursor = 0
+        self._lock = threading.Lock()
+
+    def acquire(self, excluded: frozenset[int]) -> int:
+        with self._lock:
+            available = tuple(index for index in range(len(self.backends)) if index not in excluded)
+            if not available:
+                raise LookupError("no backend remains")
+            minimum = min(self._active[index] for index in available)
+            candidates = tuple(index for index in available if self._active[index] == minimum)
+            index = candidates[self._cursor % len(candidates)]
+            self._cursor += 1
+            self._active[index] += 1
+            return index
+
+    def release(self, index: int) -> None:
+        with self._lock:
+            self._active[index] -= 1
+
+    def begin_wait(self) -> bool:
+        with self._lock:
+            if self._waiting >= self.max_waiting:
+                return False
+            self._waiting += 1
+            return True
+
+    def end_wait(self) -> None:
+        with self._lock:
+            self._waiting -= 1
+
+
+class _ProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], pool: _BackendPool) -> None:
+        self.pool = pool
+        super().__init__(address, _ProxyHandler)
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    server: _ProxyServer
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._write_response(200, b'{"status":"ok"}\n', {"Content-Type": "application/json"})
+            return
+        self._forward()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._forward()
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+    def _forward(self) -> None:
+        if not self.path.startswith("/") or self.path.startswith("//"):
+            self.send_error(400)
+            return
+        request_body = self._read_request_body()
+        if request_body is None:
+            return
+        waiting = False
+        try:
+            while True:
+                final_response = self._try_backends(request_body)
+                if final_response is None:
+                    self.send_error(503)
+                    return
+                if final_response[0] != 429:
+                    self._write_response(*final_response)
+                    return
+                if not waiting:
+                    if not self.server.pool.begin_wait():
+                        headers = _retry_after_headers(
+                            final_response[2],
+                            self.server.pool.retry_after_seconds,
+                        )
+                        self._write_response(429, final_response[1], headers)
+                        return
+                    waiting = True
+                time.sleep(self.server.pool.retry_after_seconds or 1)
+        finally:
+            if waiting:
+                self.server.pool.end_wait()
+
+    def _try_backends(self, request_body: bytes) -> tuple[int, bytes, dict[str, str]] | None:
+        excluded: set[int] = set()
+        final_response: tuple[int, bytes, dict[str, str]] | None = None
+        while len(excluded) < len(self.server.pool.backends):
+            index = self.server.pool.acquire(frozenset(excluded))
+            try:
+                final_response = self._request_backend(self.server.pool.backends[index], request_body)
+            finally:
+                self.server.pool.release(index)
+            if final_response[0] != 429:
+                break
+            excluded.add(index)
+        return final_response
+
+    def _read_request_body(self) -> bytes | None:
+        if self.headers.get("Transfer-Encoding") is not None:
+            self.send_error(501)
+            return None
+        lengths = self.headers.get_all("Content-Length", failobj=[])
+        if len(lengths) > 1:
+            self.send_error(400)
+            return None
+        raw_length = lengths[0] if lengths else "0"
+        try:
+            length = int(raw_length)
+        except ValueError:
+            self.send_error(400)
+            return None
+        if length < 0 or length > _MAXIMUM_REQUEST_BYTES:
+            self.send_error(413)
+            return None
+        content = self.rfile.read(length)
+        if len(content) != length:
+            self.send_error(400)
+            return None
+        return content
+
+    def _request_backend(self, backend: _Backend, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        headers = {
+            name: value
+            for name, value in self.headers.items()
+            if name.lower() not in _HOP_HEADERS and name.lower() not in {"host", "content-length"}
+        }
+        headers["Content-Length"] = str(len(body))
+        connection = http.client.HTTPConnection(backend.host, backend.port, timeout=300)
+        try:
+            connection.request(self.command, self.path, body=body, headers=headers)
+            response = connection.getresponse()
+            payload = response.read()
+            response_headers = {
+                name: value
+                for name, value in response.getheaders()
+                if name.lower() not in _HOP_HEADERS and name.lower() != "content-length"
+            }
+            return response.status, payload, response_headers
+        except (OSError, http.client.HTTPException):
+            return 502, b'{"error":"backend unavailable"}\n', {"Content-Type": "application/json"}
+        finally:
+            connection.close()
+
+    def _write_response(self, status: int, body: bytes, headers: dict[str, str]) -> None:
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Serve one loopback logical endpoint until the step is terminated."""
+    parser = argparse.ArgumentParser(prog="data-designer-slurm-proxy")
+    parser.add_argument("--listen-port", required=True, type=int)
+    parser.add_argument("--backend", action="append", required=True)
+    parser.add_argument("--max-waiting-requests", required=True, type=int)
+    parser.add_argument("--retry-after-seconds", type=int)
+    parsed = parser.parse_args(arguments)
+    backends = tuple(_parse_backend(value) for value in parsed.backend)
+    if not 1 <= parsed.listen_port <= 65535:
+        parser.error("listen port must be between 1 and 65535")
+    if parsed.max_waiting_requests < 0:
+        parser.error("maximum waiting requests must be non-negative")
+    if parsed.retry_after_seconds is not None and parsed.retry_after_seconds <= 0:
+        parser.error("retry-after seconds must be positive")
+    pool = _BackendPool(backends, parsed.max_waiting_requests, parsed.retry_after_seconds)
+    with _ProxyServer(("127.0.0.1", parsed.listen_port), pool) as server:
+        server.serve_forever(poll_interval=0.1)
+    return 0
+
+
+def _parse_backend(value: str) -> _Backend:
+    parsed: SplitResult = urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("backend port is invalid") from error
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != "127.0.0.1"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+        or port is None
+    ):
+        raise argparse.ArgumentTypeError("backends must be loopback HTTP origins")
+    return _Backend(parsed.hostname, port)
+
+
+def _retry_after_headers(headers: dict[str, str], retry_after_seconds: int | None) -> dict[str, str]:
+    selected = {name: value for name, value in headers.items() if name.lower() != "retry-after"}
+    if retry_after_seconds is not None:
+        selected["Retry-After"] = str(retry_after_seconds)
+    return selected
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a managed step
+    raise SystemExit(main())

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read and validate #876-owned client and candidate records."""
+
+from __future__ import annotations
+
+import posixpath
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import ValidationError
+
+from data_designer.slurm.client import ClientOutcome, ClientResult
+from data_designer.slurm.contracts import ContractRecord
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import AllocationContext
+from data_designer.slurm.state import CandidateOutputManifest
+from data_designer.slurm.state.filesystem import open_verified_directory, read_regular_text
+
+_CLIENT_RESULT_NAME = "client-result.json"
+_CANDIDATE_NAME = "output-manifest.json"
+_MAXIMUM_RECORD_SIZE = 16 * 1024 * 1024
+_RecordT = TypeVar("_RecordT", bound=ContractRecord)
+
+
+def load_complete_client_candidate(
+    context: AllocationContext,
+) -> tuple[ClientResult, CandidateOutputManifest]:
+    """Load a complete semantic client result and its digest-bound candidate."""
+    client_result = _read_record(context.attempt_directory, _CLIENT_RESULT_NAME, ClientResult)
+    if client_result.outcome is not ClientOutcome.COMPLETE:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.CLIENT_FAILED,
+            f"client generation finished with outcome {client_result.outcome.value!r}",
+        )
+    reference = client_result.candidate_output_manifest
+    if reference is None:  # pragma: no cover - ClientResult validates this invariant
+        raise SlurmRuntimeError(SlurmRuntimeErrorCode.FINALIZATION_FAILED, "client result has no candidate output")
+    expected_path = context.attempt_directory / _CANDIDATE_NAME
+    if reference.path != expected_path.as_posix():
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client candidate path does not match the allocation attempt",
+        )
+    candidate = _read_record(context.attempt_directory, _CANDIDATE_NAME, CandidateOutputManifest)
+    if candidate.compute_sha256() != reference.sha256:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client candidate digest does not match the persisted manifest",
+        )
+    _validate_candidate(context, client_result, candidate)
+    return client_result, candidate
+
+
+def _validate_candidate(
+    context: AllocationContext,
+    client_result: ClientResult,
+    candidate: CandidateOutputManifest,
+) -> None:
+    plan = context.plan
+    shard = context.shard
+    attempt = context.attempt
+    identities = (
+        client_result.run_id == candidate.run_id == plan.run_id,
+        client_result.shard_id == candidate.shard_id == shard.shard_id,
+        client_result.attempt_id == candidate.attempt_id == attempt.attempt_id,
+        candidate.attempt_ordinal == attempt.attempt_ordinal,
+    )
+    if not all(identities):
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client and candidate identities do not match the allocation",
+        )
+    if not candidate.winner_eligible:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "candidate record counts do not complete the planned shard",
+        )
+    if (
+        client_result.requested_records != shard.requested_records
+        or client_result.actual_records != candidate.actual_records
+        or candidate.actual_records != shard.requested_records
+    ):
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client and candidate record counts do not complete the planned shard",
+        )
+    if client_result.requested_resume_mode != plan.invocation.authored.resume:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client resume mode does not match the resolved plan",
+        )
+    expected_dataset_path = (
+        shard.resume_workspace.path
+        if client_result.effective_resume_mode == "always"
+        else posixpath.join(context.attempt_directory.as_posix(), "dataset")
+    )
+    if client_result.dataset_path != expected_dataset_path or candidate.dataset_path != expected_dataset_path:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client and candidate dataset paths do not match the resolved plan",
+        )
+    if candidate.created_at < attempt.created_at or client_result.completed_at < candidate.created_at:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client and candidate timestamps are inconsistent",
+        )
+
+
+def _read_record(directory: Path, name: str, record_type: type[_RecordT]) -> _RecordT:
+    display_path = directory / name
+    try:
+        with open_verified_directory(directory, require_private=True) as descriptor:
+            content = read_regular_text(
+                descriptor,
+                name,
+                display_path,
+                maximum_size=_MAXIMUM_RECORD_SIZE,
+            )
+        return record_type.model_validate_json(content)
+    except (OSError, UnicodeError, ValidationError, ValueError) as error:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            f"runtime result record {name!r} is unavailable or invalid",
+        ) from error
+
+
+__all__ = ["load_complete_client_candidate"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import posixpath
 from pathlib import Path
 from typing import TypeVar
 
@@ -13,6 +12,7 @@ from pydantic import ValidationError
 
 from data_designer.slurm.client import ClientOutcome, ClientResult
 from data_designer.slurm.contracts import ContractRecord
+from data_designer.slurm.integration import IntegrationContractError, PlanStateValidator
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
 from data_designer.slurm.runtime.models import AllocationContext
 from data_designer.slurm.state import CandidateOutputManifest
@@ -34,99 +34,20 @@ def load_complete_client_candidate(
             SlurmRuntimeErrorCode.CLIENT_FAILED,
             f"client generation finished with outcome {client_result.outcome.value!r}",
         )
-    reference = client_result.candidate_output_manifest
-    if reference is None:  # pragma: no cover - ClientResult validates this invariant
-        raise SlurmRuntimeError(SlurmRuntimeErrorCode.FINALIZATION_FAILED, "client result has no candidate output")
-    expected_path = context.attempt_directory / _CANDIDATE_NAME
-    if reference.path != expected_path.as_posix():
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client candidate path does not match the allocation attempt",
-        )
     candidate = _read_record(context.attempt_directory, _CANDIDATE_NAME, CandidateOutputManifest)
-    if candidate.compute_sha256() != reference.sha256:
+    try:
+        PlanStateValidator(context.plan).validate_client_candidate(
+            context.shard,
+            context.attempt,
+            client_result,
+            candidate,
+        )
+    except IntegrationContractError as error:
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client candidate digest does not match the persisted manifest",
-        )
-    _validate_candidate(context, client_result, candidate)
+            "client result and candidate do not match the resolved plan",
+        ) from error
     return client_result, candidate
-
-
-def _validate_candidate(
-    context: AllocationContext,
-    client_result: ClientResult,
-    candidate: CandidateOutputManifest,
-) -> None:
-    _validate_candidate_identities(context, client_result, candidate)
-    _validate_candidate_counts(context, client_result, candidate)
-    _validate_candidate_location(context, client_result, candidate)
-    if candidate.created_at < context.attempt.created_at or client_result.completed_at < candidate.created_at:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client and candidate timestamps are inconsistent",
-        )
-
-
-def _validate_candidate_identities(
-    context: AllocationContext,
-    client_result: ClientResult,
-    candidate: CandidateOutputManifest,
-) -> None:
-    identities = (
-        client_result.run_id == candidate.run_id == context.plan.run_id,
-        client_result.shard_id == candidate.shard_id == context.shard.shard_id,
-        client_result.attempt_id == candidate.attempt_id == context.attempt.attempt_id,
-        candidate.attempt_ordinal == context.attempt.attempt_ordinal,
-    )
-    if not all(identities):
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client and candidate identities do not match the allocation",
-        )
-
-
-def _validate_candidate_counts(
-    context: AllocationContext,
-    client_result: ClientResult,
-    candidate: CandidateOutputManifest,
-) -> None:
-    if not candidate.winner_eligible:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "candidate record counts do not complete the planned shard",
-        )
-    if (
-        client_result.requested_records != context.shard.requested_records
-        or client_result.actual_records != candidate.actual_records
-        or candidate.actual_records != context.shard.requested_records
-    ):
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client and candidate record counts do not complete the planned shard",
-        )
-
-
-def _validate_candidate_location(
-    context: AllocationContext,
-    client_result: ClientResult,
-    candidate: CandidateOutputManifest,
-) -> None:
-    if client_result.requested_resume_mode != context.plan.invocation.authored.resume:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client resume mode does not match the resolved plan",
-        )
-    expected_dataset_path = (
-        context.shard.resume_workspace.path
-        if client_result.effective_resume_mode == "always"
-        else posixpath.join(context.attempt_directory.as_posix(), "dataset")
-    )
-    if client_result.dataset_path != expected_dataset_path or candidate.dataset_path != expected_dataset_path:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client and candidate dataset paths do not match the resolved plan",
-        )
 
 
 def _read_record(directory: Path, name: str, record_type: type[_RecordT]) -> _RecordT:

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/records.py
@@ -58,41 +58,67 @@ def _validate_candidate(
     client_result: ClientResult,
     candidate: CandidateOutputManifest,
 ) -> None:
-    plan = context.plan
-    shard = context.shard
-    attempt = context.attempt
+    _validate_candidate_identities(context, client_result, candidate)
+    _validate_candidate_counts(context, client_result, candidate)
+    _validate_candidate_location(context, client_result, candidate)
+    if candidate.created_at < context.attempt.created_at or client_result.completed_at < candidate.created_at:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
+            "client and candidate timestamps are inconsistent",
+        )
+
+
+def _validate_candidate_identities(
+    context: AllocationContext,
+    client_result: ClientResult,
+    candidate: CandidateOutputManifest,
+) -> None:
     identities = (
-        client_result.run_id == candidate.run_id == plan.run_id,
-        client_result.shard_id == candidate.shard_id == shard.shard_id,
-        client_result.attempt_id == candidate.attempt_id == attempt.attempt_id,
-        candidate.attempt_ordinal == attempt.attempt_ordinal,
+        client_result.run_id == candidate.run_id == context.plan.run_id,
+        client_result.shard_id == candidate.shard_id == context.shard.shard_id,
+        client_result.attempt_id == candidate.attempt_id == context.attempt.attempt_id,
+        candidate.attempt_ordinal == context.attempt.attempt_ordinal,
     )
     if not all(identities):
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
             "client and candidate identities do not match the allocation",
         )
+
+
+def _validate_candidate_counts(
+    context: AllocationContext,
+    client_result: ClientResult,
+    candidate: CandidateOutputManifest,
+) -> None:
     if not candidate.winner_eligible:
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
             "candidate record counts do not complete the planned shard",
         )
     if (
-        client_result.requested_records != shard.requested_records
+        client_result.requested_records != context.shard.requested_records
         or client_result.actual_records != candidate.actual_records
-        or candidate.actual_records != shard.requested_records
+        or candidate.actual_records != context.shard.requested_records
     ):
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
             "client and candidate record counts do not complete the planned shard",
         )
-    if client_result.requested_resume_mode != plan.invocation.authored.resume:
+
+
+def _validate_candidate_location(
+    context: AllocationContext,
+    client_result: ClientResult,
+    candidate: CandidateOutputManifest,
+) -> None:
+    if client_result.requested_resume_mode != context.plan.invocation.authored.resume:
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
             "client resume mode does not match the resolved plan",
         )
     expected_dataset_path = (
-        shard.resume_workspace.path
+        context.shard.resume_workspace.path
         if client_result.effective_resume_mode == "always"
         else posixpath.join(context.attempt_directory.as_posix(), "dataset")
     )
@@ -100,11 +126,6 @@ def _validate_candidate(
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.FINALIZATION_FAILED,
             "client and candidate dataset paths do not match the resolved plan",
-        )
-    if candidate.created_at < attempt.created_at or client_result.completed_at < candidate.created_at:
-        raise SlurmRuntimeError(
-            SlurmRuntimeErrorCode.FINALIZATION_FAILED,
-            "client and candidate timestamps are inconsistent",
         )
 
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/signals.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/signals.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized termination-signal coordination for the allocation runtime."""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from types import FrameType
+
+_TERMINATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+
+class TerminationSignalCoordinator:
+    """Install, defer, and block allocation termination handling."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._cleanup: Callable[[], None] | None = None
+        self._defer_depth = 0
+        self._deferred_signal: signal.Signals | None = None
+        self._interrupted = False
+
+    @contextmanager
+    def interrupt_on_termination(self, cleanup: Callable[[], None]) -> Iterator[None]:
+        """Install one cleanup-first termination handler for an allocation run."""
+        if self._cleanup is not None:
+            raise RuntimeError("termination signal coordination is already active")
+        previous = {selected: signal.getsignal(selected) for selected in _TERMINATION_SIGNALS}
+        self._cleanup = cleanup
+        self._interrupted = False
+        for selected in _TERMINATION_SIGNALS:
+            signal.signal(selected, self._handle_termination)
+        try:
+            yield
+        finally:
+            for selected, handler in previous.items():
+                signal.signal(selected, handler)
+            self._cleanup = None
+            self._deferred_signal = None
+            self._defer_depth = 0
+
+    @contextmanager
+    def defer_termination(self) -> Iterator[None]:
+        """Delay termination delivery until a child process is registered."""
+        with self._lock:
+            self._defer_depth += 1
+        try:
+            yield
+        finally:
+            deferred = self._finish_defer()
+        if deferred is not None:
+            os.kill(os.getpid(), deferred)
+
+    @contextmanager
+    def block_termination(self) -> Iterator[None]:
+        """Block termination delivery while owned children are being stopped."""
+        previous = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+        try:
+            yield
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, previous)
+
+    def _finish_defer(self) -> signal.Signals | None:
+        with self._lock:
+            self._defer_depth -= 1
+            if self._defer_depth or self._interrupted:
+                return None
+            deferred = self._deferred_signal
+            self._deferred_signal = None
+            return deferred
+
+    def _handle_termination(self, signum: int, frame: FrameType | None) -> None:
+        del frame
+        selected = signal.Signals(signum)
+        with self._lock:
+            if self._defer_depth:
+                if self._deferred_signal is None:
+                    self._deferred_signal = selected
+                return
+            if self._interrupted:
+                return
+            self._interrupted = True
+            cleanup = self._cleanup
+        try:
+            if cleanup is not None:
+                cleanup()
+        finally:
+            raise KeyboardInterrupt
+
+
+__all__ = ["TerminationSignalCoordinator"]

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/steps.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/steps.py
@@ -125,39 +125,8 @@ class DefaultClientStepBuilder:
         endpoints: tuple[RuntimeEndpoint, ...],
         source_environment: Mapping[str, str],
     ) -> RuntimeStep:
-        endpoint_arguments = tuple(
-            argument
-            for endpoint in endpoints
-            for argument in (
-                "--endpoint",
-                f"{endpoint.model_alias}=http://{endpoint.host}:{endpoint.port}/v1",
-            )
-        )
-        command = (
-            "python3",
-            "-m",
-            "data_designer.slurm.client.worker",
-            operation,
-            "--plan",
-            get_container_path(plan, plan_path(plan)),
-            "--shard-id",
-            shard.shard_id,
-            "--attempt-id",
-            attempt.attempt_id,
-            "--attempt-dir",
-            get_container_path(plan, attempt_directory.as_posix(), require_writable=True),
-            *endpoint_arguments,
-        )
-        secret_names = _collect_client_secret_environment_names(plan)
-        environment = _base_environment(source_environment)
-        for name in secret_names:
-            try:
-                environment[name] = source_environment[name]
-            except KeyError:
-                raise SlurmRuntimeError(
-                    SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
-                    f"required client secret environment {name!r} is unavailable",
-                ) from None
+        command = _build_client_command(operation, plan, shard, attempt, attempt_directory, endpoints)
+        secret_names, environment = _build_client_environment(plan, source_environment)
         return _build_srun_step(
             step_id=step_id,
             role=role,
@@ -168,6 +137,53 @@ class DefaultClientStepBuilder:
             plan=plan,
             attempt_directory=attempt_directory,
         )
+
+
+def _build_client_command(
+    operation: str,
+    plan: ResolvedSlurmRunPlan,
+    shard: PlannedShard,
+    attempt: AttemptManifest,
+    attempt_directory: Path,
+    endpoints: tuple[RuntimeEndpoint, ...],
+) -> tuple[str, ...]:
+    endpoint_arguments = tuple(
+        argument
+        for endpoint in endpoints
+        for argument in ("--endpoint", f"{endpoint.model_alias}=http://{endpoint.host}:{endpoint.port}/v1")
+    )
+    return (
+        "python3",
+        "-m",
+        "data_designer.slurm.client.worker",
+        operation,
+        "--plan",
+        get_container_path(plan, plan_path(plan)),
+        "--shard-id",
+        shard.shard_id,
+        "--attempt-id",
+        attempt.attempt_id,
+        "--attempt-dir",
+        get_container_path(plan, attempt_directory.as_posix(), require_writable=True),
+        *endpoint_arguments,
+    )
+
+
+def _build_client_environment(
+    plan: ResolvedSlurmRunPlan,
+    source_environment: Mapping[str, str],
+) -> tuple[tuple[str, ...], dict[str, str]]:
+    secret_names = _collect_client_secret_environment_names(plan)
+    environment = _base_environment(source_environment)
+    for name in secret_names:
+        try:
+            environment[name] = source_environment[name]
+        except KeyError:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                f"required client secret environment {name!r} is unavailable",
+            ) from None
+    return secret_names, environment
 
 
 def build_vllm_steps(
@@ -193,37 +209,54 @@ def build_endpoint_steps(
     """Build one package-owned logical-endpoint process per deployment."""
     steps: list[tuple[RuntimeStep, RuntimeEndpoint]] = []
     for deployment in deployments:
-        endpoint = RuntimeEndpoint(
-            model_alias=deployment.model_alias,
-            served_model_name=deployment.served_model_name,
-            host="127.0.0.1",
-            port=deployment.logical_endpoint.port,
-        )
-        backends = tuple(f"http://127.0.0.1:{backend.port}" for backend in deployment.backend_endpoints)
-        retry_after_seconds = deployment.launch_policy.queue_backpressure.retry_after_seconds
-        retry_arguments = ("--retry-after-seconds", str(retry_after_seconds)) if retry_after_seconds is not None else ()
-        command = (
-            "python3",
-            get_container_path(plan, runtime_proxy_path.as_posix()),
-            "--listen-port",
-            str(endpoint.port),
-            "--max-waiting-requests",
-            str(deployment.launch_policy.queue_backpressure.max_waiting_requests),
-            *retry_arguments,
-            *(argument for backend in backends for argument in ("--backend", backend)),
-        )
-        step = _build_srun_step(
-            step_id=f"{deployment.deployment_id}-endpoint",
-            role=RuntimeStepRole.ENDPOINT,
-            image_path=plan.client.image.path,
-            command=command,
-            environment=_base_environment(source_environment),
-            container_environment=(),
-            plan=plan,
-            attempt_directory=attempt_directory,
-        )
-        steps.append((step, endpoint))
+        steps.append(_build_endpoint_step(deployment, plan, attempt_directory, source_environment, runtime_proxy_path))
     return tuple(steps)
+
+
+def _build_endpoint_step(
+    deployment: ResolvedVllmServerDeployment,
+    plan: ResolvedSlurmRunPlan,
+    attempt_directory: Path,
+    source_environment: Mapping[str, str],
+    runtime_proxy_path: Path,
+) -> tuple[RuntimeStep, RuntimeEndpoint]:
+    endpoint = RuntimeEndpoint(
+        model_alias=deployment.model_alias,
+        served_model_name=deployment.served_model_name,
+        host="127.0.0.1",
+        port=deployment.logical_endpoint.port,
+    )
+    command = _build_endpoint_command(deployment, plan, runtime_proxy_path, endpoint.port)
+    step = _build_srun_step(
+        step_id=f"{deployment.deployment_id}-endpoint",
+        role=RuntimeStepRole.ENDPOINT,
+        image_path=plan.client.image.path,
+        command=command,
+        environment=_base_environment(source_environment),
+        container_environment=(),
+        plan=plan,
+        attempt_directory=attempt_directory,
+    )
+    return step, endpoint
+
+
+def _build_endpoint_command(
+    deployment: ResolvedVllmServerDeployment,
+    plan: ResolvedSlurmRunPlan,
+    runtime_proxy_path: Path,
+    port: int,
+) -> tuple[str, ...]:
+    backends = tuple(f"http://127.0.0.1:{backend.port}" for backend in deployment.backend_endpoints)
+    retry_after_seconds = deployment.launch_policy.queue_backpressure.retry_after_seconds
+    retry_arguments = ("--retry-after-seconds", str(retry_after_seconds)) if retry_after_seconds is not None else ()
+    return (
+        "python3",
+        get_container_path(plan, runtime_proxy_path.as_posix()),
+        "--listen-port",
+        str(port),
+        *retry_arguments,
+        *(argument for backend in backends for argument in ("--backend", backend)),
+    )
 
 
 def plan_path(plan: ResolvedSlurmRunPlan) -> str:
@@ -238,11 +271,36 @@ def _build_vllm_step(
     attempt_directory: Path,
     source_environment: Mapping[str, str],
 ) -> RuntimeStep:
+    _validate_local_vllm_process(process)
+    command = _build_vllm_command(deployment, process)
+    environment, container_environment = _build_vllm_environment(deployment, source_environment)
+    return _build_srun_step(
+        step_id=process.process_id,
+        role=RuntimeStepRole.SERVER,
+        image_path=deployment.image.path,
+        command=command,
+        environment=environment,
+        container_environment=container_environment,
+        plan=plan,
+        attempt_directory=attempt_directory,
+        gpu_indices=tuple(process.gpu_indices),
+    )
+
+
+def _validate_local_vllm_process(process: ResolvedVllmProcess) -> None:
     if process.pipeline_parallel != 1 or process.node_index != 0 or process.http_port is None:
         raise SlurmRuntimeError(
             SlurmRuntimeErrorCode.INVALID_CONTEXT,
             "one-node runtime received a distributed vLLM process",
         )
+
+
+def _build_vllm_command(
+    deployment: ResolvedVllmServerDeployment,
+    process: ResolvedVllmProcess,
+) -> tuple[str, ...]:
+    if process.http_port is None:  # pragma: no cover - validated before command construction
+        raise AssertionError("vLLM HTTP port is unavailable")
     command: tuple[str, ...] = (
         deployment.executable_path,
         "serve",
@@ -258,11 +316,15 @@ def _build_vllm_step(
     )
     if deployment.launch_policy.enable_expert_parallel:
         command += ("--enable-expert-parallel",)
-    command += deployment.launch_policy.extra_args
+    return command + deployment.launch_policy.extra_args
 
+
+def _build_vllm_environment(
+    deployment: ResolvedVllmServerDeployment,
+    source_environment: Mapping[str, str],
+) -> tuple[dict[str, str], tuple[str, ...]]:
     environment = _base_environment(source_environment)
-    container_environment = ["CUDA_VISIBLE_DEVICES"]
-    environment["CUDA_VISIBLE_DEVICES"] = ",".join(str(index) for index in process.gpu_indices)
+    container_environment: list[str] = []
     for name, binding in deployment.launch_policy.environment.items():
         if isinstance(binding, LiteralEnvironmentBinding):
             environment[name] = binding.value
@@ -277,17 +339,7 @@ def _build_vllm_step(
         else:  # pragma: no cover - persisted contracts reject unknown bindings
             raise AssertionError(f"unhandled environment binding: {type(binding)!r}")
         container_environment.append(name)
-    return _build_srun_step(
-        step_id=process.process_id,
-        role=RuntimeStepRole.SERVER,
-        image_path=deployment.image.path,
-        command=command,
-        environment=environment,
-        container_environment=tuple(container_environment),
-        plan=plan,
-        attempt_directory=attempt_directory,
-        gpu_indices=tuple(process.gpu_indices),
-    )
+    return environment, tuple(container_environment)
 
 
 def _build_srun_step(
@@ -302,32 +354,9 @@ def _build_srun_step(
     attempt_directory: Path,
     gpu_indices: tuple[int, ...] = (),
 ) -> RuntimeStep:
-    mounts = _render_mounts(plan)
-    srun_command = [
-        "srun",
-        "--nodes=1",
-        "--ntasks=1",
-        "--exact",
-        "--overlap",
-        "--unbuffered",
-        "--export=ALL",
-        f"--cpus-per-task={plan.client.authored.cpus}",
-        f"--container-image={image_path}",
-    ]
-    if gpu_indices:
-        rendered_indices = ",".join(str(index) for index in gpu_indices)
-        srun_command.extend(
-            (
-                f"--gpus-per-task={len(gpu_indices)}",
-                f"--gpu-bind=map_gpu:{rendered_indices}",
-            )
-        )
-    else:
-        srun_command.append("--gres=none")
-    if mounts:
-        srun_command.append(f"--container-mounts={mounts}")
-    if container_environment:
-        srun_command.append(f"--container-env={','.join(sorted(set(container_environment)))}")
+    srun_command = _build_srun_prefix(plan, image_path)
+    _add_srun_resources(srun_command, gpu_indices)
+    _add_srun_container_options(srun_command, plan, container_environment)
     srun_command.extend(("--", *command))
     log_root = attempt_directory / "logs"
     return RuntimeStep(
@@ -338,6 +367,48 @@ def _build_srun_step(
         stdout_path=log_root / f"{step_id}.out",
         stderr_path=log_root / f"{step_id}.err",
     )
+
+
+def _build_srun_prefix(plan: ResolvedSlurmRunPlan, image_path: str) -> list[str]:
+    return [
+        "srun",
+        "--nodes=1",
+        "--ntasks=1",
+        "--exact",
+        "--overlap",
+        "--unbuffered",
+        "--export=ALL",
+        f"--cpus-per-task={plan.client.authored.cpus}",
+        f"--container-image={image_path}",
+    ]
+
+
+def _add_srun_resources(srun_command: list[str], gpu_indices: tuple[int, ...]) -> None:
+    if gpu_indices:
+        srun_command.extend(
+            (
+                f"--gpus-per-task={len(gpu_indices)}",
+                f"--gpu-bind=mask_gpu:{_get_gpu_mask(gpu_indices):#x}",
+            )
+        )
+    else:
+        srun_command.append("--gres=none")
+
+
+def _add_srun_container_options(
+    srun_command: list[str],
+    plan: ResolvedSlurmRunPlan,
+    container_environment: tuple[str, ...],
+) -> None:
+    mounts = _render_mounts(plan)
+    if mounts:
+        srun_command.append(f"--container-mounts={mounts}")
+    if container_environment:
+        srun_command.append(f"--container-env={','.join(sorted(set(container_environment)))}")
+
+
+def _get_gpu_mask(gpu_indices: tuple[int, ...]) -> int:
+    return sum(1 << index for index in gpu_indices)
 
 
 def _render_mounts(plan: ResolvedSlurmRunPlan) -> str:
@@ -368,21 +439,20 @@ def _base_environment(source_environment: Mapping[str, str]) -> dict[str, str]:
 
 def _collect_client_secret_environment_names(plan: ResolvedSlurmRunPlan) -> tuple[str, ...]:
     names: set[str] = set()
-
-    def visit(value: object) -> None:
-        if isinstance(value, SecretRef):
-            names.add(value.environment)
-            return
-        if isinstance(value, BaseModel):
-            for field_name in type(value).model_fields:
-                visit(getattr(value, field_name))
-        elif isinstance(value, Mapping):
-            for child in value.values():
-                visit(child)
-        elif isinstance(value, (tuple, list)):
-            for child in value:
-                visit(child)
-
-    visit(plan.client.authored.dependencies.index_credentials)
-    visit(plan.invocation.authored.mcp_providers)
+    _collect_secret_environment_names(plan.client.authored.dependencies.index_credentials, names)
+    _collect_secret_environment_names(plan.invocation.authored.mcp_providers, names)
     return tuple(sorted(names))
+
+
+def _collect_secret_environment_names(value: object, names: set[str]) -> None:
+    if isinstance(value, SecretRef):
+        names.add(value.environment)
+    elif isinstance(value, BaseModel):
+        for field_name in type(value).model_fields:
+            _collect_secret_environment_names(getattr(value, field_name), names)
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            _collect_secret_environment_names(child, names)
+    elif isinstance(value, (tuple, list)):
+        for child in value:
+            _collect_secret_environment_names(child, names)

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/steps.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/steps.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build every allocation-local process as one structured ``srun`` step."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel
+
+from data_designer.slurm.config.environment import LiteralEnvironmentBinding, SecretRef
+from data_designer.slurm.planning import PlannedShard, ResolvedSlurmRunPlan
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import RuntimeEndpoint, RuntimeStep, RuntimeStepRole
+from data_designer.slurm.runtime.paths import get_container_path
+from data_designer.slurm.serving.deployment import ResolvedVllmServerDeployment
+from data_designer.slurm.serving.vllm import ResolvedVllmProcess
+from data_designer.slurm.state import AttemptManifest
+
+_SLURM_ENVIRONMENT_NAMES = (
+    "SLURM_ARRAY_JOB_ID",
+    "SLURM_ARRAY_TASK_ID",
+    "SLURM_CLUSTER_NAME",
+    "SLURM_CONF",
+    "SLURM_CPUS_ON_NODE",
+    "SLURM_JOB_CPUS_PER_NODE",
+    "SLURM_JOB_GPUS",
+    "SLURM_JOB_ID",
+    "SLURM_JOB_NODELIST",
+    "SLURM_JOB_NUM_NODES",
+    "SLURM_NODEID",
+    "SLURM_PROCID",
+    "SLURM_SUBMIT_DIR",
+)
+
+
+class ClientStepBuilder(Protocol):
+    """Construct #876-owned client commands for the common runtime runner."""
+
+    def build_preflight_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        attempt: AttemptManifest,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: Mapping[str, str],
+    ) -> RuntimeStep:
+        """Build the zero-GPU client preflight step."""
+        ...
+
+    def build_generation_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        attempt: AttemptManifest,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: Mapping[str, str],
+    ) -> RuntimeStep:
+        """Build the zero-GPU client generation step."""
+        ...
+
+
+class DefaultClientStepBuilder:
+    """Invoke the allocation client worker supplied by #876."""
+
+    def build_preflight_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        attempt: AttemptManifest,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: Mapping[str, str],
+    ) -> RuntimeStep:
+        """Build a deterministic client-worker preflight command."""
+        return self._build_step(
+            "client-preflight",
+            RuntimeStepRole.CLIENT_PREFLIGHT,
+            "preflight",
+            plan,
+            shard,
+            attempt,
+            attempt_directory,
+            endpoints,
+            source_environment,
+        )
+
+    def build_generation_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        attempt: AttemptManifest,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: Mapping[str, str],
+    ) -> RuntimeStep:
+        """Build a deterministic client-worker generation command."""
+        return self._build_step(
+            "client-generation",
+            RuntimeStepRole.CLIENT,
+            "run",
+            plan,
+            shard,
+            attempt,
+            attempt_directory,
+            endpoints,
+            source_environment,
+        )
+
+    @staticmethod
+    def _build_step(
+        step_id: str,
+        role: RuntimeStepRole,
+        operation: str,
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        attempt: AttemptManifest,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: Mapping[str, str],
+    ) -> RuntimeStep:
+        endpoint_arguments = tuple(
+            argument
+            for endpoint in endpoints
+            for argument in (
+                "--endpoint",
+                f"{endpoint.model_alias}=http://{endpoint.host}:{endpoint.port}/v1",
+            )
+        )
+        command = (
+            "python3",
+            "-m",
+            "data_designer.slurm.client.worker",
+            operation,
+            "--plan",
+            get_container_path(plan, plan_path(plan)),
+            "--shard-id",
+            shard.shard_id,
+            "--attempt-id",
+            attempt.attempt_id,
+            "--attempt-dir",
+            get_container_path(plan, attempt_directory.as_posix(), require_writable=True),
+            *endpoint_arguments,
+        )
+        secret_names = _collect_client_secret_environment_names(plan)
+        environment = _base_environment(source_environment)
+        for name in secret_names:
+            try:
+                environment[name] = source_environment[name]
+            except KeyError:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                    f"required client secret environment {name!r} is unavailable",
+                ) from None
+        return _build_srun_step(
+            step_id=step_id,
+            role=role,
+            image_path=plan.client.image.path,
+            command=command,
+            environment=environment,
+            container_environment=secret_names,
+            plan=plan,
+            attempt_directory=attempt_directory,
+        )
+
+
+def build_vllm_steps(
+    deployment: ResolvedVllmServerDeployment,
+    plan: ResolvedSlurmRunPlan,
+    attempt_directory: Path,
+    source_environment: Mapping[str, str],
+) -> tuple[RuntimeStep, ...]:
+    """Build one structured server step per resolved vLLM process."""
+    return tuple(
+        _build_vllm_step(deployment, process, plan, attempt_directory, source_environment)
+        for process in deployment.processes
+    )
+
+
+def build_endpoint_steps(
+    deployments: tuple[ResolvedVllmServerDeployment, ...],
+    plan: ResolvedSlurmRunPlan,
+    attempt_directory: Path,
+    source_environment: Mapping[str, str],
+    runtime_proxy_path: Path,
+) -> tuple[tuple[RuntimeStep, RuntimeEndpoint], ...]:
+    """Build one package-owned logical-endpoint process per deployment."""
+    steps: list[tuple[RuntimeStep, RuntimeEndpoint]] = []
+    for deployment in deployments:
+        endpoint = RuntimeEndpoint(
+            model_alias=deployment.model_alias,
+            served_model_name=deployment.served_model_name,
+            host="127.0.0.1",
+            port=deployment.logical_endpoint.port,
+        )
+        backends = tuple(f"http://127.0.0.1:{backend.port}" for backend in deployment.backend_endpoints)
+        retry_after_seconds = deployment.launch_policy.queue_backpressure.retry_after_seconds
+        retry_arguments = ("--retry-after-seconds", str(retry_after_seconds)) if retry_after_seconds is not None else ()
+        command = (
+            "python3",
+            get_container_path(plan, runtime_proxy_path.as_posix()),
+            "--listen-port",
+            str(endpoint.port),
+            "--max-waiting-requests",
+            str(deployment.launch_policy.queue_backpressure.max_waiting_requests),
+            *retry_arguments,
+            *(argument for backend in backends for argument in ("--backend", backend)),
+        )
+        step = _build_srun_step(
+            step_id=f"{deployment.deployment_id}-endpoint",
+            role=RuntimeStepRole.ENDPOINT,
+            image_path=plan.client.image.path,
+            command=command,
+            environment=_base_environment(source_environment),
+            container_environment=(),
+            plan=plan,
+            attempt_directory=attempt_directory,
+        )
+        steps.append((step, endpoint))
+    return tuple(steps)
+
+
+def plan_path(plan: ResolvedSlurmRunPlan) -> str:
+    """Return the canonical persisted resolved-plan path."""
+    return str(Path(plan.authored_config.path).with_name("resolved-plan.json"))
+
+
+def _build_vllm_step(
+    deployment: ResolvedVllmServerDeployment,
+    process: ResolvedVllmProcess,
+    plan: ResolvedSlurmRunPlan,
+    attempt_directory: Path,
+    source_environment: Mapping[str, str],
+) -> RuntimeStep:
+    if process.pipeline_parallel != 1 or process.node_index != 0 or process.http_port is None:
+        raise SlurmRuntimeError(
+            SlurmRuntimeErrorCode.INVALID_CONTEXT,
+            "one-node runtime received a distributed vLLM process",
+        )
+    command: tuple[str, ...] = (
+        deployment.executable_path,
+        "serve",
+        deployment.model,
+        "--served-model-name",
+        deployment.served_model_name,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(process.http_port),
+        "--tensor-parallel-size",
+        str(process.tensor_parallel),
+    )
+    if deployment.launch_policy.enable_expert_parallel:
+        command += ("--enable-expert-parallel",)
+    command += deployment.launch_policy.extra_args
+
+    environment = _base_environment(source_environment)
+    container_environment = ["CUDA_VISIBLE_DEVICES"]
+    environment["CUDA_VISIBLE_DEVICES"] = ",".join(str(index) for index in process.gpu_indices)
+    for name, binding in deployment.launch_policy.environment.items():
+        if isinstance(binding, LiteralEnvironmentBinding):
+            environment[name] = binding.value
+        elif isinstance(binding, SecretRef):
+            try:
+                environment[name] = source_environment[binding.environment]
+            except KeyError:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.PREFLIGHT_FAILED,
+                    f"required server secret environment {binding.environment!r} is unavailable",
+                ) from None
+        else:  # pragma: no cover - persisted contracts reject unknown bindings
+            raise AssertionError(f"unhandled environment binding: {type(binding)!r}")
+        container_environment.append(name)
+    return _build_srun_step(
+        step_id=process.process_id,
+        role=RuntimeStepRole.SERVER,
+        image_path=deployment.image.path,
+        command=command,
+        environment=environment,
+        container_environment=tuple(container_environment),
+        plan=plan,
+        attempt_directory=attempt_directory,
+        gpu_indices=tuple(process.gpu_indices),
+    )
+
+
+def _build_srun_step(
+    *,
+    step_id: str,
+    role: RuntimeStepRole,
+    image_path: str,
+    command: tuple[str, ...],
+    environment: Mapping[str, str],
+    container_environment: tuple[str, ...],
+    plan: ResolvedSlurmRunPlan,
+    attempt_directory: Path,
+    gpu_indices: tuple[int, ...] = (),
+) -> RuntimeStep:
+    mounts = _render_mounts(plan)
+    srun_command = [
+        "srun",
+        "--nodes=1",
+        "--ntasks=1",
+        "--exact",
+        "--overlap",
+        "--unbuffered",
+        "--export=ALL",
+        f"--cpus-per-task={plan.client.authored.cpus}",
+        f"--container-image={image_path}",
+    ]
+    if gpu_indices:
+        rendered_indices = ",".join(str(index) for index in gpu_indices)
+        srun_command.extend(
+            (
+                f"--gpus-per-task={len(gpu_indices)}",
+                f"--gpu-bind=map_gpu:{rendered_indices}",
+            )
+        )
+    else:
+        srun_command.append("--gres=none")
+    if mounts:
+        srun_command.append(f"--container-mounts={mounts}")
+    if container_environment:
+        srun_command.append(f"--container-env={','.join(sorted(set(container_environment)))}")
+    srun_command.extend(("--", *command))
+    log_root = attempt_directory / "logs"
+    return RuntimeStep(
+        step_id=step_id,
+        role=role,
+        command=tuple(srun_command),
+        environment=environment,
+        stdout_path=log_root / f"{step_id}.out",
+        stderr_path=log_root / f"{step_id}.err",
+    )
+
+
+def _render_mounts(plan: ResolvedSlurmRunPlan) -> str:
+    rendered: list[str] = []
+    for mount in plan.container_mounts:
+        if any(character in mount.source or character in mount.target for character in (",", ":")):
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.INVALID_CONTEXT,
+                "container mount paths cannot contain comma or colon delimiters",
+            )
+        value = f"{mount.source}:{mount.target}"
+        if mount.read_only:
+            value += ":ro"
+        rendered.append(value)
+    return ",".join(rendered)
+
+
+def _base_environment(source_environment: Mapping[str, str]) -> dict[str, str]:
+    environment = {
+        "PATH": source_environment.get("PATH") or os.defpath,
+        "LC_ALL": "C",
+    }
+    environment.update(
+        (name, source_environment[name]) for name in _SLURM_ENVIRONMENT_NAMES if name in source_environment
+    )
+    return environment
+
+
+def _collect_client_secret_environment_names(plan: ResolvedSlurmRunPlan) -> tuple[str, ...]:
+    names: set[str] = set()
+
+    def visit(value: object) -> None:
+        if isinstance(value, SecretRef):
+            names.add(value.environment)
+            return
+        if isinstance(value, BaseModel):
+            for field_name in type(value).model_fields:
+                visit(getattr(value, field_name))
+        elif isinstance(value, Mapping):
+            for child in value.values():
+                visit(child)
+        elif isinstance(value, (tuple, list)):
+            for child in value:
+                visit(child)
+
+    visit(plan.client.authored.dependencies.index_credentials)
+    visit(plan.invocation.authored.mcp_providers)
+    return tuple(sorted(names))

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
@@ -10,12 +10,17 @@ import signal
 import stat
 import subprocess
 import time
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from types import FrameType
 from typing import Protocol
 
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
 from data_designer.slurm.runtime.models import RuntimeStep
+
+_TERMINATION_SIGNALS = frozenset((signal.SIGINT, signal.SIGTERM))
 
 
 class RuntimeClock(Protocol):
@@ -88,45 +93,18 @@ class SubprocessStepRunner:
 
     def start(self, step: RuntimeStep) -> StepProcess:
         """Start one step with restrictive package-owned log files."""
-        log_root = step.stdout_path.parent
-        log_root.mkdir(mode=0o700, parents=False, exist_ok=True)
-        before = log_root.lstat()
-        if not stat.S_ISDIR(before.st_mode):
-            raise OSError(f"runtime log root {log_root} is not a directory")
-        directory_descriptor = os.open(
-            log_root,
-            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
-        )
-        try:
-            opened = os.fstat(directory_descriptor)
-            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
-                raise OSError(f"runtime log root {log_root} changed while it was opened")
-            os.fchmod(directory_descriptor, 0o700)
-            stdout_descriptor = _create_log_file(directory_descriptor, step.stdout_path.name)
-            try:
-                stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
-            except BaseException:
-                os.close(stdout_descriptor)
-                raise
-            try:
-                process = _SessionStepProcess(
-                    subprocess.Popen(
-                        step.command,
-                        stdin=subprocess.DEVNULL,
-                        stdout=stdout_descriptor,
-                        stderr=stderr_descriptor,
-                        env=dict(step.environment),
-                        shell=False,
-                        start_new_session=True,
-                        close_fds=True,
-                    )
-                )
-            finally:
-                os.close(stdout_descriptor)
-                os.close(stderr_descriptor)
-        finally:
-            os.close(directory_descriptor)
-        return process
+        with _open_step_logs(step) as (stdout_descriptor, stderr_descriptor):
+            process = subprocess.Popen(
+                step.command,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_descriptor,
+                stderr=stderr_descriptor,
+                env=dict(step.environment),
+                shell=False,
+                start_new_session=True,
+                close_fds=True,
+            )
+        return _SessionStepProcess(process)
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,18 +172,24 @@ class StepSupervisor:
         """Return the started process identities in launch order."""
         return tuple(self._managed)
 
+    @property
+    def cleanup_complete(self) -> bool:
+        """Return whether every registered process is confirmed exited."""
+        return self._cleanup_complete
+
     def start(self, step: RuntimeStep) -> ManagedStep:
         """Start and register one structured step."""
         if self._cleanup_started:
             raise SlurmRuntimeError(SlurmRuntimeErrorCode.CLEANUP_FAILED, "cannot start a step after cleanup")
         try:
-            managed = ManagedStep(step=step, process=self._runner.start(step))
+            with _defer_termination_signals():
+                managed = ManagedStep(step=step, process=self._runner.start(step))
+                self._managed.append(managed)
         except (OSError, subprocess.SubprocessError) as error:
             raise SlurmRuntimeError(
                 SlurmRuntimeErrorCode.STEP_FAILED,
                 f"cannot start runtime step {step.step_id!r}",
             ) from error
-        self._managed.append(managed)
         return managed
 
     def wait(self, target: ManagedStep, *, required: tuple[ManagedStep, ...] = ()) -> None:
@@ -239,35 +223,59 @@ class StepSupervisor:
             return
         self._cleanup_started = True
         self._cleanup_in_progress = True
-        failures: list[BaseException] = []
         try:
-            live = tuple(managed for managed in reversed(self._managed) if managed.process.poll() is None)
-            for managed in live:
-                try:
-                    managed.process.terminate()
-                except BaseException as error:
-                    failures.append(error)
-            deadline = self._clock.monotonic() + self._termination_grace_seconds
-            for managed in live:
-                while managed.process.poll() is None and self._clock.monotonic() < deadline:
-                    self._clock.sleep(self._poll_interval_seconds)
-                if managed.process.poll() is None:
-                    try:
-                        managed.process.kill()
-                    except BaseException as error:
-                        failures.append(error)
-                try:
-                    managed.process.wait(timeout=self._termination_grace_seconds)
-                except BaseException as error:
-                    failures.append(error)
+            with _block_termination_signals():
+                failures = self._stop_managed_steps()
+                self._cleanup_complete = self._are_all_steps_stopped()
         finally:
             self._cleanup_in_progress = False
+        if not self._cleanup_complete:
+            failures.append(RuntimeError("one or more runtime processes are still running"))
         if failures:
             raise SlurmRuntimeError(
                 SlurmRuntimeErrorCode.CLEANUP_FAILED,
                 f"cleanup failed for {len(failures)} runtime process operation(s)",
             ) from failures[0]
-        self._cleanup_complete = True
+
+    def _stop_managed_steps(self) -> list[BaseException]:
+        failures: list[BaseException] = []
+        live = tuple(managed for managed in reversed(self._managed) if self._is_running(managed, failures))
+        for managed in live:
+            try:
+                managed.process.terminate()
+            except BaseException as error:
+                failures.append(error)
+        deadline = self._clock.monotonic() + self._termination_grace_seconds
+        for managed in live:
+            self._stop_step(managed, deadline, failures)
+        return failures
+
+    def _stop_step(self, managed: ManagedStep, deadline: float, failures: list[BaseException]) -> None:
+        while self._is_running(managed, failures) and self._clock.monotonic() < deadline:
+            self._clock.sleep(self._poll_interval_seconds)
+        if self._is_running(managed, failures):
+            try:
+                managed.process.kill()
+            except BaseException as error:
+                failures.append(error)
+        try:
+            managed.process.wait(timeout=self._termination_grace_seconds)
+        except BaseException as error:
+            failures.append(error)
+
+    @staticmethod
+    def _is_running(managed: ManagedStep, failures: list[BaseException]) -> bool:
+        try:
+            return managed.process.poll() is None
+        except BaseException as error:
+            failures.append(error)
+            return True
+
+    def _are_all_steps_stopped(self) -> bool:
+        try:
+            return all(managed.process.poll() is not None for managed in self._managed)
+        except BaseException:
+            return False
 
 
 def _create_log_file(directory_descriptor: int, name: str) -> int:
@@ -277,3 +285,68 @@ def _create_log_file(directory_descriptor: int, name: str) -> int:
         0o600,
         dir_fd=directory_descriptor,
     )
+
+
+@contextmanager
+def _open_step_logs(step: RuntimeStep) -> Iterator[tuple[int, int]]:
+    log_root = step.stdout_path.parent
+    log_root.mkdir(mode=0o700, parents=False, exist_ok=True)
+    before = log_root.lstat()
+    if not stat.S_ISDIR(before.st_mode):
+        raise OSError(f"runtime log root {log_root} is not a directory")
+    with ExitStack() as resources:
+        directory_descriptor = os.open(
+            log_root,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        resources.callback(os.close, directory_descriptor)
+        opened = os.fstat(directory_descriptor)
+        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+            raise OSError(f"runtime log root {log_root} changed while it was opened")
+        os.fchmod(directory_descriptor, 0o700)
+        stdout_descriptor = _create_log_file(directory_descriptor, step.stdout_path.name)
+        resources.callback(os.close, stdout_descriptor)
+        stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
+        resources.callback(os.close, stderr_descriptor)
+        yield stdout_descriptor, stderr_descriptor
+
+
+@contextmanager
+def _block_termination_signals() -> Iterator[None]:
+    previous = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+    try:
+        yield
+    finally:
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous)
+
+
+@contextmanager
+def _defer_termination_signals() -> Iterator[None]:
+    previous = {selected: signal.getsignal(selected) for selected in _TERMINATION_SIGNALS}
+    deferred: list[signal.Signals] = []
+
+    def defer(signum: int, frame: FrameType | None) -> None:
+        del frame
+        if not deferred:
+            deferred.append(signal.Signals(signum))
+
+    for selected in _TERMINATION_SIGNALS:
+        signal.signal(selected, defer)
+    try:
+        yield
+    finally:
+        for selected, handler in previous.items():
+            signal.signal(selected, handler)
+    if deferred:
+        _deliver_deferred_signal(deferred[0], previous[deferred[0]])
+
+
+def _deliver_deferred_signal(selected: signal.Signals, handler: signal.Handlers) -> None:
+    if handler is signal.SIG_IGN:
+        return
+    if callable(handler):
+        handler(selected, None)
+        return
+    if selected is signal.SIGINT:
+        raise KeyboardInterrupt
+    os.kill(os.getpid(), selected)

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
@@ -14,13 +14,11 @@ from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from types import FrameType
 from typing import Protocol
 
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
 from data_designer.slurm.runtime.models import RuntimeStep
-
-_TERMINATION_SIGNALS = frozenset((signal.SIGINT, signal.SIGTERM))
+from data_designer.slurm.runtime.signals import TerminationSignalCoordinator
 
 
 class RuntimeClock(Protocol):
@@ -152,6 +150,7 @@ class StepSupervisor:
         self,
         runner: RuntimeStepRunner,
         *,
+        signals: TerminationSignalCoordinator,
         clock: RuntimeClock | None = None,
         poll_interval_seconds: float = 0.1,
         termination_grace_seconds: float = 10.0,
@@ -159,6 +158,7 @@ class StepSupervisor:
         if poll_interval_seconds <= 0 or termination_grace_seconds <= 0:
             raise ValueError("runtime polling and termination intervals must be positive")
         self._runner = runner
+        self._signals = signals
         self._clock = clock or SystemRuntimeClock()
         self._poll_interval_seconds = poll_interval_seconds
         self._termination_grace_seconds = termination_grace_seconds
@@ -182,7 +182,7 @@ class StepSupervisor:
         if self._cleanup_started:
             raise SlurmRuntimeError(SlurmRuntimeErrorCode.CLEANUP_FAILED, "cannot start a step after cleanup")
         try:
-            with _defer_termination_signals():
+            with self._signals.defer_termination():
                 managed = ManagedStep(step=step, process=self._runner.start(step))
                 self._managed.append(managed)
         except (OSError, subprocess.SubprocessError) as error:
@@ -224,7 +224,7 @@ class StepSupervisor:
         self._cleanup_started = True
         self._cleanup_in_progress = True
         try:
-            with _block_termination_signals():
+            with self._signals.block_termination():
                 failures = self._stop_managed_steps()
                 self._cleanup_complete = self._are_all_steps_stopped()
         finally:
@@ -309,44 +309,3 @@ def _open_step_logs(step: RuntimeStep) -> Iterator[tuple[int, int]]:
         stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
         resources.callback(os.close, stderr_descriptor)
         yield stdout_descriptor, stderr_descriptor
-
-
-@contextmanager
-def _block_termination_signals() -> Iterator[None]:
-    previous = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
-    try:
-        yield
-    finally:
-        signal.pthread_sigmask(signal.SIG_SETMASK, previous)
-
-
-@contextmanager
-def _defer_termination_signals() -> Iterator[None]:
-    previous = {selected: signal.getsignal(selected) for selected in _TERMINATION_SIGNALS}
-    deferred: list[signal.Signals] = []
-
-    def defer(signum: int, frame: FrameType | None) -> None:
-        del frame
-        if not deferred:
-            deferred.append(signal.Signals(signum))
-
-    for selected in _TERMINATION_SIGNALS:
-        signal.signal(selected, defer)
-    try:
-        yield
-    finally:
-        for selected, handler in previous.items():
-            signal.signal(selected, handler)
-    if deferred:
-        _deliver_deferred_signal(deferred[0], previous[deferred[0]])
-
-
-def _deliver_deferred_signal(selected: signal.Signals, handler: signal.Handlers) -> None:
-    if handler is signal.SIG_IGN:
-        return
-    if callable(handler):
-        handler(selected, None)
-        return
-    if selected is signal.SIGINT:
-        raise KeyboardInterrupt
-    os.kill(os.getpid(), selected)

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One owner for allocation-local process launch, observation, and cleanup."""
+
+from __future__ import annotations
+
+import os
+import signal
+import stat
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import RuntimeStep
+
+
+class RuntimeClock(Protocol):
+    """Monotonic time and sleep boundary used by runtime polling."""
+
+    def monotonic(self) -> float:
+        """Return monotonic seconds."""
+        ...
+
+    def now(self) -> datetime:
+        """Return timezone-aware UTC wall-clock time."""
+        ...
+
+    def sleep(self, seconds: float) -> None:
+        """Advance or wait for positive seconds."""
+        ...
+
+
+class SystemRuntimeClock:
+    """Production runtime clock."""
+
+    def monotonic(self) -> float:
+        """Return system monotonic seconds."""
+        return time.monotonic()
+
+    def now(self) -> datetime:
+        """Return current UTC wall-clock time."""
+        return datetime.now(timezone.utc)
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep for the requested duration."""
+        time.sleep(seconds)
+
+
+class StepProcess(Protocol):
+    """Minimal process handle required by the allocation supervisor."""
+
+    @property
+    def pid(self) -> int:
+        """Return the child process identity."""
+        ...
+
+    def poll(self) -> int | None:
+        """Return the exit status when complete."""
+        ...
+
+    def terminate(self) -> None:
+        """Request graceful termination."""
+        ...
+
+    def kill(self) -> None:
+        """Force termination."""
+        ...
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Wait for completion and return the exit status."""
+        ...
+
+
+class RuntimeStepRunner(Protocol):
+    """Start structured runtime steps without a shell."""
+
+    def start(self, step: RuntimeStep) -> StepProcess:
+        """Start one process and return its handle."""
+        ...
+
+
+class SubprocessStepRunner:
+    """Production process boundary using ``Popen`` with exact argv and environment."""
+
+    def start(self, step: RuntimeStep) -> StepProcess:
+        """Start one step with restrictive package-owned log files."""
+        log_root = step.stdout_path.parent
+        log_root.mkdir(mode=0o700, parents=False, exist_ok=True)
+        before = log_root.lstat()
+        if not stat.S_ISDIR(before.st_mode):
+            raise OSError(f"runtime log root {log_root} is not a directory")
+        directory_descriptor = os.open(
+            log_root,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            opened = os.fstat(directory_descriptor)
+            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+                raise OSError(f"runtime log root {log_root} changed while it was opened")
+            os.fchmod(directory_descriptor, 0o700)
+            stdout_descriptor = _create_log_file(directory_descriptor, step.stdout_path.name)
+            try:
+                stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
+            except BaseException:
+                os.close(stdout_descriptor)
+                raise
+            try:
+                process = _SessionStepProcess(
+                    subprocess.Popen(
+                        step.command,
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout_descriptor,
+                        stderr=stderr_descriptor,
+                        env=dict(step.environment),
+                        shell=False,
+                        start_new_session=True,
+                        close_fds=True,
+                    )
+                )
+            finally:
+                os.close(stdout_descriptor)
+                os.close(stderr_descriptor)
+        finally:
+            os.close(directory_descriptor)
+        return process
+
+
+@dataclass(frozen=True, slots=True)
+class _SessionStepProcess:
+    """Process handle that signals the complete session-owned process group."""
+
+    process: subprocess.Popen[bytes]
+
+    @property
+    def pid(self) -> int:
+        return self.process.pid
+
+    def poll(self) -> int | None:
+        return self.process.poll()
+
+    def terminate(self) -> None:
+        self._signal_group(signal.SIGTERM)
+
+    def kill(self) -> None:
+        self._signal_group(signal.SIGKILL)
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.process.wait(timeout=timeout)
+
+    def _signal_group(self, selected: signal.Signals) -> None:
+        try:
+            os.killpg(self.pid, selected)
+        except ProcessLookupError:
+            if self.poll() is None:
+                raise
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedStep:
+    """A started structured step and its process identity."""
+
+    step: RuntimeStep
+    process: StepProcess
+
+
+class StepSupervisor:
+    """Own every child process and perform idempotent reverse-order cleanup."""
+
+    def __init__(
+        self,
+        runner: RuntimeStepRunner,
+        *,
+        clock: RuntimeClock | None = None,
+        poll_interval_seconds: float = 0.1,
+        termination_grace_seconds: float = 10.0,
+    ) -> None:
+        if poll_interval_seconds <= 0 or termination_grace_seconds <= 0:
+            raise ValueError("runtime polling and termination intervals must be positive")
+        self._runner = runner
+        self._clock = clock or SystemRuntimeClock()
+        self._poll_interval_seconds = poll_interval_seconds
+        self._termination_grace_seconds = termination_grace_seconds
+        self._managed: list[ManagedStep] = []
+        self._cleanup_started = False
+        self._cleanup_in_progress = False
+        self._cleanup_complete = False
+
+    @property
+    def managed_steps(self) -> tuple[ManagedStep, ...]:
+        """Return the started process identities in launch order."""
+        return tuple(self._managed)
+
+    def start(self, step: RuntimeStep) -> ManagedStep:
+        """Start and register one structured step."""
+        if self._cleanup_started:
+            raise SlurmRuntimeError(SlurmRuntimeErrorCode.CLEANUP_FAILED, "cannot start a step after cleanup")
+        try:
+            managed = ManagedStep(step=step, process=self._runner.start(step))
+        except (OSError, subprocess.SubprocessError) as error:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.STEP_FAILED,
+                f"cannot start runtime step {step.step_id!r}",
+            ) from error
+        self._managed.append(managed)
+        return managed
+
+    def wait(self, target: ManagedStep, *, required: tuple[ManagedStep, ...] = ()) -> None:
+        """Wait for one finite step while requiring long-running peers to stay alive."""
+        while True:
+            self.require_running(required)
+            returncode = target.process.poll()
+            if returncode is not None:
+                if returncode != 0:
+                    raise SlurmRuntimeError(
+                        SlurmRuntimeErrorCode.STEP_FAILED,
+                        f"runtime step {target.step.step_id!r} exited with status {returncode}",
+                    )
+                return
+            self._clock.sleep(self._poll_interval_seconds)
+
+    @staticmethod
+    def require_running(required: tuple[ManagedStep, ...]) -> None:
+        """Fail when any required long-running step has exited."""
+        for managed in required:
+            returncode = managed.process.poll()
+            if returncode is not None:
+                raise SlurmRuntimeError(
+                    SlurmRuntimeErrorCode.STEP_FAILED,
+                    f"required runtime step {managed.step.step_id!r} exited with status {returncode}",
+                )
+
+    def cleanup(self) -> None:
+        """Terminate every live child exactly once, escalating after a bounded grace period."""
+        if self._cleanup_complete or self._cleanup_in_progress:
+            return
+        self._cleanup_started = True
+        self._cleanup_in_progress = True
+        failures: list[BaseException] = []
+        try:
+            live = tuple(managed for managed in reversed(self._managed) if managed.process.poll() is None)
+            for managed in live:
+                try:
+                    managed.process.terminate()
+                except BaseException as error:
+                    failures.append(error)
+            deadline = self._clock.monotonic() + self._termination_grace_seconds
+            for managed in live:
+                while managed.process.poll() is None and self._clock.monotonic() < deadline:
+                    self._clock.sleep(self._poll_interval_seconds)
+                if managed.process.poll() is None:
+                    try:
+                        managed.process.kill()
+                    except BaseException as error:
+                        failures.append(error)
+                try:
+                    managed.process.wait(timeout=self._termination_grace_seconds)
+                except BaseException as error:
+                    failures.append(error)
+        finally:
+            self._cleanup_in_progress = False
+        if failures:
+            raise SlurmRuntimeError(
+                SlurmRuntimeErrorCode.CLEANUP_FAILED,
+                f"cleanup failed for {len(failures)} runtime process operation(s)",
+            ) from failures[0]
+        self._cleanup_complete = True
+
+
+def _create_log_file(directory_descriptor: int, name: str) -> int:
+    return os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=directory_descriptor,
+    )

--- a/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/runtime/supervisor.py
@@ -7,16 +7,14 @@ from __future__ import annotations
 
 import os
 import signal
-import stat
 import subprocess
 import time
-from collections.abc import Iterator
-from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Protocol
 
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.logs import open_step_logs
 from data_designer.slurm.runtime.models import RuntimeStep
 from data_designer.slurm.runtime.signals import TerminationSignalCoordinator
 
@@ -91,7 +89,7 @@ class SubprocessStepRunner:
 
     def start(self, step: RuntimeStep) -> StepProcess:
         """Start one step with restrictive package-owned log files."""
-        with _open_step_logs(step) as (stdout_descriptor, stderr_descriptor):
+        with open_step_logs(step) as (stdout_descriptor, stderr_descriptor):
             process = subprocess.Popen(
                 step.command,
                 stdin=subprocess.DEVNULL,
@@ -276,36 +274,3 @@ class StepSupervisor:
             return all(managed.process.poll() is not None for managed in self._managed)
         except BaseException:
             return False
-
-
-def _create_log_file(directory_descriptor: int, name: str) -> int:
-    return os.open(
-        name,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-        0o600,
-        dir_fd=directory_descriptor,
-    )
-
-
-@contextmanager
-def _open_step_logs(step: RuntimeStep) -> Iterator[tuple[int, int]]:
-    log_root = step.stdout_path.parent
-    log_root.mkdir(mode=0o700, parents=False, exist_ok=True)
-    before = log_root.lstat()
-    if not stat.S_ISDIR(before.st_mode):
-        raise OSError(f"runtime log root {log_root} is not a directory")
-    with ExitStack() as resources:
-        directory_descriptor = os.open(
-            log_root,
-            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
-        )
-        resources.callback(os.close, directory_descriptor)
-        opened = os.fstat(directory_descriptor)
-        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
-            raise OSError(f"runtime log root {log_root} changed while it was opened")
-        os.fchmod(directory_descriptor, 0o700)
-        stdout_descriptor = _create_log_file(directory_descriptor, step.stdout_path.name)
-        resources.callback(os.close, stdout_descriptor)
-        stderr_descriptor = _create_log_file(directory_descriptor, step.stderr_path.name)
-        resources.callback(os.close, stderr_descriptor)
-        yield stdout_descriptor, stderr_descriptor

--- a/packages/data-designer-slurm/src/data_designer/slurm/state/readiness.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/state/readiness.py
@@ -24,6 +24,7 @@ ReasonCode = Annotated[
 
 class ReadinessState(str, Enum):
     PENDING = "pending"
+    RESTARTING = "restarting"
     STARTING = "starting"
     READY = "ready"
     FAILED = "failed"
@@ -72,32 +73,8 @@ class DeploymentReadiness(StateValue):
 
     @model_validator(mode="after")
     def validate_counts_and_state(self) -> DeploymentReadiness:
-        if self.ready_backends > self.expected_backends:
-            raise ValueError("ready_backends must not exceed expected_backends")
-        if self.endpoint_publication is EndpointPublicationState.FAILED and self.state not in {
-            ReadinessState.FAILED,
-            ReadinessState.STOPPED,
-        }:
-            raise ValueError("failed endpoint publication requires a failed or stopped deployment")
-
-        if self.state is ReadinessState.PENDING:
-            if self.ready_backends != 0:
-                raise ValueError("pending deployments cannot have ready backends")
-            if self.endpoint_publication is not EndpointPublicationState.PENDING:
-                raise ValueError("pending deployments require pending endpoint publication")
-        elif self.state is ReadinessState.STARTING:
-            if (
-                self.ready_backends == self.expected_backends
-                and self.endpoint_publication is EndpointPublicationState.PUBLISHED
-            ):
-                raise ValueError("fully ready published deployments must use the ready state")
-        elif self.state is ReadinessState.READY:
-            if self.ready_backends != self.expected_backends:
-                raise ValueError("ready deployments require every expected backend")
-            if self.endpoint_publication is not EndpointPublicationState.PUBLISHED:
-                raise ValueError("ready deployments require a published endpoint")
-        elif self.state is ReadinessState.STOPPED and self.ready_backends != 0:
-            raise ValueError("stopped deployments cannot have ready backends")
+        _validate_deployment_common(self)
+        _validate_deployment_state(self)
         return self
 
 
@@ -116,33 +93,85 @@ class AttemptReadiness(StateRecord):
 
     @model_validator(mode="after")
     def validate_deployments(self) -> AttemptReadiness:
-        deployment_ids = [deployment.deployment_id for deployment in self.deployments]
-        model_aliases = [deployment.model_alias for deployment in self.deployments]
-        if len(deployment_ids) != len(set(deployment_ids)):
-            raise ValueError("deployment IDs must be unique")
-        if len(model_aliases) != len(set(model_aliases)):
-            raise ValueError("model aliases must be unique")
-        if any(
-            deployment.last_probe is not None and deployment.last_probe.observed_at > self.updated_at
-            for deployment in self.deployments
-        ):
-            raise ValueError("probe observations must not be later than the readiness snapshot")
-
-        deployment_states = tuple(deployment.state for deployment in self.deployments)
-        if self.state is ReadinessState.PENDING:
-            if any(state is not ReadinessState.PENDING for state in deployment_states):
-                raise ValueError("pending attempts require every deployment to be pending")
-        elif self.state is ReadinessState.STARTING:
-            if any(state in {ReadinessState.FAILED, ReadinessState.STOPPED} for state in deployment_states):
-                raise ValueError("starting attempts cannot contain failed or stopped deployments")
-            if all(state is ReadinessState.READY for state in deployment_states):
-                raise ValueError("attempts with every deployment ready must use the ready state")
-        elif self.state is ReadinessState.READY:
-            if any(state is not ReadinessState.READY for state in deployment_states):
-                raise ValueError("ready attempts require every deployment to be ready")
-        elif self.state is ReadinessState.FAILED:
-            if not any(state is ReadinessState.FAILED for state in deployment_states):
-                raise ValueError("failed attempts require at least one failed deployment")
-        elif any(state is not ReadinessState.STOPPED for state in deployment_states):
-            raise ValueError("stopped attempts require every deployment to be stopped")
+        _validate_deployment_uniqueness(self.deployments)
+        _validate_probe_chronology(self.deployments, self.updated_at)
+        _validate_attempt_state(self.state, self.deployments)
         return self
+
+
+def _validate_deployment_common(deployment: DeploymentReadiness) -> None:
+    if deployment.ready_backends > deployment.expected_backends:
+        raise ValueError("ready_backends must not exceed expected_backends")
+    if deployment.endpoint_publication is EndpointPublicationState.FAILED and deployment.state not in {
+        ReadinessState.FAILED,
+        ReadinessState.STOPPED,
+    }:
+        raise ValueError("failed endpoint publication requires a failed or stopped deployment")
+
+
+def _validate_deployment_state(deployment: DeploymentReadiness) -> None:
+    if deployment.state in {ReadinessState.PENDING, ReadinessState.RESTARTING}:
+        _validate_inactive_deployment(deployment)
+    elif deployment.state is ReadinessState.STARTING:
+        _validate_starting_deployment(deployment)
+    elif deployment.state is ReadinessState.READY:
+        _validate_ready_deployment(deployment)
+    elif deployment.state is ReadinessState.STOPPED and deployment.ready_backends != 0:
+        raise ValueError("stopped deployments cannot have ready backends")
+
+
+def _validate_inactive_deployment(deployment: DeploymentReadiness) -> None:
+    if deployment.ready_backends != 0:
+        raise ValueError("pending or restarting deployments cannot have ready backends")
+    if deployment.endpoint_publication is not EndpointPublicationState.PENDING:
+        raise ValueError("pending or restarting deployments require pending endpoint publication")
+
+
+def _validate_starting_deployment(deployment: DeploymentReadiness) -> None:
+    if (
+        deployment.ready_backends == deployment.expected_backends
+        and deployment.endpoint_publication is EndpointPublicationState.PUBLISHED
+    ):
+        raise ValueError("fully ready published deployments must use the ready state")
+
+
+def _validate_ready_deployment(deployment: DeploymentReadiness) -> None:
+    if deployment.ready_backends != deployment.expected_backends:
+        raise ValueError("ready deployments require every expected backend")
+    if deployment.endpoint_publication is not EndpointPublicationState.PUBLISHED:
+        raise ValueError("ready deployments require a published endpoint")
+
+
+def _validate_deployment_uniqueness(deployments: tuple[DeploymentReadiness, ...]) -> None:
+    deployment_ids = [deployment.deployment_id for deployment in deployments]
+    model_aliases = [deployment.model_alias for deployment in deployments]
+    if len(deployment_ids) != len(set(deployment_ids)):
+        raise ValueError("deployment IDs must be unique")
+    if len(model_aliases) != len(set(model_aliases)):
+        raise ValueError("model aliases must be unique")
+
+
+def _validate_probe_chronology(deployments: tuple[DeploymentReadiness, ...], updated_at: datetime) -> None:
+    if any(
+        deployment.last_probe is not None and deployment.last_probe.observed_at > updated_at
+        for deployment in deployments
+    ):
+        raise ValueError("probe observations must not be later than the readiness snapshot")
+
+
+def _validate_attempt_state(state: ReadinessState, deployments: tuple[DeploymentReadiness, ...]) -> None:
+    deployment_states = tuple(deployment.state for deployment in deployments)
+    if state in {ReadinessState.PENDING, ReadinessState.RESTARTING}:
+        if any(deployment_state is not state for deployment_state in deployment_states):
+            raise ValueError(f"{state.value} attempts require every deployment to be {state.value}")
+    elif state is ReadinessState.STARTING:
+        if any(item in {ReadinessState.FAILED, ReadinessState.STOPPED} for item in deployment_states):
+            raise ValueError("starting attempts cannot contain failed or stopped deployments")
+        if all(item is ReadinessState.READY for item in deployment_states):
+            raise ValueError("attempts with every deployment ready must use the ready state")
+    elif state is ReadinessState.READY and any(item is not ReadinessState.READY for item in deployment_states):
+        raise ValueError("ready attempts require every deployment to be ready")
+    elif state is ReadinessState.FAILED and not any(item is ReadinessState.FAILED for item in deployment_states):
+        raise ValueError("failed attempts require at least one failed deployment")
+    elif state is ReadinessState.STOPPED and any(item is not ReadinessState.STOPPED for item in deployment_states):
+        raise ValueError("stopped attempts require every deployment to be stopped")

--- a/packages/data-designer-slurm/src/data_designer/slurm/state/reconciliation.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/state/reconciliation.py
@@ -20,12 +20,29 @@ from data_designer.slurm.state.validation import StateContractError
 
 _ALLOWED_READINESS_TRANSITIONS: dict[ReadinessState, frozenset[ReadinessState]] = {
     ReadinessState.PENDING: frozenset(
-        {ReadinessState.PENDING, ReadinessState.STARTING, ReadinessState.FAILED, ReadinessState.STOPPED}
+        {
+            ReadinessState.PENDING,
+            ReadinessState.RESTARTING,
+            ReadinessState.STARTING,
+            ReadinessState.FAILED,
+            ReadinessState.STOPPED,
+        }
     ),
     ReadinessState.STARTING: frozenset(
-        {ReadinessState.STARTING, ReadinessState.READY, ReadinessState.FAILED, ReadinessState.STOPPED}
+        {
+            ReadinessState.RESTARTING,
+            ReadinessState.STARTING,
+            ReadinessState.READY,
+            ReadinessState.FAILED,
+            ReadinessState.STOPPED,
+        }
     ),
-    ReadinessState.READY: frozenset({ReadinessState.READY, ReadinessState.FAILED, ReadinessState.STOPPED}),
+    ReadinessState.RESTARTING: frozenset(
+        {ReadinessState.RESTARTING, ReadinessState.STARTING, ReadinessState.FAILED, ReadinessState.STOPPED}
+    ),
+    ReadinessState.READY: frozenset(
+        {ReadinessState.RESTARTING, ReadinessState.READY, ReadinessState.FAILED, ReadinessState.STOPPED}
+    ),
     ReadinessState.FAILED: frozenset({ReadinessState.FAILED, ReadinessState.STOPPED}),
     ReadinessState.STOPPED: frozenset({ReadinessState.STOPPED}),
 }
@@ -74,6 +91,7 @@ def validate_readiness_transition(
         "readiness deployment count cannot change",
     )
 
+    restarting = current.state is ReadinessState.RESTARTING
     for old_deployment, new_deployment in zip(previous.deployments, current.deployments, strict=True):
         _require(
             old_deployment.deployment_id == new_deployment.deployment_id,
@@ -87,20 +105,33 @@ def validate_readiness_transition(
             old_deployment.expected_backends == new_deployment.expected_backends,
             "readiness expected backend count cannot change",
         )
-        _require(
-            new_deployment.state in _ALLOWED_READINESS_TRANSITIONS[old_deployment.state],
-            (
-                f"deployment {old_deployment.deployment_id!r} cannot move from "
-                f"{old_deployment.state.value} to {new_deployment.state.value}"
-            ),
-        )
-        _require(
-            new_deployment.endpoint_publication in _ALLOWED_ENDPOINT_TRANSITIONS[old_deployment.endpoint_publication],
-            f"deployment {old_deployment.deployment_id!r} endpoint publication cannot move backward",
-        )
+        if restarting:
+            _require(
+                old_deployment.state not in {ReadinessState.FAILED, ReadinessState.STOPPED},
+                f"deployment {old_deployment.deployment_id!r} cannot restart from terminal readiness",
+            )
+            _require(
+                new_deployment.state is ReadinessState.RESTARTING
+                and new_deployment.ready_backends == 0
+                and new_deployment.endpoint_publication is EndpointPublicationState.PENDING,
+                f"deployment {old_deployment.deployment_id!r} restart state is not reset",
+            )
+        else:
+            _require(
+                new_deployment.state in _ALLOWED_READINESS_TRANSITIONS[old_deployment.state],
+                (
+                    f"deployment {old_deployment.deployment_id!r} cannot move from "
+                    f"{old_deployment.state.value} to {new_deployment.state.value}"
+                ),
+            )
+            _require(
+                new_deployment.endpoint_publication
+                in _ALLOWED_ENDPOINT_TRANSITIONS[old_deployment.endpoint_publication],
+                f"deployment {old_deployment.deployment_id!r} endpoint publication cannot move backward",
+            )
         old_probe = old_deployment.last_probe
         new_probe = new_deployment.last_probe
-        if old_probe is not None:
+        if old_probe is not None and not restarting:
             if new_probe is None:
                 raise StateContractError(
                     f"deployment {old_deployment.deployment_id!r} probe evidence cannot be removed"

--- a/packages/data-designer-slurm/tests/integration/test_integration_validation.py
+++ b/packages/data-designer-slurm/tests/integration/test_integration_validation.py
@@ -359,6 +359,27 @@ def test_plan_state_validator_reuses_one_context_for_an_attempt_batch() -> None:
     )
 
 
+def test_client_candidate_validation_supports_preterminal_runtime_state(records: IntegrationRecords) -> None:
+    attempt = AttemptManifest.model_validate(
+        records.attempt.model_dump(mode="python")
+        | {
+            "state": AttemptLifecycleState.RUNNING,
+            "terminal_classification": None,
+            "candidate_output": None,
+        }
+    )
+
+    assert (
+        records.validator.validate_client_candidate(
+            records.plan.shards[0],
+            attempt,
+            records.client_result,
+            records.candidate,
+        )
+        is records.candidate
+    )
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [
@@ -446,8 +467,8 @@ def test_finalization_rejects_invalid_chains(
         ("winner_shard_id", "winner shard_id"),
         ("client_attempt_id", "client result attempt_id"),
         ("candidate_attempt_id", "candidate attempt_id"),
-        ("candidate_ordinal", "attempt ordinals"),
-        ("winner_ordinal", "attempt ordinals"),
+        ("candidate_ordinal", "attempt ordinal"),
+        ("winner_ordinal", "attempt ordinal"),
         ("client_requested_records", "requested records"),
         ("candidate_requested_records", "requested records"),
         ("client_actual_records", "actual records"),

--- a/packages/data-designer-slurm/tests/runtime/conftest.py
+++ b/packages/data-designer-slurm/tests/runtime/conftest.py
@@ -20,6 +20,7 @@ from data_designer.slurm.state import (
     AttemptManifest,
     AttemptReadiness,
     SchedulerIdentity,
+    StateNotFoundError,
     validate_attempt_transition,
     validate_readiness_transition,
 )
@@ -48,6 +49,14 @@ class FakeStateStore:
         else:
             assert readiness.revision == 1
         self.readiness.append(readiness)
+        return readiness
+
+    def load_readiness(self, shard_id: str, attempt_id: str) -> AttemptReadiness:
+        if not self.readiness:
+            raise StateNotFoundError(f"attempt {attempt_id!r} has no readiness snapshot")
+        readiness = self.readiness[-1]
+        assert readiness.shard_id == shard_id
+        assert readiness.attempt_id == attempt_id
         return readiness
 
 

--- a/packages/data-designer-slurm/tests/runtime/conftest.py
+++ b/packages/data-designer-slurm/tests/runtime/conftest.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from data_designer.slurm.config import SlurmProfile
+from data_designer.slurm.contracts import ArtifactReference, compute_canonical_json_sha256
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.runtime.models import AllocationContext, RuntimeEndpoint, RuntimeStep, RuntimeStepRole
+from data_designer.slurm.state import (
+    AttemptLifecycleState,
+    AttemptManifest,
+    AttemptReadiness,
+    SchedulerIdentity,
+    validate_attempt_transition,
+    validate_readiness_transition,
+)
+
+
+@dataclass(slots=True)
+class RuntimeCase:
+    workspace: Path
+    context: AllocationContext
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class FakeStateStore:
+    attempt: AttemptManifest
+    readiness: list[AttemptReadiness] = field(default_factory=list)
+
+    def update_attempt(self, attempt: AttemptManifest) -> AttemptManifest:
+        validate_attempt_transition(self.attempt, attempt)
+        self.attempt = attempt
+        return attempt
+
+    def write_readiness(self, readiness: AttemptReadiness) -> AttemptReadiness:
+        if self.readiness:
+            validate_readiness_transition(self.readiness[-1], readiness)
+        else:
+            assert readiness.revision == 1
+        self.readiness.append(readiness)
+        return readiness
+
+
+class FakePreflight:
+    def __init__(self, failure: BaseException | None = None) -> None:
+        self.failure = failure
+        self.calls = 0
+
+    def verify(self, context: AllocationContext, environment: object) -> None:
+        del context, environment
+        self.calls += 1
+        if self.failure is not None:
+            raise self.failure
+
+
+class FakeClientStepBuilder:
+    def build_preflight_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: object,
+        attempt: object,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: object,
+    ) -> RuntimeStep:
+        del plan, shard, attempt, endpoints, source_environment
+        return _step("client-preflight", RuntimeStepRole.CLIENT_PREFLIGHT, attempt_directory)
+
+    def build_generation_step(
+        self,
+        plan: ResolvedSlurmRunPlan,
+        shard: object,
+        attempt: object,
+        attempt_directory: Path,
+        endpoints: tuple[RuntimeEndpoint, ...],
+        source_environment: object,
+    ) -> RuntimeStep:
+        del plan, shard, attempt, endpoints, source_environment
+        return _step("client-generation", RuntimeStepRole.CLIENT, attempt_directory)
+
+
+@pytest.fixture
+def runtime_case(tmp_path: Path, single_node_plan: ResolvedSlurmRunPlan) -> RuntimeCase:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    plan = relocate_plan(single_node_plan, workspace)
+    created_at = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+    plan_reference = ArtifactReference(
+        path=Path(plan.authored_config.path).with_name("resolved-plan.json").as_posix(),
+        sha256=plan.compute_sha256(),
+    )
+    attempt = AttemptManifest(
+        schema_version=1,
+        run_id=plan.run_id,
+        shard_id=plan.shards[0].shard_id,
+        attempt_id="attempt-0001",
+        attempt_ordinal=1,
+        resolved_plan=plan_reference,
+        state=AttemptLifecycleState.SUBMITTED,
+        scheduler=SchedulerIdentity(array_job_id=4101, array_task_id=0),
+        created_at=created_at,
+        updated_at=created_at + timedelta(seconds=1),
+    )
+    attempt_directory = (
+        Path(plan.authored_config.path).parent / "shards" / attempt.shard_id / "attempts" / attempt.attempt_id
+    )
+    attempt_directory.mkdir(parents=True, mode=0o700)
+    return RuntimeCase(
+        workspace=workspace,
+        context=AllocationContext(
+            plan=plan,
+            shard=plan.shards[0],
+            attempt=attempt,
+            attempt_directory=attempt_directory,
+        ),
+        created_at=created_at,
+    )
+
+
+def relocate_plan(plan: ResolvedSlurmRunPlan, workspace: Path) -> ResolvedSlurmRunPlan:
+    previous_workspace = plan.selected_profile.profile.workspace_root
+    payload = cast(
+        dict[str, object],
+        json.loads(plan.serialize_json().replace(previous_workspace, workspace.as_posix())),
+    )
+    selected_profile = cast(dict[str, object], payload["selected_profile"])
+    profile_payload = cast(dict[str, object], selected_profile["profile"])
+    relocated_mount = {
+        "source": workspace.as_posix(),
+        "target": previous_workspace,
+        "read_only": False,
+    }
+    profile_payload["container_mounts"] = [relocated_mount]
+    payload["container_mounts"] = [relocated_mount]
+    profile = SlurmProfile.model_validate(profile_payload)
+    selected_profile["profile_sha256"] = compute_canonical_json_sha256(profile.model_dump(mode="json"))
+    return ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+
+
+def _step(step_id: str, role: RuntimeStepRole, attempt_directory: Path) -> RuntimeStep:
+    return RuntimeStep(
+        step_id=step_id,
+        role=role,
+        command=("true",),
+        environment={"PATH": "/usr/bin", "LC_ALL": "C"},
+        stdout_path=attempt_directory / "logs" / f"{step_id}.out",
+        stderr_path=attempt_directory / "logs" / f"{step_id}.err",
+    )

--- a/packages/data-designer-slurm/tests/runtime/test_bundle.py
+++ b/packages/data-designer-slurm/tests/runtime/test_bundle.py
@@ -36,10 +36,12 @@ def test_runtime_bundle_is_deterministic_content_addressed_and_restrictive(tmp_p
     with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
         names = archive.getnames()
         assert names[0] == "entrypoint.sh"
-        assert names[1] == "data_designer/slurm/__init__.py"
-        assert names[2] == "data_designer/slurm/runtime/runtime-sources.txt"
+        assert names[1] == "data_designer/slurm/runtime/slurm-sources.txt"
+        assert names[2] == "data_designer/slurm/__init__.py"
         assert "data_designer/slurm/runtime/controller.py" in names
         assert "data_designer/slurm/runtime/entrypoint.py" in names
+        assert "data_designer/slurm/state/store.py" in names
+        assert "data_designer/slurm/contracts.py" in names
         assert archive.getmember("entrypoint.sh").mode == 0o500
         assert all(archive.getmember(name).uid == 0 for name in names)
         entrypoint = archive.extractfile("entrypoint.sh")
@@ -52,21 +54,23 @@ def test_runtime_bundle_recursively_collects_and_imports_nested_packages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace = tmp_path / "workspace"
-    source_root = tmp_path / "source" / "runtime"
-    nested_root = source_root / "nested"
+    source_root = tmp_path / "source" / "slurm"
+    runtime_root = source_root / "runtime"
+    nested_root = runtime_root / "nested"
     workspace.mkdir(mode=0o700)
     nested_root.mkdir(parents=True)
     (source_root / "__init__.py").write_text("")
-    (source_root / "bundle.py").write_text("")
+    (runtime_root / "__init__.py").write_text("")
+    (runtime_root / "bundle.py").write_text("")
     (nested_root / "__init__.py").write_text("")
     (nested_root / "worker.py").write_text("VALUE = 42\n")
-    monkeypatch.setattr(runtime_bundle, "__file__", (source_root / "bundle.py").as_posix())
+    monkeypatch.setattr(runtime_bundle, "__file__", (runtime_root / "bundle.py").as_posix())
 
     reference = stage_runtime_bundle(workspace)
     extracted = tmp_path / "extracted"
     with tarfile.open(reference.path, mode="r:gz") as archive:
         archive.extractall(extracted, filter="data")
-    manifest_path = extracted / "data_designer/slurm/runtime/runtime-sources.txt"
+    manifest_path = extracted / "data_designer/slurm/runtime/slurm-sources.txt"
     manifest = manifest_path.read_text().splitlines()
     assert "data_designer/slurm/runtime/nested/worker.py" in manifest
     environment = dict(os.environ)
@@ -208,7 +212,7 @@ def test_extracted_bundle_runtime_takes_precedence_over_installed_sources(tmp_pa
         archive.extractall(extracted, filter="data")
     environment = dict(os.environ)
     environment["PYTHONPATH"] = extracted.as_posix()
-    manifest = (extracted / "data_designer/slurm/runtime/runtime-sources.txt").read_text().splitlines()
+    manifest = (extracted / "data_designer/slurm/runtime/slurm-sources.txt").read_text().splitlines()
     modules = tuple(_get_module_name(source_name) for source_name in manifest)
     import_all = "; ".join(f"importlib.import_module({module_name!r})" for module_name in modules)
 

--- a/packages/data-designer-slurm/tests/runtime/test_bundle.py
+++ b/packages/data-designer-slurm/tests/runtime/test_bundle.py
@@ -37,6 +37,7 @@ def test_runtime_bundle_is_deterministic_content_addressed_and_restrictive(tmp_p
         names = archive.getnames()
         assert names[0] == "entrypoint.sh"
         assert names[1] == "data_designer/slurm/__init__.py"
+        assert names[2] == "data_designer/slurm/runtime/runtime-sources.txt"
         assert "data_designer/slurm/runtime/controller.py" in names
         assert "data_designer/slurm/runtime/entrypoint.py" in names
         assert archive.getmember("entrypoint.sh").mode == 0o500
@@ -44,6 +45,47 @@ def test_runtime_bundle_is_deterministic_content_addressed_and_restrictive(tmp_p
         entrypoint = archive.extractfile("entrypoint.sh")
         assert entrypoint is not None
         assert b'PYTHONPATH="${runtime_root}"' in entrypoint.read()
+
+
+def test_runtime_bundle_recursively_collects_and_imports_nested_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    source_root = tmp_path / "source" / "runtime"
+    nested_root = source_root / "nested"
+    workspace.mkdir(mode=0o700)
+    nested_root.mkdir(parents=True)
+    (source_root / "__init__.py").write_text("")
+    (source_root / "bundle.py").write_text("")
+    (nested_root / "__init__.py").write_text("")
+    (nested_root / "worker.py").write_text("VALUE = 42\n")
+    monkeypatch.setattr(runtime_bundle, "__file__", (source_root / "bundle.py").as_posix())
+
+    reference = stage_runtime_bundle(workspace)
+    extracted = tmp_path / "extracted"
+    with tarfile.open(reference.path, mode="r:gz") as archive:
+        archive.extractall(extracted, filter="data")
+    manifest_path = extracted / "data_designer/slurm/runtime/runtime-sources.txt"
+    manifest = manifest_path.read_text().splitlines()
+    assert "data_designer/slurm/runtime/nested/worker.py" in manifest
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = extracted.as_posix()
+
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-c",
+            "from data_designer.slurm.runtime.nested.worker import VALUE; print(VALUE, end='')",
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "42"
 
 
 def test_runtime_bundle_rejects_different_bytes_at_digest_path(tmp_path: Path) -> None:
@@ -166,11 +208,15 @@ def test_extracted_bundle_runtime_takes_precedence_over_installed_sources(tmp_pa
         archive.extractall(extracted, filter="data")
     environment = dict(os.environ)
     environment["PYTHONPATH"] = extracted.as_posix()
+    manifest = (extracted / "data_designer/slurm/runtime/runtime-sources.txt").read_text().splitlines()
+    modules = tuple(_get_module_name(source_name) for source_name in manifest)
+    import_all = "; ".join(f"importlib.import_module({module_name!r})" for module_name in modules)
 
     completed = subprocess.run(
         (
             sys.executable,
             "-c",
+            f"import importlib; {import_all}; "
             "import data_designer.slurm.runtime as runtime; print(runtime.__file__, end='')",
         ),
         capture_output=True,
@@ -181,3 +227,8 @@ def test_extracted_bundle_runtime_takes_precedence_over_installed_sources(tmp_pa
 
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout == (extracted / "data_designer/slurm/runtime/__init__.py").as_posix()
+
+
+def _get_module_name(source_name: str) -> str:
+    module_name = source_name.removesuffix(".py").replace("/", ".")
+    return module_name.removesuffix(".__init__")

--- a/packages/data-designer-slurm/tests/runtime/test_bundle.py
+++ b/packages/data-designer-slurm/tests/runtime/test_bundle.py
@@ -58,6 +58,35 @@ def test_runtime_bundle_rejects_different_bytes_at_digest_path(tmp_path: Path) -
         stage_runtime_bundle(workspace)
 
 
+def test_runtime_bundle_recovers_an_interrupted_immutable_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    original_unlink = runtime_bundle.os.unlink
+
+    def interrupt_temporary_unlink(path: str, *, dir_fd: int | None = None) -> None:
+        del path, dir_fd
+        raise KeyboardInterrupt("injected runtime publication interruption")
+
+    monkeypatch.setattr(runtime_bundle.os, "unlink", interrupt_temporary_unlink)
+    with pytest.raises(KeyboardInterrupt, match="runtime publication interruption"):
+        stage_runtime_bundle(workspace)
+
+    runtime_root = workspace / "runtime"
+    archive_paths = tuple(runtime_root.glob("*.tar.gz"))
+    temporary_paths = tuple(runtime_root.glob(".runtime.*.tmp"))
+    assert len(archive_paths) == len(temporary_paths) == 1
+    assert archive_paths[0].stat().st_ino == temporary_paths[0].stat().st_ino
+    assert archive_paths[0].stat().st_nlink == 2
+
+    monkeypatch.setattr(runtime_bundle.os, "unlink", original_unlink)
+    reference = stage_runtime_bundle(workspace)
+    assert Path(reference.path).stat().st_nlink == 1
+    assert not tuple(runtime_root.glob(".runtime.*.tmp"))
+
+
 def test_runtime_bundle_rejects_symlinked_runtime_root(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     outside = tmp_path / "outside"

--- a/packages/data-designer-slurm/tests/runtime/test_bundle.py
+++ b/packages/data-designer-slurm/tests/runtime/test_bundle.py
@@ -87,6 +87,37 @@ def test_runtime_bundle_recovers_an_interrupted_immutable_publication(
     assert not tuple(runtime_root.glob(".runtime.*.tmp"))
 
 
+def test_runtime_bundle_restats_after_a_peer_recovers_interrupted_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    original_unlink = runtime_bundle.os.unlink
+    original_listdir = runtime_bundle.os.listdir
+
+    def interrupt_temporary_unlink(path: str, *, dir_fd: int | None = None) -> None:
+        del path, dir_fd
+        raise KeyboardInterrupt("injected runtime publication interruption")
+
+    monkeypatch.setattr(runtime_bundle.os, "unlink", interrupt_temporary_unlink)
+    with pytest.raises(KeyboardInterrupt, match="runtime publication interruption"):
+        stage_runtime_bundle(workspace)
+    monkeypatch.setattr(runtime_bundle.os, "unlink", original_unlink)
+
+    def recover_before_candidate_stat(directory_descriptor: int) -> list[str]:
+        names = original_listdir(directory_descriptor)
+        temporary_name = next(name for name in names if name.startswith(".runtime."))
+        original_unlink(temporary_name, dir_fd=directory_descriptor)
+        return names
+
+    monkeypatch.setattr(runtime_bundle.os, "listdir", recover_before_candidate_stat)
+
+    reference = stage_runtime_bundle(workspace)
+
+    assert Path(reference.path).stat().st_nlink == 1
+
+
 def test_runtime_bundle_rejects_symlinked_runtime_root(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     outside = tmp_path / "outside"

--- a/packages/data-designer-slurm/tests/runtime/test_bundle.py
+++ b/packages/data-designer-slurm/tests/runtime/test_bundle.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import stat
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+import data_designer.slurm.runtime.bundle as runtime_bundle
+from data_designer.slurm.runtime.bundle import stage_runtime_bundle
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+
+
+def test_runtime_bundle_is_deterministic_content_addressed_and_restrictive(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+
+    first = stage_runtime_bundle(workspace)
+    second = stage_runtime_bundle(workspace)
+
+    assert first == second
+    archive_path = Path(first.path)
+    content = archive_path.read_bytes()
+    assert hashlib.sha256(content).hexdigest() == first.sha256
+    assert archive_path.name == f"{first.sha256}.tar.gz"
+    assert stat.S_IMODE(archive_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(archive_path.parent.stat().st_mode) == 0o700
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+        names = archive.getnames()
+        assert names[0] == "entrypoint.sh"
+        assert names[1] == "data_designer/slurm/__init__.py"
+        assert "data_designer/slurm/runtime/controller.py" in names
+        assert "data_designer/slurm/runtime/entrypoint.py" in names
+        assert archive.getmember("entrypoint.sh").mode == 0o500
+        assert all(archive.getmember(name).uid == 0 for name in names)
+        entrypoint = archive.extractfile("entrypoint.sh")
+        assert entrypoint is not None
+        assert b'PYTHONPATH="${runtime_root}"' in entrypoint.read()
+
+
+def test_runtime_bundle_rejects_different_bytes_at_digest_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    reference = stage_runtime_bundle(workspace)
+    path = Path(reference.path)
+    path.write_bytes(b"different")
+    path.chmod(0o600)
+
+    with pytest.raises(SlurmRuntimeError, match="cannot stage"):
+        stage_runtime_bundle(workspace)
+
+
+def test_runtime_bundle_rejects_symlinked_runtime_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir(mode=0o700)
+    outside.mkdir(mode=0o700)
+    (workspace / "runtime").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(SlurmRuntimeError, match="cannot stage"):
+        stage_runtime_bundle(workspace)
+
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_runtime_bundle_rejects_a_group_writable_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o770)
+    workspace.chmod(0o770)
+
+    with pytest.raises(SlurmRuntimeError, match="cannot stage"):
+        stage_runtime_bundle(workspace)
+
+
+def test_runtime_bundle_normalizes_source_read_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+
+    def fail_archive() -> bytes:
+        raise OSError("injected source race")
+
+    monkeypatch.setattr(runtime_bundle, "_build_runtime_archive", fail_archive)
+
+    with pytest.raises(SlurmRuntimeError, match="cannot stage"):
+        stage_runtime_bundle(workspace)
+
+
+def test_extracted_bundle_runtime_takes_precedence_over_installed_sources(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    extracted = tmp_path / "extracted"
+    workspace.mkdir(mode=0o700)
+    extracted.mkdir(mode=0o700)
+    reference = stage_runtime_bundle(workspace)
+    with tarfile.open(reference.path, mode="r:gz") as archive:
+        archive.extractall(extracted, filter="data")
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = extracted.as_posix()
+
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-c",
+            "import data_designer.slurm.runtime as runtime; print(runtime.__file__, end='')",
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == (extracted / "data_designer/slurm/runtime/__init__.py").as_posix()

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -26,6 +26,7 @@ from data_designer.slurm.state import (
     CandidateOutcome,
     CandidateOutputFile,
     CandidateOutputManifest,
+    DeploymentReadiness,
     EndpointPublicationState,
     ReadinessState,
 )
@@ -193,7 +194,19 @@ def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: Run
     assert state.attempt.state is AttemptLifecycleState.FAILED
 
 
-def test_running_attempt_is_not_restarted_without_owned_process_identity(runtime_case: RuntimeCase) -> None:
+@pytest.mark.parametrize(
+    ("persisted_state", "ready_backends", "endpoint_publication"),
+    (
+        (ReadinessState.STARTING, 0, EndpointPublicationState.PENDING),
+        (ReadinessState.READY, 1, EndpointPublicationState.PUBLISHED),
+    ),
+)
+def test_requeued_running_attempt_continues_readiness_revision_without_regression(
+    runtime_case: RuntimeCase,
+    persisted_state: ReadinessState,
+    ready_backends: int,
+    endpoint_publication: EndpointPublicationState,
+) -> None:
     clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
     running_attempt = runtime_case.context.attempt.__class__.model_validate(
         runtime_case.context.attempt.model_dump(mode="python")
@@ -203,8 +216,28 @@ def test_running_attempt_is_not_restarted_without_owned_process_identity(runtime
         }
     )
     context = replace(runtime_case.context, attempt=running_attempt)
-    state = FakeStateStore(running_attempt)
-    runner = _FakeRunner()
+    persisted_readiness = AttemptReadiness(
+        schema_version=1,
+        run_id=running_attempt.run_id,
+        shard_id=running_attempt.shard_id,
+        attempt_id=running_attempt.attempt_id,
+        revision=7,
+        updated_at=runtime_case.created_at + timedelta(seconds=3),
+        state=persisted_state,
+        deployments=(
+            DeploymentReadiness(
+                deployment_id=context.plan.deployments[0].deployment_id,
+                model_alias=context.plan.deployments[0].authored.model_alias,
+                state=persisted_state,
+                expected_backends=context.plan.deployments[0].topology.replica_count,
+                ready_backends=ready_backends,
+                endpoint_publication=endpoint_publication,
+            ),
+        ),
+    )
+    state = FakeStateStore(running_attempt, readiness=[persisted_readiness])
+    restarted_case = replace(runtime_case, context=context)
+    runner = _FakeRunner(generation_hook=lambda: _write_complete_result(restarted_case, clock))
     controller = OneNodeAllocationController(
         context,
         runtime_proxy_path=context.attempt_directory / "runtime/proxy.py",
@@ -217,12 +250,22 @@ def test_running_attempt_is_not_restarted_without_owned_process_identity(runtime
         environment={},
     )
 
-    with pytest.raises(SlurmRuntimeError, match="not executable"):
-        controller.run()
+    result = controller.run()
 
-    assert runner.steps == []
-    assert state.readiness == []
-    assert state.attempt.state is AttemptLifecycleState.FAILED
+    assert result.state is AttemptLifecycleState.SUCCEEDED
+    assert state.readiness[1].revision == 8
+    assert all(readiness.state is not ReadinessState.PENDING for readiness in state.readiness[1:])
+    if persisted_state is ReadinessState.READY:
+        assert all(
+            readiness.state in {ReadinessState.READY, ReadinessState.STOPPED} for readiness in state.readiness[1:]
+        )
+    assert state.readiness[-1].state is ReadinessState.STOPPED
+    assert [step.role for step in runner.steps] == [
+        RuntimeStepRole.CLIENT_PREFLIGHT,
+        RuntimeStepRole.SERVER,
+        RuntimeStepRole.ENDPOINT,
+        RuntimeStepRole.CLIENT,
+    ]
 
 
 def test_required_server_exit_fails_and_cleans_partial_start(runtime_case: RuntimeCase) -> None:

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -35,6 +35,7 @@ class _FakeProcess:
     pid: int
     returncode: int | None
     fail_terminate: bool = False
+    remain_running: bool = False
     terminate_calls: int = 0
     kill_calls: int = 0
 
@@ -45,11 +46,13 @@ class _FakeProcess:
         self.terminate_calls += 1
         if self.fail_terminate:
             raise OSError("injected termination failure")
-        self.returncode = -15
+        if not self.remain_running:
+            self.returncode = -15
 
     def kill(self) -> None:
         self.kill_calls += 1
-        self.returncode = -9
+        if not self.remain_running:
+            self.returncode = -9
 
     def wait(self, timeout: float | None = None) -> int:
         del timeout
@@ -66,11 +69,13 @@ class _FakeRunner:
         server_returncode: int | None = None,
         failed_role: RuntimeStepRole | None = None,
         fail_cleanup: bool = False,
+        incomplete_cleanup: bool = False,
     ) -> None:
         self.generation_hook = generation_hook
         self.server_returncode = server_returncode
         self.failed_role = failed_role
         self.fail_cleanup = fail_cleanup
+        self.incomplete_cleanup = incomplete_cleanup
         self.steps: list[RuntimeStep] = []
         self.processes: list[_FakeProcess] = []
 
@@ -89,6 +94,7 @@ class _FakeRunner:
             pid=1000 + len(self.processes),
             returncode=returncode,
             fail_terminate=self.fail_cleanup and is_managed_service,
+            remain_running=self.incomplete_cleanup and is_managed_service,
         )
         self.processes.append(process)
         return process
@@ -379,6 +385,38 @@ def test_cleanup_failure_is_retained_as_a_note_on_the_primary_failure(runtime_ca
 
     assert any("cleanup also failed" in note for note in raised.value.__notes__)
     assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def test_incomplete_cleanup_does_not_publish_stopped_readiness(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(
+        generation_hook=lambda: _write_complete_result(runtime_case, clock),
+        incomplete_cleanup=True,
+    )
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(
+            runner,
+            clock=clock,
+            poll_interval_seconds=1,
+            termination_grace_seconds=1,
+        ),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="cleanup failed"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+    assert state.readiness[-1].state is ReadinessState.FAILED
+    assert ReadinessState.STOPPED not in {readiness.state for readiness in state.readiness}
 
 
 def test_future_client_timestamp_cannot_push_persisted_state_clock_forward(runtime_case: RuntimeCase) -> None:

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -117,6 +117,15 @@ class _FakeProber:
         return self.ready
 
 
+@dataclass(slots=True)
+class _RestartAwarePreflight:
+    state: FakeStateStore
+
+    def verify(self, context: object, environment: object) -> None:
+        del context, environment
+        assert self.state.readiness[-1].state is ReadinessState.RESTARTING
+
+
 def _supervisor(
     runner: _FakeRunner,
     clock: FakeClock,
@@ -166,6 +175,7 @@ def test_controller_runs_preflight_servers_endpoint_client_and_cleanup(runtime_c
     assert state.readiness[-1].state is ReadinessState.STOPPED
     assert state.readiness[-1].deployments[0].endpoint_publication is EndpointPublicationState.PUBLISHED
     assert all(process.poll() is not None for process in runner.processes)
+    assert {step.stdout_path.parent.name for step in runner.steps} == {"execution-00000001"}
 
 
 def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: RuntimeCase) -> None:
@@ -201,7 +211,7 @@ def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: Run
         (ReadinessState.READY, 1, EndpointPublicationState.PUBLISHED),
     ),
 )
-def test_requeued_running_attempt_continues_readiness_revision_without_regression(
+def test_requeued_running_attempt_publishes_restart_epoch_and_uses_fresh_logs(
     runtime_case: RuntimeCase,
     persisted_state: ReadinessState,
     ready_backends: int,
@@ -243,7 +253,7 @@ def test_requeued_running_attempt_continues_readiness_revision_without_regressio
         runtime_proxy_path=context.attempt_directory / "runtime/proxy.py",
         state=state,
         supervisor=_supervisor(runner, clock),
-        preflight=FakePreflight(),
+        preflight=_RestartAwarePreflight(state),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
         clock=clock,
@@ -254,11 +264,10 @@ def test_requeued_running_attempt_continues_readiness_revision_without_regressio
 
     assert result.state is AttemptLifecycleState.SUCCEEDED
     assert state.readiness[1].revision == 8
-    assert all(readiness.state is not ReadinessState.PENDING for readiness in state.readiness[1:])
-    if persisted_state is ReadinessState.READY:
-        assert all(
-            readiness.state in {ReadinessState.READY, ReadinessState.STOPPED} for readiness in state.readiness[1:]
-        )
+    assert state.readiness[1].state is ReadinessState.RESTARTING
+    assert state.readiness[1].deployments[0].state is ReadinessState.RESTARTING
+    assert state.readiness[1].deployments[0].ready_backends == 0
+    assert state.readiness[1].deployments[0].endpoint_publication is EndpointPublicationState.PENDING
     assert state.readiness[-1].state is ReadinessState.STOPPED
     assert [step.role for step in runner.steps] == [
         RuntimeStepRole.CLIENT_PREFLIGHT,
@@ -266,6 +275,7 @@ def test_requeued_running_attempt_continues_readiness_revision_without_regressio
         RuntimeStepRole.ENDPOINT,
         RuntimeStepRole.CLIENT,
     ]
+    assert {step.stdout_path.parent.name for step in runner.steps} == {"execution-00000008"}
 
 
 def test_required_server_exit_fails_and_cleans_partial_start(runtime_case: RuntimeCase) -> None:

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -17,6 +17,7 @@ from data_designer.slurm.contracts import ArtifactReference
 from data_designer.slurm.runtime.controller import OneNodeAllocationController
 from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
 from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
+from data_designer.slurm.runtime.signals import TerminationSignalCoordinator
 from data_designer.slurm.runtime.supervisor import StepSupervisor
 from data_designer.slurm.state import (
     AttemptLifecycleState,
@@ -115,11 +116,27 @@ class _FakeProber:
         return self.ready
 
 
+def _supervisor(
+    runner: _FakeRunner,
+    clock: FakeClock,
+    *,
+    poll_interval_seconds: float = 0.1,
+    termination_grace_seconds: float = 10.0,
+) -> StepSupervisor:
+    return StepSupervisor(
+        runner,
+        signals=TerminationSignalCoordinator(),
+        clock=clock,
+        poll_interval_seconds=poll_interval_seconds,
+        termination_grace_seconds=termination_grace_seconds,
+    )
+
+
 def test_controller_runs_preflight_servers_endpoint_client_and_cleanup(runtime_case: RuntimeCase) -> None:
     clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
     state = FakeStateStore(runtime_case.context.attempt)
     runner = _FakeRunner(generation_hook=lambda: _write_complete_result(runtime_case, clock))
-    supervisor = StepSupervisor(runner, clock=clock, poll_interval_seconds=0.1)
+    supervisor = _supervisor(runner, clock, poll_interval_seconds=0.1)
     controller = OneNodeAllocationController(
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
@@ -159,7 +176,7 @@ def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: Run
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(failure),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -192,7 +209,7 @@ def test_running_attempt_is_not_restarted_without_owned_process_identity(runtime
         context,
         runtime_proxy_path=context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -216,7 +233,7 @@ def test_required_server_exit_fails_and_cleans_partial_start(runtime_case: Runti
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -247,7 +264,7 @@ def test_interrupted_failed_readiness_write_cannot_bypass_cleanup(runtime_case: 
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -271,7 +288,7 @@ def test_readiness_timeout_fails_and_terminates_server(runtime_case: RuntimeCase
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=False, clock=clock, advance_on_failure=10_000),
@@ -307,7 +324,7 @@ def test_managed_step_failure_fails_attempt_and_cleans_started_services(
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -339,9 +356,9 @@ def test_cleanup_failure_prevents_false_success(runtime_case: RuntimeCase) -> No
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(
+        supervisor=_supervisor(
             runner,
-            clock=clock,
+            clock,
             poll_interval_seconds=1,
             termination_grace_seconds=1,
         ),
@@ -367,9 +384,9 @@ def test_cleanup_failure_is_retained_as_a_note_on_the_primary_failure(runtime_ca
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(
+        supervisor=_supervisor(
             runner,
-            clock=clock,
+            clock,
             poll_interval_seconds=1,
             termination_grace_seconds=1,
         ),
@@ -398,9 +415,9 @@ def test_incomplete_cleanup_does_not_publish_stopped_readiness(runtime_case: Run
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(
+        supervisor=_supervisor(
             runner,
-            clock=clock,
+            clock,
             poll_interval_seconds=1,
             termination_grace_seconds=1,
         ),
@@ -432,7 +449,7 @@ def test_future_client_timestamp_cannot_push_persisted_state_clock_forward(runti
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(runner, clock=clock),
+        supervisor=_supervisor(runner, clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -446,6 +463,29 @@ def test_future_client_timestamp_cannot_push_persisted_state_clock_forward(runti
     assert state.attempt.state is AttemptLifecycleState.FAILED
 
 
+def test_partial_client_result_is_classified_before_candidate_loading(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(generation_hook=lambda: _write_partial_result(runtime_case, clock))
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=_supervisor(runner, clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError) as raised:
+        controller.run()
+
+    assert raised.value.code is SlurmRuntimeErrorCode.CLIENT_FAILED
+    assert not (runtime_case.context.attempt_directory / "output-manifest.json").exists()
+
+
 def test_stale_candidate_from_an_earlier_generation_cannot_succeed(runtime_case: RuntimeCase) -> None:
     clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
     _write_complete_result(runtime_case, clock)
@@ -455,7 +495,7 @@ def test_stale_candidate_from_an_earlier_generation_cannot_succeed(runtime_case:
         runtime_case.context,
         runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
         state=state,
-        supervisor=StepSupervisor(_FakeRunner(), clock=clock),
+        supervisor=_supervisor(_FakeRunner(), clock),
         preflight=FakePreflight(),
         client_steps=FakeClientStepBuilder(),
         prober=_FakeProber(ready=True, clock=clock),
@@ -514,6 +554,30 @@ def _write_complete_result(runtime_case: RuntimeCase, clock: FakeClock) -> None:
         candidate_output_manifest=ArtifactReference(
             path=candidate_path.as_posix(),
             sha256=candidate.compute_sha256(),
+        ),
+    )
+    _write_record(context.attempt_directory / "client-result.json", result.serialize_json())
+
+
+def _write_partial_result(runtime_case: RuntimeCase, clock: FakeClock) -> None:
+    context = runtime_case.context
+    candidate_path = context.attempt_directory / "output-manifest.json"
+    result = ClientResult(
+        schema_version=1,
+        run_id=context.plan.run_id,
+        shard_id=context.shard.shard_id,
+        attempt_id=context.attempt.attempt_id,
+        completed_at=clock.now(),
+        requested_records=context.shard.requested_records,
+        actual_records=context.shard.requested_records - 1,
+        outcome=ClientOutcome.PARTIAL,
+        dataset_path=(context.attempt_directory / "dataset").as_posix(),
+        early_shutdown=True,
+        requested_resume_mode=context.plan.invocation.authored.resume,
+        effective_resume_mode="never",
+        candidate_output_manifest=ArtifactReference(
+            path=candidate_path.as_posix(),
+            sha256="a" * 64,
         ),
     )
     _write_record(context.attempt_directory / "client-result.json", result.serialize_json())

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -20,6 +20,7 @@ from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
 from data_designer.slurm.runtime.supervisor import StepSupervisor
 from data_designer.slurm.state import (
     AttemptLifecycleState,
+    AttemptReadiness,
     AttemptTerminalClassification,
     CandidateOutcome,
     CandidateOutputFile,
@@ -223,6 +224,37 @@ def test_required_server_exit_fails_and_cleans_partial_start(runtime_case: Runti
     assert state.attempt.state is AttemptLifecycleState.FAILED
     assert ReadinessState.FAILED in [item.state for item in state.readiness]
     assert state.readiness[-1].state is ReadinessState.STOPPED
+
+
+def test_interrupted_failed_readiness_write_cannot_bypass_cleanup(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+
+    class InterruptingState(FakeStateStore):
+        def write_readiness(self, readiness: AttemptReadiness) -> AttemptReadiness:
+            if readiness.state is ReadinessState.FAILED:
+                raise KeyboardInterrupt("injected readiness interruption")
+            return super().write_readiness(readiness)
+
+    state = InterruptingState(runtime_case.context.attempt)
+    runner = _FakeRunner(server_returncode=17)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="required runtime step") as raised:
+        controller.run()
+
+    assert any("failed readiness could not be persisted: KeyboardInterrupt" in note for note in raised.value.__notes__)
+    assert all(process.poll() is not None for process in runner.processes)
+    assert state.attempt.state is AttemptLifecycleState.FAILED
 
 
 def test_readiness_timeout_fails_and_terminates_server(runtime_case: RuntimeCase) -> None:

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from conftest import FakeClientStepBuilder, FakePreflight, FakeStateStore, RuntimeCase
+from slurm_test_fakes import FakeClock
+
+from data_designer.slurm.client import ClientOutcome, ClientResult
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.runtime.controller import OneNodeAllocationController
+from data_designer.slurm.runtime.errors import SlurmRuntimeError, SlurmRuntimeErrorCode
+from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
+from data_designer.slurm.runtime.supervisor import StepSupervisor
+from data_designer.slurm.state import (
+    AttemptLifecycleState,
+    AttemptTerminalClassification,
+    CandidateOutcome,
+    CandidateOutputFile,
+    CandidateOutputManifest,
+    EndpointPublicationState,
+    ReadinessState,
+)
+
+
+@dataclass(slots=True)
+class _FakeProcess:
+    pid: int
+    returncode: int | None
+    fail_terminate: bool = False
+    terminate_calls: int = 0
+    kill_calls: int = 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self.fail_terminate:
+            raise OSError("injected termination failure")
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self.returncode is None:
+            raise TimeoutError
+        return self.returncode
+
+
+class _FakeRunner:
+    def __init__(
+        self,
+        *,
+        generation_hook: Callable[[], None] | None = None,
+        server_returncode: int | None = None,
+        failed_role: RuntimeStepRole | None = None,
+        fail_cleanup: bool = False,
+    ) -> None:
+        self.generation_hook = generation_hook
+        self.server_returncode = server_returncode
+        self.failed_role = failed_role
+        self.fail_cleanup = fail_cleanup
+        self.steps: list[RuntimeStep] = []
+        self.processes: list[_FakeProcess] = []
+
+    def start(self, step: RuntimeStep) -> _FakeProcess:
+        self.steps.append(step)
+        if step.role is RuntimeStepRole.CLIENT and self.generation_hook is not None:
+            self.generation_hook()
+        is_managed_service = step.role in {RuntimeStepRole.SERVER, RuntimeStepRole.ENDPOINT}
+        if step.role is self.failed_role:
+            returncode = 23
+        elif step.role is RuntimeStepRole.SERVER:
+            returncode = self.server_returncode
+        else:
+            returncode = None if is_managed_service else 0
+        process = _FakeProcess(
+            pid=1000 + len(self.processes),
+            returncode=returncode,
+            fail_terminate=self.fail_cleanup and is_managed_service,
+        )
+        self.processes.append(process)
+        return process
+
+
+class _FakeProber:
+    def __init__(self, *, ready: bool, clock: FakeClock, advance_on_failure: float = 0) -> None:
+        self.ready = ready
+        self.clock = clock
+        self.advance_on_failure = advance_on_failure
+        self.calls = 0
+
+    def is_ready(self, host: str, port: int, path: str, *, timeout_seconds: float) -> bool:
+        del host, port, path, timeout_seconds
+        self.calls += 1
+        if not self.ready and self.advance_on_failure:
+            self.clock.advance(self.advance_on_failure)
+        return self.ready
+
+
+def test_controller_runs_preflight_servers_endpoint_client_and_cleanup(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(generation_hook=lambda: _write_complete_result(runtime_case, clock))
+    supervisor = StepSupervisor(runner, clock=clock, poll_interval_seconds=0.1)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=supervisor,
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    result = controller.run()
+
+    assert result.state is AttemptLifecycleState.SUCCEEDED
+    assert result.terminal_classification is AttemptTerminalClassification.SUCCEEDED
+    assert result.candidate_output is not None
+    assert [step.role for step in runner.steps] == [
+        RuntimeStepRole.CLIENT_PREFLIGHT,
+        RuntimeStepRole.SERVER,
+        RuntimeStepRole.ENDPOINT,
+        RuntimeStepRole.CLIENT,
+    ]
+    assert [item.state for item in state.readiness][0] is ReadinessState.PENDING
+    assert ReadinessState.READY in [item.state for item in state.readiness]
+    assert state.readiness[-1].state is ReadinessState.STOPPED
+    assert state.readiness[-1].deployments[0].endpoint_publication is EndpointPublicationState.PUBLISHED
+    assert all(process.poll() is not None for process in runner.processes)
+
+
+def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner()
+    failure = SlurmRuntimeError(SlurmRuntimeErrorCode.PREFLIGHT_FAILED, "injected preflight failure")
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(failure),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="injected preflight failure") as raised:
+        controller.run()
+
+    assert raised.value.__cause__ is None
+    assert runner.steps == []
+    assert state.readiness == []
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def test_required_server_exit_fails_and_cleans_partial_start(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(server_returncode=17)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="required runtime step"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+    assert ReadinessState.FAILED in [item.state for item in state.readiness]
+    assert state.readiness[-1].state is ReadinessState.STOPPED
+
+
+def test_readiness_timeout_fails_and_terminates_server(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner()
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=False, clock=clock, advance_on_failure=10_000),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="readiness timed out"):
+        controller.run()
+
+    server = next(
+        process
+        for step, process in zip(runner.steps, runner.processes, strict=True)
+        if step.role is RuntimeStepRole.SERVER
+    )
+    assert server.terminate_calls == 1
+    assert server.poll() == -15
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+@pytest.mark.parametrize(
+    "failed_role",
+    (RuntimeStepRole.CLIENT_PREFLIGHT, RuntimeStepRole.ENDPOINT, RuntimeStepRole.CLIENT),
+)
+def test_managed_step_failure_fails_attempt_and_cleans_started_services(
+    runtime_case: RuntimeCase,
+    failed_role: RuntimeStepRole,
+) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(failed_role=failed_role)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="status 23"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+    assert state.readiness[-1].state is ReadinessState.STOPPED
+    services = (
+        process
+        for step, process in zip(runner.steps, runner.processes, strict=True)
+        if step.role in {RuntimeStepRole.SERVER, RuntimeStepRole.ENDPOINT}
+    )
+    assert all(process.poll() is not None for process in services)
+
+
+def test_cleanup_failure_prevents_false_success(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(
+        generation_hook=lambda: _write_complete_result(runtime_case, clock),
+        fail_cleanup=True,
+    )
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(
+            runner,
+            clock=clock,
+            poll_interval_seconds=1,
+            termination_grace_seconds=1,
+        ),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="cleanup failed"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+    assert all(process.poll() is not None for process in runner.processes)
+
+
+def test_cleanup_failure_is_retained_as_a_note_on_the_primary_failure(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+    runner = _FakeRunner(failed_role=RuntimeStepRole.CLIENT, fail_cleanup=True)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(
+            runner,
+            clock=clock,
+            poll_interval_seconds=1,
+            termination_grace_seconds=1,
+        ),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="status 23") as raised:
+        controller.run()
+
+    assert any("cleanup also failed" in note for note in raised.value.__notes__)
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def test_future_client_timestamp_cannot_push_persisted_state_clock_forward(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    state = FakeStateStore(runtime_case.context.attempt)
+
+    def write_future_result() -> None:
+        _write_complete_result(runtime_case, clock)
+        clock.current_time -= timedelta(milliseconds=500)
+
+    runner = _FakeRunner(generation_hook=write_future_result)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="later than the allocation clock"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def test_stale_candidate_from_an_earlier_generation_cannot_succeed(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    _write_complete_result(runtime_case, clock)
+    clock.advance(5)
+    state = FakeStateStore(runtime_case.context.attempt)
+    controller = OneNodeAllocationController(
+        runtime_case.context,
+        runtime_proxy_path=runtime_case.context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(_FakeRunner(), clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="predates the current generation"):
+        controller.run()
+
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def _write_complete_result(runtime_case: RuntimeCase, clock: FakeClock) -> None:
+    context = runtime_case.context
+    requested = context.shard.requested_records
+    dataset_path = (context.attempt_directory / "dataset").as_posix()
+    candidate = CandidateOutputManifest(
+        schema_version=1,
+        run_id=context.plan.run_id,
+        shard_id=context.shard.shard_id,
+        attempt_id=context.attempt.attempt_id,
+        attempt_ordinal=context.attempt.attempt_ordinal,
+        created_at=clock.now(),
+        dataset_path=dataset_path,
+        requested_records=requested,
+        actual_records=requested,
+        outcome=CandidateOutcome.COMPLETE,
+        files=(
+            CandidateOutputFile(
+                relative_path="part-00000.parquet",
+                sha256="a" * 64,
+                byte_size=128,
+                record_count=requested,
+            ),
+        ),
+        dataset_schema_digest="b" * 64,
+        provenance_digest="c" * 64,
+    )
+    candidate_path = context.attempt_directory / "output-manifest.json"
+    _write_record(candidate_path, candidate.serialize_json())
+    clock.advance(1)
+    result = ClientResult(
+        schema_version=1,
+        run_id=context.plan.run_id,
+        shard_id=context.shard.shard_id,
+        attempt_id=context.attempt.attempt_id,
+        completed_at=clock.now(),
+        requested_records=requested,
+        actual_records=requested,
+        outcome=ClientOutcome.COMPLETE,
+        dataset_path=dataset_path,
+        early_shutdown=False,
+        requested_resume_mode=context.plan.invocation.authored.resume,
+        effective_resume_mode="never",
+        candidate_output_manifest=ArtifactReference(
+            path=candidate_path.as_posix(),
+            sha256=candidate.compute_sha256(),
+        ),
+    )
+    _write_record(context.attempt_directory / "client-result.json", result.serialize_json())
+
+
+def _write_record(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o600)

--- a/packages/data-designer-slurm/tests/runtime/test_controller.py
+++ b/packages/data-designer-slurm/tests/runtime/test_controller.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from pathlib import Path
 from typing import Callable
@@ -164,6 +164,38 @@ def test_preflight_failure_starts_no_process_and_fails_attempt(runtime_case: Run
         controller.run()
 
     assert raised.value.__cause__ is None
+    assert runner.steps == []
+    assert state.readiness == []
+    assert state.attempt.state is AttemptLifecycleState.FAILED
+
+
+def test_running_attempt_is_not_restarted_without_owned_process_identity(runtime_case: RuntimeCase) -> None:
+    clock = FakeClock(runtime_case.created_at.replace(second=10), monotonic_time=100)
+    running_attempt = runtime_case.context.attempt.__class__.model_validate(
+        runtime_case.context.attempt.model_dump(mode="python")
+        | {
+            "state": AttemptLifecycleState.RUNNING,
+            "updated_at": runtime_case.created_at + timedelta(seconds=2),
+        }
+    )
+    context = replace(runtime_case.context, attempt=running_attempt)
+    state = FakeStateStore(running_attempt)
+    runner = _FakeRunner()
+    controller = OneNodeAllocationController(
+        context,
+        runtime_proxy_path=context.attempt_directory / "runtime/proxy.py",
+        state=state,
+        supervisor=StepSupervisor(runner, clock=clock),
+        preflight=FakePreflight(),
+        client_steps=FakeClientStepBuilder(),
+        prober=_FakeProber(ready=True, clock=clock),
+        clock=clock,
+        environment={},
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="not executable"):
+        controller.run()
+
     assert runner.steps == []
     assert state.readiness == []
     assert state.attempt.state is AttemptLifecycleState.FAILED

--- a/packages/data-designer-slurm/tests/runtime/test_entrypoint.py
+++ b/packages/data-designer-slurm/tests/runtime/test_entrypoint.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from data_designer.slurm.runtime.entrypoint import main
+
+
+def test_entrypoint_rejects_relative_paths_without_traceback(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(("--plan", "resolved-plan.json", "--attempt-dir", "attempt-0001")) == 64
+    captured = capsys.readouterr()
+    assert "runtime paths must be absolute" in captured.err
+    assert "Traceback" not in captured.err

--- a/packages/data-designer-slurm/tests/runtime/test_paths.py
+++ b/packages/data-designer-slurm/tests/runtime/test_paths.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from conftest import RuntimeCase
+
+from data_designer.slurm.config import ContainerMount
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+from data_designer.slurm.runtime.paths import get_container_path
+
+
+def test_container_path_uses_most_specific_mount_and_preserves_relative_path(runtime_case: RuntimeCase) -> None:
+    workspace = runtime_case.workspace.as_posix()
+    nested = f"{workspace}/runs"
+    plan = runtime_case.context.plan.model_copy(
+        update={
+            "container_mounts": (
+                ContainerMount(source=workspace, target="/container/workspace"),
+                ContainerMount(source=nested, target="/container/runs"),
+            )
+        }
+    )
+
+    mapped = get_container_path(plan, f"{nested}/run-single/resolved-plan.json")
+
+    assert mapped == "/container/runs/run-single/resolved-plan.json"
+
+
+def test_container_path_rejects_unmounted_and_read_only_writes(runtime_case: RuntimeCase) -> None:
+    plan = runtime_case.context.plan.model_copy(
+        update={
+            "container_mounts": (
+                ContainerMount(
+                    source=runtime_case.workspace.as_posix(),
+                    target="/container/workspace",
+                    read_only=True,
+                ),
+            )
+        }
+    )
+
+    with pytest.raises(SlurmRuntimeError, match="writable"):
+        get_container_path(plan, runtime_case.context.attempt_directory.as_posix(), require_writable=True)
+    with pytest.raises(SlurmRuntimeError, match="not available"):
+        get_container_path(plan, "/different/root/file.json")

--- a/packages/data-designer-slurm/tests/runtime/test_preflight.py
+++ b/packages/data-designer-slurm/tests/runtime/test_preflight.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 
 import pytest
 from conftest import RuntimeCase
 
 from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.runtime import preflight as runtime_preflight
 from data_designer.slurm.runtime.errors import SlurmRuntimeError
 from data_designer.slurm.runtime.preflight import SystemAllocationPreflight, _verify_artifact
 
@@ -71,6 +73,35 @@ def test_artifact_verification_checks_exact_bytes_and_rejects_symlink(tmp_path: 
     artifact.symlink_to(target)
     with pytest.raises(OSError, match="regular file"):
         _verify_artifact(reference)
+
+
+def test_artifact_verification_rejects_path_replacement_during_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "artifact.bin"
+    content = b"reviewed artifact"
+    artifact.write_bytes(content)
+    reference = ArtifactReference(path=artifact.as_posix(), sha256=hashlib.sha256(content).hexdigest())
+    replacement = tmp_path / "replacement.bin"
+    replacement.write_bytes(b"different artifact")
+    original_fstat = runtime_preflight.os.fstat
+    fstat_calls = 0
+    replaced = False
+
+    def replace_after_descriptor_validation(descriptor: int) -> os.stat_result:
+        nonlocal fstat_calls, replaced
+        status = original_fstat(descriptor)
+        fstat_calls += 1
+        if fstat_calls == 2:
+            replaced = True
+            os.replace(replacement, artifact)
+        return status
+
+    monkeypatch.setattr(runtime_preflight.os, "fstat", replace_after_descriptor_validation)
+    with pytest.raises(OSError, match="replaced while it was verified"):
+        _verify_artifact(reference)
+    assert replaced
 
 
 def test_port_preflight_detects_collision_before_launch(

--- a/packages/data-designer-slurm/tests/runtime/test_preflight.py
+++ b/packages/data-designer-slurm/tests/runtime/test_preflight.py
@@ -109,6 +109,8 @@ def test_port_preflight_detects_collision_before_launch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _UnavailableSocket:
+        closed: bool = False
+
         def __init__(self, *arguments: object) -> None:
             del arguments
 
@@ -120,12 +122,13 @@ def test_port_preflight_detects_collision_before_launch(
             raise OSError("injected port collision")
 
         def close(self) -> None:
-            pass
+            type(self).closed = True
 
     monkeypatch.setattr("data_designer.slurm.runtime.preflight.socket.socket", _UnavailableSocket)
 
     with pytest.raises(SlurmRuntimeError, match="ports are unavailable"):
         SystemAllocationPreflight._verify_ports(runtime_case.context)
+    assert _UnavailableSocket.closed
 
 
 def test_attempt_directory_must_be_restrictive(runtime_case: RuntimeCase) -> None:

--- a/packages/data-designer-slurm/tests/runtime/test_preflight.py
+++ b/packages/data-designer-slurm/tests/runtime/test_preflight.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from conftest import RuntimeCase
+
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+from data_designer.slurm.runtime.preflight import SystemAllocationPreflight, _verify_artifact
+
+
+def test_scheduler_preflight_accepts_exact_one_node_gpu_shape(runtime_case: RuntimeCase) -> None:
+    environment = {
+        "SLURM_ARRAY_JOB_ID": "4101",
+        "SLURM_ARRAY_TASK_ID": "0",
+        "SLURM_JOB_NUM_NODES": "1",
+        "SLURM_NODEID": "0",
+        "CUDA_VISIBLE_DEVICES": "0,1,2,3,4,5,6,7",
+    }
+
+    SystemAllocationPreflight._verify_scheduler(runtime_case.context, environment)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    (
+        ("SLURM_ARRAY_TASK_ID", "1"),
+        ("SLURM_ARRAY_JOB_ID", "4102"),
+        ("SLURM_JOB_NUM_NODES", "2"),
+        ("SLURM_NODEID", "1"),
+        ("CUDA_VISIBLE_DEVICES", "0,1"),
+    ),
+)
+def test_scheduler_preflight_rejects_mismatched_allocation_fact(
+    runtime_case: RuntimeCase,
+    name: str,
+    value: str,
+) -> None:
+    environment = {
+        "SLURM_ARRAY_JOB_ID": "4101",
+        "SLURM_ARRAY_TASK_ID": "0",
+        "SLURM_JOB_NUM_NODES": "1",
+        "SLURM_NODEID": "0",
+        "CUDA_VISIBLE_DEVICES": "0,1,2,3,4,5,6,7",
+    }
+    environment[name] = value
+
+    with pytest.raises(SlurmRuntimeError, match="does not match|GPU visibility"):
+        SystemAllocationPreflight._verify_scheduler(runtime_case.context, environment)
+
+
+def test_artifact_verification_checks_exact_bytes_and_rejects_symlink(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.bin"
+    content = b"reviewed artifact"
+    artifact.write_bytes(content)
+    reference = ArtifactReference(path=artifact.as_posix(), sha256=hashlib.sha256(content).hexdigest())
+
+    _verify_artifact(reference)
+    artifact.write_bytes(b"changed")
+    with pytest.raises(OSError, match="digest"):
+        _verify_artifact(reference)
+
+    target = tmp_path / "target.bin"
+    target.write_bytes(content)
+    artifact.unlink()
+    artifact.symlink_to(target)
+    with pytest.raises(OSError, match="regular file"):
+        _verify_artifact(reference)
+
+
+def test_port_preflight_detects_collision_before_launch(
+    runtime_case: RuntimeCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _UnavailableSocket:
+        def __init__(self, *arguments: object) -> None:
+            del arguments
+
+        def setsockopt(self, *arguments: object) -> None:
+            del arguments
+
+        def bind(self, address: tuple[str, int]) -> None:
+            del address
+            raise OSError("injected port collision")
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("data_designer.slurm.runtime.preflight.socket.socket", _UnavailableSocket)
+
+    with pytest.raises(SlurmRuntimeError, match="ports are unavailable"):
+        SystemAllocationPreflight._verify_ports(runtime_case.context)
+
+
+def test_attempt_directory_must_be_restrictive(runtime_case: RuntimeCase) -> None:
+    runtime_case.context.attempt_directory.chmod(0o755)
+
+    with pytest.raises(SlurmRuntimeError, match="restrictive directory"):
+        SystemAllocationPreflight._verify_attempt_directory(runtime_case.context.attempt_directory)

--- a/packages/data-designer-slurm/tests/runtime/test_probes.py
+++ b/packages/data-designer-slurm/tests/runtime/test_probes.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from data_designer.slurm.runtime import probes
+from data_designer.slurm.runtime.probes import HttpReadinessProber
+
+
+def test_readiness_probe_does_not_buffer_response_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _FakeConnection()
+    monkeypatch.setattr(probes.http.client, "HTTPConnection", lambda *args, **kwargs: connection)
+
+    assert HttpReadinessProber().is_ready("127.0.0.1", 8000, "/health", timeout_seconds=1.0)
+
+    assert connection.requested == ("GET", "/health", {"Connection": "close"})
+    assert connection.closed
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.requested: tuple[str, str, dict[str, str]] | None = None
+        self.closed = False
+
+    def request(self, method: str, path: str, *, headers: dict[str, str]) -> None:
+        self.requested = (method, path, headers)
+
+    def getresponse(self) -> SimpleNamespace:
+        return SimpleNamespace(status=200)
+
+    def close(self) -> None:
+        self.closed = True

--- a/packages/data-designer-slurm/tests/runtime/test_proxy.py
+++ b/packages/data-designer-slurm/tests/runtime/test_proxy.py
@@ -145,6 +145,54 @@ def test_proxy_bounds_backend_response_buffering(monkeypatch: pytest.MonkeyPatch
     )
 
 
+def test_proxy_strips_connection_nominated_headers_in_both_directions(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        status = 200
+
+        def read(self, amount: int) -> bytes:
+            del amount
+            return b"complete"
+
+        def getheaders(self) -> list[tuple[str, str]]:
+            return [
+                ("Connection", "X-Backend-Hop"),
+                ("X-Backend-Hop", "private"),
+                ("Content-Type", "application/json"),
+            ]
+
+    class _Connection:
+        forwarded_headers: dict[str, str] = {}
+
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            del host, port, timeout
+
+        def request(self, method: str, path: str, *, body: bytes, headers: dict[str, str]) -> None:
+            del method, path, body
+            type(self).forwarded_headers = headers
+
+        def getresponse(self) -> _Response:
+            return _Response()
+
+        def close(self) -> None:
+            pass
+
+    handler = object.__new__(_ProxyHandler)
+    handler.command = "POST"
+    handler.path = "/v1/chat/completions"
+    handler.headers = Message()
+    handler.headers["Connection"] = "X-Client-Hop"
+    handler.headers["X-Client-Hop"] = "private"
+    handler.headers["Proxy-Connection"] = "keep-alive"
+    handler.headers["Authorization"] = "Bearer reviewed"
+    monkeypatch.setattr(runtime_proxy.http.client, "HTTPConnection", _Connection)
+
+    status, body, headers = handler._request_backend(_Backend("127.0.0.1", 8001), b"{}")
+
+    assert (status, body) == (200, b"complete")
+    assert _Connection.forwarded_headers == {"Authorization": "Bearer reviewed", "Content-Length": "2"}
+    assert headers == {"Content-Type": "application/json"}
+
+
 @pytest.mark.parametrize(
     "value",
     (

--- a/packages/data-designer-slurm/tests/runtime/test_proxy.py
+++ b/packages/data-designer-slurm/tests/runtime/test_proxy.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from data_designer.slurm.runtime import proxy as runtime_proxy
 from data_designer.slurm.runtime.proxy import _Backend, _BackendPool, _parse_backend, _ProxyHandler
 
 
@@ -104,6 +105,44 @@ def test_proxy_rejects_a_truncated_fixed_length_request() -> None:
 
     assert handler._read_request_body() is None
     assert errors == [400]
+
+
+def test_proxy_bounds_backend_response_buffering(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        status = 200
+
+        def read(self, amount: int) -> bytes:
+            assert amount == 5
+            return b"12345"
+
+        def getheaders(self) -> list[tuple[str, str]]:
+            return []
+
+    class _Connection:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            del host, port, timeout
+
+        def request(self, method: str, path: str, *, body: bytes, headers: dict[str, str]) -> None:
+            del method, path, body, headers
+
+        def getresponse(self) -> _Response:
+            return _Response()
+
+        def close(self) -> None:
+            pass
+
+    handler = object.__new__(_ProxyHandler)
+    handler.command = "POST"
+    handler.path = "/v1/chat/completions"
+    handler.headers = Message()
+    monkeypatch.setattr(runtime_proxy, "_MAXIMUM_RESPONSE_BYTES", 4)
+    monkeypatch.setattr(runtime_proxy.http.client, "HTTPConnection", _Connection)
+
+    assert handler._request_backend(_Backend("127.0.0.1", 8001), b"{}") == (
+        502,
+        b'{"error":"backend response too large"}\n',
+        {"Content-Type": "application/json"},
+    )
 
 
 @pytest.mark.parametrize(

--- a/packages/data-designer-slurm/tests/runtime/test_proxy.py
+++ b/packages/data-designer-slurm/tests/runtime/test_proxy.py
@@ -7,7 +7,6 @@ import argparse
 import io
 from email.message import Message
 from types import MethodType
-from unittest.mock import patch
 
 import pytest
 
@@ -17,7 +16,7 @@ from data_designer.slurm.runtime.proxy import _Backend, _BackendPool, _parse_bac
 
 def test_proxy_retries_overload_on_another_least_active_backend() -> None:
     handler = object.__new__(_ProxyHandler)
-    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 4, 1)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 1)
     handler.server = type("Server", (), {"pool": pool})()
     handler.path = "/v1/chat/completions"
     handler.command = "POST"
@@ -48,43 +47,24 @@ def test_proxy_retries_overload_on_another_least_active_backend() -> None:
     assert captured == [(200, b"complete", {"Content-Type": "application/json"})]
 
 
-def test_proxy_queues_a_bounded_overload_and_retries_until_available() -> None:
+def test_proxy_passes_final_overload_through_after_one_backend_pass() -> None:
     handler = object.__new__(_ProxyHandler)
-    pool = _BackendPool((_Backend("127.0.0.1", 8001),), 1, None)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 3)
     handler.server = type("Server", (), {"pool": pool})()
     handler.path = "/v1/chat/completions"
     handler.command = "POST"
     handler.rfile = io.BytesIO(b"{}")
     handler.headers = Message()
     handler.headers["Content-Length"] = "2"
-    responses = iter(((429, b"overloaded", {}), (200, b"complete", {})))
+    calls: list[int] = []
     captured: list[tuple[int, bytes, dict[str, str]]] = []
 
-    handler._request_backend = MethodType(lambda self, backend, body: next(responses), handler)
-    handler._write_response = MethodType(
-        lambda self, status, body, headers: captured.append((status, body, headers)),
-        handler,
-    )
+    def request_backend(self: _ProxyHandler, backend: _Backend, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        del self, body
+        calls.append(backend.port)
+        return 429, f"overloaded-{backend.port}".encode(), {"Retry-After": "99"}
 
-    with patch("data_designer.slurm.runtime.proxy.time.sleep") as sleep:
-        handler._forward()
-
-    sleep.assert_called_once_with(1)
-    assert captured == [(200, b"complete", {})]
-
-
-def test_proxy_rejects_overload_immediately_when_queue_is_disabled() -> None:
-    handler = object.__new__(_ProxyHandler)
-    pool = _BackendPool((_Backend("127.0.0.1", 8001),), 0, None)
-    handler.server = type("Server", (), {"pool": pool})()
-    handler.path = "/v1/chat/completions"
-    handler.command = "POST"
-    handler.rfile = io.BytesIO(b"{}")
-    handler.headers = Message()
-    handler.headers["Content-Length"] = "2"
-    captured: list[tuple[int, bytes, dict[str, str]]] = []
-
-    handler._request_backend = MethodType(lambda self, backend, body: (429, b"overloaded", {}), handler)
+    handler._request_backend = MethodType(request_backend, handler)
     handler._write_response = MethodType(
         lambda self, status, body, headers: captured.append((status, body, headers)),
         handler,
@@ -92,7 +72,8 @@ def test_proxy_rejects_overload_immediately_when_queue_is_disabled() -> None:
 
     handler._forward()
 
-    assert captured == [(429, b"overloaded", {})]
+    assert calls == [8001, 8002]
+    assert captured == [(429, b"overloaded-8002", {"Retry-After": "3"})]
 
 
 def test_proxy_rejects_a_truncated_fixed_length_request() -> None:
@@ -209,7 +190,7 @@ def test_proxy_rejects_non_loopback_or_malformed_backend(value: str) -> None:
 
 
 def test_pool_selects_least_active_backend() -> None:
-    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 2, 1)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 1)
     first = pool.acquire(frozenset())
     second = pool.acquire(frozenset())
     pool.release(second)

--- a/packages/data-designer-slurm/tests/runtime/test_proxy.py
+++ b/packages/data-designer-slurm/tests/runtime/test_proxy.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import io
+from email.message import Message
+from types import MethodType
+from unittest.mock import patch
+
+import pytest
+
+from data_designer.slurm.runtime.proxy import _Backend, _BackendPool, _parse_backend, _ProxyHandler
+
+
+def test_proxy_retries_overload_on_another_least_active_backend() -> None:
+    handler = object.__new__(_ProxyHandler)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 4, 1)
+    handler.server = type("Server", (), {"pool": pool})()
+    handler.path = "/v1/chat/completions"
+    handler.command = "POST"
+    handler.rfile = io.BytesIO(b"{}")
+    handler.headers = Message()
+    handler.headers["Content-Length"] = "2"
+    calls: list[int] = []
+    captured: list[tuple[int, bytes, dict[str, str]]] = []
+
+    def request_backend(self: _ProxyHandler, backend: _Backend, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        del self
+        calls.append(backend.port)
+        assert body == b"{}"
+        if backend.port == 8001:
+            return 429, b"overloaded", {}
+        return 200, b"complete", {"Content-Type": "application/json"}
+
+    def write_response(self: _ProxyHandler, status: int, body: bytes, headers: dict[str, str]) -> None:
+        del self
+        captured.append((status, body, headers))
+
+    handler._request_backend = MethodType(request_backend, handler)
+    handler._write_response = MethodType(write_response, handler)
+
+    handler._forward()
+
+    assert calls == [8001, 8002]
+    assert captured == [(200, b"complete", {"Content-Type": "application/json"})]
+
+
+def test_proxy_queues_a_bounded_overload_and_retries_until_available() -> None:
+    handler = object.__new__(_ProxyHandler)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001),), 1, None)
+    handler.server = type("Server", (), {"pool": pool})()
+    handler.path = "/v1/chat/completions"
+    handler.command = "POST"
+    handler.rfile = io.BytesIO(b"{}")
+    handler.headers = Message()
+    handler.headers["Content-Length"] = "2"
+    responses = iter(((429, b"overloaded", {}), (200, b"complete", {})))
+    captured: list[tuple[int, bytes, dict[str, str]]] = []
+
+    handler._request_backend = MethodType(lambda self, backend, body: next(responses), handler)
+    handler._write_response = MethodType(
+        lambda self, status, body, headers: captured.append((status, body, headers)),
+        handler,
+    )
+
+    with patch("data_designer.slurm.runtime.proxy.time.sleep") as sleep:
+        handler._forward()
+
+    sleep.assert_called_once_with(1)
+    assert captured == [(200, b"complete", {})]
+
+
+def test_proxy_rejects_overload_immediately_when_queue_is_disabled() -> None:
+    handler = object.__new__(_ProxyHandler)
+    pool = _BackendPool((_Backend("127.0.0.1", 8001),), 0, None)
+    handler.server = type("Server", (), {"pool": pool})()
+    handler.path = "/v1/chat/completions"
+    handler.command = "POST"
+    handler.rfile = io.BytesIO(b"{}")
+    handler.headers = Message()
+    handler.headers["Content-Length"] = "2"
+    captured: list[tuple[int, bytes, dict[str, str]]] = []
+
+    handler._request_backend = MethodType(lambda self, backend, body: (429, b"overloaded", {}), handler)
+    handler._write_response = MethodType(
+        lambda self, status, body, headers: captured.append((status, body, headers)),
+        handler,
+    )
+
+    handler._forward()
+
+    assert captured == [(429, b"overloaded", {})]
+
+
+def test_proxy_rejects_a_truncated_fixed_length_request() -> None:
+    handler = object.__new__(_ProxyHandler)
+    handler.rfile = io.BytesIO(b"{")
+    handler.headers = Message()
+    handler.headers["Content-Length"] = "2"
+    errors: list[int] = []
+    handler.send_error = MethodType(lambda self, status: errors.append(status), handler)
+
+    assert handler._read_request_body() is None
+    assert errors == [400]
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "https://127.0.0.1:8000",
+        "http://example.com:8000",
+        "http://127.0.0.1:70000",
+        "http://user@127.0.0.1:8000",
+        "http://127.0.0.1:8000/path",
+    ),
+)
+def test_proxy_rejects_non_loopback_or_malformed_backend(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="backend"):
+        _parse_backend(value)
+
+
+def test_pool_selects_least_active_backend() -> None:
+    pool = _BackendPool((_Backend("127.0.0.1", 8001), _Backend("127.0.0.1", 8002)), 2, 1)
+    first = pool.acquire(frozenset())
+    second = pool.acquire(frozenset())
+    pool.release(second)
+    pool.release(first)
+
+    assert first != second

--- a/packages/data-designer-slurm/tests/runtime/test_steps.py
+++ b/packages/data-designer-slurm/tests/runtime/test_steps.py
@@ -78,9 +78,10 @@ def test_all_processes_use_structured_srun_steps_and_sanitized_environment(runti
     server = server_steps[0]
     assert server.role is RuntimeStepRole.SERVER
     assert f"--gpus-per-task={deployment.topology.tensor_parallel}" in server.command
-    assert any(argument.startswith("--gpu-bind=map_gpu:") for argument in server.command)
-    assert "CUDA_VISIBLE_DEVICES" in server.environment
-    assert any(argument.startswith("--container-env=CUDA_VISIBLE_DEVICES") for argument in server.command)
+    expected_mask = sum(1 << index for index in deployment.processes[0].gpu_indices)
+    assert f"--gpu-bind=mask_gpu:{expected_mask:#x}" in server.command
+    assert "CUDA_VISIBLE_DEVICES" not in server.environment
+    assert all("CUDA_VISIBLE_DEVICES" not in argument for argument in server.command)
     assert all("--gpus-per-task=" not in argument for step in client_steps for argument in step.command)
     assert all("--gres=none" in step.command for step in client_steps)
     assert all("CUDA_VISIBLE_DEVICES" not in step.environment for step in client_steps)
@@ -121,7 +122,7 @@ def test_client_worker_receives_only_persisted_identity_and_logical_endpoint(run
     assert f"generator=http://127.0.0.1:{endpoints[0].port}/v1" in worker
 
 
-def test_endpoint_step_uses_resolved_backpressure_and_backends(runtime_case: RuntimeCase) -> None:
+def test_endpoint_step_uses_resolved_retry_policy_and_backends(runtime_case: RuntimeCase) -> None:
     context = runtime_case.context
     deployment = resolve_vllm_server(context.plan, context.plan.deployments[0].deployment_id)
 
@@ -135,7 +136,12 @@ def test_endpoint_step_uses_resolved_backpressure_and_backends(runtime_case: Run
 
     assert step.role is RuntimeStepRole.ENDPOINT
     assert endpoint.port == deployment.logical_endpoint.port
-    assert str(deployment.launch_policy.queue_backpressure.max_waiting_requests) in step.command
+    retry_after_seconds = deployment.launch_policy.queue_backpressure.retry_after_seconds
+    assert retry_after_seconds is not None
+    assert ("--retry-after-seconds", str(retry_after_seconds)) == step.command[
+        step.command.index("--retry-after-seconds") : step.command.index("--retry-after-seconds") + 2
+    ]
+    assert "--max-waiting-requests" not in step.command
     for backend in deployment.backend_endpoints:
         assert f"http://127.0.0.1:{backend.port}" in step.command
 
@@ -150,9 +156,8 @@ def test_endpoint_step_uses_resolved_backpressure_and_backends(runtime_case: Run
         {},
         context.attempt_directory / "runtime/proxy.py",
     )
-    assert "--max-waiting-requests" in disabled_step.command
-    assert "0" in disabled_step.command
     assert "--retry-after-seconds" not in disabled_step.command
+    assert "--max-waiting-requests" not in disabled_step.command
 
 
 def test_client_receives_client_secrets_without_server_only_secrets(

--- a/packages/data-designer-slurm/tests/runtime/test_steps.py
+++ b/packages/data-designer-slurm/tests/runtime/test_steps.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from conftest import RuntimeCase, relocate_plan
+
+from data_designer.slurm.config import QueueBackpressureConfig
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+from data_designer.slurm.runtime.models import RuntimeEndpoint, RuntimeStepRole
+from data_designer.slurm.runtime.steps import (
+    DefaultClientStepBuilder,
+    build_endpoint_steps,
+    build_vllm_steps,
+)
+from data_designer.slurm.serving.resolver import resolve_vllm_server
+from data_designer.slurm.state import AttemptLifecycleState, AttemptManifest, SchedulerIdentity
+
+
+def test_all_processes_use_structured_srun_steps_and_sanitized_environment(runtime_case: RuntimeCase) -> None:
+    context = runtime_case.context
+    deployment = resolve_vllm_server(context.plan, context.plan.deployments[0].deployment_id)
+    source_environment = {
+        "PATH": "/custom/bin",
+        "SLURM_JOB_ID": "4101",
+        "UNREVIEWED_VALUE": "must-not-forward",
+    }
+
+    server_steps = build_vllm_steps(
+        deployment,
+        context.plan,
+        context.attempt_directory,
+        source_environment,
+    )
+    endpoint_steps = build_endpoint_steps(
+        (deployment,),
+        context.plan,
+        context.attempt_directory,
+        source_environment,
+        context.attempt_directory / "runtime/proxy.py",
+    )
+    endpoints = tuple(endpoint for _, endpoint in endpoint_steps)
+    client_builder = DefaultClientStepBuilder()
+    client_steps = (
+        client_builder.build_preflight_step(
+            context.plan,
+            context.shard,
+            context.attempt,
+            context.attempt_directory,
+            endpoints,
+            source_environment,
+        ),
+        client_builder.build_generation_step(
+            context.plan,
+            context.shard,
+            context.attempt,
+            context.attempt_directory,
+            endpoints,
+            source_environment,
+        ),
+    )
+
+    all_steps = server_steps + tuple(step for step, _ in endpoint_steps) + client_steps
+    assert all(step.command[0] == "srun" for step in all_steps)
+    assert all("--" in step.command for step in all_steps)
+    assert all("UNREVIEWED_VALUE" not in step.environment for step in all_steps)
+    assert all(step.environment["SLURM_JOB_ID"] == "4101" for step in all_steps)
+    assert all(step.environment["LC_ALL"] == "C" for step in all_steps)
+    assert all(step.stdout_path.parent == context.attempt_directory / "logs" for step in all_steps)
+    assert all(f"--cpus-per-task={context.plan.client.authored.cpus}" in step.command for step in all_steps)
+
+    server = server_steps[0]
+    assert server.role is RuntimeStepRole.SERVER
+    assert f"--gpus-per-task={deployment.topology.tensor_parallel}" in server.command
+    assert any(argument.startswith("--gpu-bind=map_gpu:") for argument in server.command)
+    assert "CUDA_VISIBLE_DEVICES" in server.environment
+    assert any(argument.startswith("--container-env=CUDA_VISIBLE_DEVICES") for argument in server.command)
+    assert all("--gpus-per-task=" not in argument for step in client_steps for argument in step.command)
+    assert all("--gres=none" in step.command for step in client_steps)
+    assert all("CUDA_VISIBLE_DEVICES" not in step.environment for step in client_steps)
+
+
+def test_client_worker_receives_only_persisted_identity_and_logical_endpoint(runtime_case: RuntimeCase) -> None:
+    context = runtime_case.context
+    deployment = resolve_vllm_server(context.plan, context.plan.deployments[0].deployment_id)
+    endpoint_steps = build_endpoint_steps(
+        (deployment,),
+        context.plan,
+        context.attempt_directory,
+        {},
+        context.attempt_directory / "runtime/proxy.py",
+    )
+    endpoints = tuple(endpoint for _, endpoint in endpoint_steps)
+
+    step = DefaultClientStepBuilder().build_generation_step(
+        context.plan,
+        context.shard,
+        context.attempt,
+        context.attempt_directory,
+        endpoints,
+        {},
+    )
+
+    separator = step.command.index("--")
+    worker = step.command[separator + 1 :]
+    assert worker[:5] == (
+        "python3",
+        "-m",
+        "data_designer.slurm.client.worker",
+        "run",
+        "--plan",
+    )
+    assert context.attempt.attempt_id in worker
+    assert context.shard.shard_id in worker
+    assert f"generator=http://127.0.0.1:{endpoints[0].port}/v1" in worker
+
+
+def test_endpoint_step_uses_resolved_backpressure_and_backends(runtime_case: RuntimeCase) -> None:
+    context = runtime_case.context
+    deployment = resolve_vllm_server(context.plan, context.plan.deployments[0].deployment_id)
+
+    ((step, endpoint),) = build_endpoint_steps(
+        (deployment,),
+        context.plan,
+        context.attempt_directory,
+        {},
+        context.attempt_directory / "runtime/proxy.py",
+    )
+
+    assert step.role is RuntimeStepRole.ENDPOINT
+    assert endpoint.port == deployment.logical_endpoint.port
+    assert str(deployment.launch_policy.queue_backpressure.max_waiting_requests) in step.command
+    for backend in deployment.backend_endpoints:
+        assert f"http://127.0.0.1:{backend.port}" in step.command
+
+    disabled_policy = deployment.launch_policy.model_copy(
+        update={"queue_backpressure": QueueBackpressureConfig(max_waiting_requests=0, retry_after_seconds=None)}
+    )
+    disabled = deployment.model_copy(update={"launch_policy": disabled_policy})
+    ((disabled_step, _),) = build_endpoint_steps(
+        (disabled,),
+        context.plan,
+        context.attempt_directory,
+        {},
+        context.attempt_directory / "runtime/proxy.py",
+    )
+    assert "--max-waiting-requests" in disabled_step.command
+    assert "0" in disabled_step.command
+    assert "--retry-after-seconds" not in disabled_step.command
+
+
+def test_client_receives_client_secrets_without_server_only_secrets(
+    tmp_path: Path,
+    multi_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    plan = relocate_plan(multi_node_plan, workspace)
+    shard = plan.shards[0]
+    attempt_directory = workspace / "attempt"
+    attempt = AttemptManifest(
+        schema_version=1,
+        run_id=plan.run_id,
+        shard_id=shard.shard_id,
+        attempt_id="attempt-0001",
+        attempt_ordinal=1,
+        resolved_plan=ArtifactReference(
+            path=Path(plan.authored_config.path).with_name("resolved-plan.json").as_posix(),
+            sha256=plan.compute_sha256(),
+        ),
+        state=AttemptLifecycleState.SUBMITTED,
+        scheduler=SchedulerIdentity(array_job_id=4101, array_task_id=0),
+        created_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    endpoints = tuple(
+        RuntimeEndpoint(
+            model_alias=deployment.authored.model_alias,
+            served_model_name=deployment.served_model_name,
+            host="127.0.0.1",
+            port=port.port,
+        )
+        for deployment, port in zip(plan.deployments, plan.client.ports, strict=True)
+    )
+
+    step = DefaultClientStepBuilder().build_preflight_step(
+        plan,
+        shard,
+        attempt,
+        attempt_directory,
+        endpoints,
+        {
+            "PACKAGE_INDEX_TOKEN": "client-secret",
+            "HF_TOKEN": "server-secret",
+        },
+    )
+
+    assert step.environment["PACKAGE_INDEX_TOKEN"] == "client-secret"
+    assert "HF_TOKEN" not in step.environment
+    assert "--container-env=PACKAGE_INDEX_TOKEN" in step.command
+
+    with pytest.raises(SlurmRuntimeError, match="PACKAGE_INDEX_TOKEN"):
+        DefaultClientStepBuilder().build_preflight_step(
+            plan,
+            shard,
+            attempt,
+            attempt_directory,
+            endpoints,
+            {"HF_TOKEN": "server-secret"},
+        )

--- a/packages/data-designer-slurm/tests/runtime/test_supervisor.py
+++ b/packages/data-designer-slurm/tests/runtime/test_supervisor.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from slurm_test_fakes import FakeClock
+
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
+from data_designer.slurm.runtime.supervisor import StepSupervisor, SubprocessStepRunner
+
+
+@dataclass(slots=True)
+class _Process:
+    pid: int
+    returncode: int | None = None
+    terminated: int = 0
+    killed: int = 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated += 1
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed += 1
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        assert self.returncode is not None
+        return self.returncode
+
+
+class _Runner:
+    def __init__(self, processes: list[_Process]) -> None:
+        self.processes = processes
+        self.started = 0
+
+    def start(self, step: RuntimeStep) -> _Process:
+        del step
+        process = self.processes[self.started]
+        self.started += 1
+        return process
+
+
+def test_cleanup_is_reverse_order_and_idempotent(tmp_path: Path, fake_clock: FakeClock) -> None:
+    first = _Process(1)
+    second = _Process(2)
+    runner = _Runner([first, second])
+    supervisor = StepSupervisor(runner, clock=fake_clock)
+    supervisor.start(_step(tmp_path, "first"))
+    supervisor.start(_step(tmp_path, "second"))
+
+    supervisor.cleanup()
+    supervisor.cleanup()
+
+    assert first.terminated == second.terminated == 1
+    assert first.killed == second.killed == 0
+    with pytest.raises(SlurmRuntimeError, match="after cleanup"):
+        supervisor.start(_step(tmp_path, "third"))
+
+
+def test_wait_fails_when_required_service_exits(tmp_path: Path, fake_clock: FakeClock) -> None:
+    service = _Process(1, returncode=19)
+    target = _Process(2)
+    supervisor = StepSupervisor(_Runner([service, target]), clock=fake_clock)
+    managed_service = supervisor.start(_step(tmp_path, "service"))
+    managed_target = supervisor.start(_step(tmp_path, "target"))
+
+    with pytest.raises(SlurmRuntimeError, match="status 19"):
+        supervisor.wait(managed_target, required=(managed_service,))
+
+
+def test_subprocess_runner_uses_restrictive_logs_and_rejects_symlink_root(tmp_path: Path) -> None:
+    attempt = tmp_path / "attempt"
+    attempt.mkdir(mode=0o700)
+    step = RuntimeStep(
+        step_id="real-step",
+        role=RuntimeStepRole.CLIENT_PREFLIGHT,
+        command=(sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"),
+        environment={"PATH": "/usr/bin", "LC_ALL": "C"},
+        stdout_path=attempt / "logs" / "real-step.out",
+        stderr_path=attempt / "logs" / "real-step.err",
+    )
+
+    process = SubprocessStepRunner().start(step)
+    assert process.wait(timeout=10) == 0
+    assert step.stdout_path.read_text() == "out\n"
+    assert step.stderr_path.read_text() == "err\n"
+    assert step.stdout_path.stat().st_mode & 0o077 == 0
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    symlink_attempt = tmp_path / "symlink-attempt"
+    symlink_attempt.mkdir()
+    (symlink_attempt / "logs").symlink_to(outside, target_is_directory=True)
+    unsafe = RuntimeStep(
+        step_id="unsafe-step",
+        role=RuntimeStepRole.CLIENT,
+        command=("true",),
+        environment={"PATH": "/usr/bin"},
+        stdout_path=symlink_attempt / "logs" / "unsafe.out",
+        stderr_path=symlink_attempt / "logs" / "unsafe.err",
+    )
+    with pytest.raises(OSError, match="not a directory"):
+        SubprocessStepRunner().start(unsafe)
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_subprocess_cleanup_terminates_the_complete_step_process_group(tmp_path: Path) -> None:
+    attempt = tmp_path / "attempt"
+    attempt.mkdir(mode=0o700)
+    parent_stopped = attempt / "parent-stopped"
+    child_stopped = attempt / "child-stopped"
+    child_ready = attempt / "child-ready"
+    child_code = (
+        "import signal,time; from pathlib import Path; "
+        f"stopped=Path({child_stopped.as_posix()!r}); ready=Path({child_ready.as_posix()!r}); "
+        "signal.signal(signal.SIGTERM, lambda *_: (stopped.write_text('stopped'), exit(0))); "
+        "ready.write_text('ready'); time.sleep(60)"
+    )
+    parent_code = (
+        "import signal,subprocess,sys,time; from pathlib import Path; "
+        f"stopped=Path({parent_stopped.as_posix()!r}); child_code={child_code!r}; "
+        "signal.signal(signal.SIGTERM, lambda *_: (stopped.write_text('stopped'), exit(0))); "
+        "subprocess.Popen([sys.executable, '-c', child_code]); time.sleep(60)"
+    )
+    step = RuntimeStep(
+        step_id="process-tree",
+        role=RuntimeStepRole.SERVER,
+        command=(sys.executable, "-c", parent_code),
+        environment={"PATH": "/usr/bin"},
+        stdout_path=attempt / "logs" / "process-tree.out",
+        stderr_path=attempt / "logs" / "process-tree.err",
+    )
+    supervisor = StepSupervisor(
+        SubprocessStepRunner(),
+        poll_interval_seconds=0.01,
+        termination_grace_seconds=3,
+    )
+    supervisor.start(step)
+    deadline = time.monotonic() + 3
+    while not child_ready.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert child_ready.exists()
+
+    supervisor.cleanup()
+
+    assert parent_stopped.read_text() == "stopped"
+    assert child_stopped.read_text() == "stopped"
+
+
+def test_start_normalizes_process_creation_failure(tmp_path: Path, fake_clock: FakeClock) -> None:
+    class _FailingRunner:
+        def start(self, step: RuntimeStep) -> _Process:
+            del step
+            raise subprocess.SubprocessError("injected")
+
+    with pytest.raises(SlurmRuntimeError, match="cannot start"):
+        StepSupervisor(_FailingRunner(), clock=fake_clock).start(_step(tmp_path, "failed"))
+
+
+def _step(root: Path, step_id: str) -> RuntimeStep:
+    return RuntimeStep(
+        step_id=step_id,
+        role=RuntimeStepRole.SERVER,
+        command=("true",),
+        environment={"PATH": "/usr/bin"},
+        stdout_path=(root / f"{step_id}.out").absolute(),
+        stderr_path=(root / f"{step_id}.err").absolute(),
+    )

--- a/packages/data-designer-slurm/tests/runtime/test_supervisor.py
+++ b/packages/data-designer-slurm/tests/runtime/test_supervisor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 from slurm_test_fakes import FakeClock
 
+from data_designer.slurm.runtime import supervisor as runtime_supervisor
 from data_designer.slurm.runtime.errors import SlurmRuntimeError
 from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
 from data_designer.slurm.runtime.supervisor import StepSupervisor, SubprocessStepRunner
@@ -168,6 +169,77 @@ def test_start_normalizes_process_creation_failure(tmp_path: Path, fake_clock: F
 
     with pytest.raises(SlurmRuntimeError, match="cannot start"):
         StepSupervisor(_FailingRunner(), clock=fake_clock).start(_step(tmp_path, "failed"))
+
+
+def test_start_registers_process_before_restoring_termination_signals(
+    tmp_path: Path,
+    fake_clock: FakeClock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _Process(1)
+    installed_handlers: dict[object, object] = {}
+    supervisor: StepSupervisor
+
+    def previous_handler(signum: int, frame: object) -> None:
+        del signum, frame
+        assert len(supervisor.managed_steps) == 1
+        raise KeyboardInterrupt("deferred termination")
+
+    def fake_getsignal(selected: object) -> object:
+        del selected
+        return previous_handler
+
+    def fake_signal(selected: object, handler: object) -> object:
+        installed_handlers[selected] = handler
+        return previous_handler
+
+    class _InterruptingRunner(_Runner):
+        def start(self, step: RuntimeStep) -> _Process:
+            started = super().start(step)
+            handler = installed_handlers[runtime_supervisor.signal.SIGTERM]
+            assert callable(handler)
+            handler(runtime_supervisor.signal.SIGTERM, None)
+            return started
+
+    monkeypatch.setattr(runtime_supervisor.signal, "getsignal", fake_getsignal)
+    monkeypatch.setattr(runtime_supervisor.signal, "signal", fake_signal)
+    supervisor = StepSupervisor(_InterruptingRunner([process]), clock=fake_clock)
+
+    with pytest.raises(KeyboardInterrupt, match="deferred termination"):
+        supervisor.start(_step(tmp_path, "server"))
+
+    assert supervisor.managed_steps[0].process is process
+
+
+def test_cleanup_remains_incomplete_while_a_process_is_still_running(
+    tmp_path: Path,
+    fake_clock: FakeClock,
+) -> None:
+    class _StubbornProcess(_Process):
+        def terminate(self) -> None:
+            self.terminated += 1
+
+        def kill(self) -> None:
+            self.killed += 1
+
+        def wait(self, timeout: float | None = None) -> int:
+            del timeout
+            raise TimeoutError("still running")
+
+    process = _StubbornProcess(1)
+    supervisor = StepSupervisor(
+        _Runner([process]),
+        clock=fake_clock,
+        poll_interval_seconds=1,
+        termination_grace_seconds=1,
+    )
+    supervisor.start(_step(tmp_path, "server"))
+
+    with pytest.raises(SlurmRuntimeError, match="cleanup failed"):
+        supervisor.cleanup()
+
+    assert process.terminated == process.killed == 1
+    assert not supervisor.cleanup_complete
 
 
 def _step(root: Path, step_id: str) -> RuntimeStep:

--- a/packages/data-designer-slurm/tests/runtime/test_supervisor.py
+++ b/packages/data-designer-slurm/tests/runtime/test_supervisor.py
@@ -96,8 +96,8 @@ def test_subprocess_runner_uses_restrictive_logs_and_rejects_symlink_root(tmp_pa
         role=RuntimeStepRole.CLIENT_PREFLIGHT,
         command=(sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"),
         environment={"PATH": "/usr/bin", "LC_ALL": "C"},
-        stdout_path=attempt / "logs" / "real-step.out",
-        stderr_path=attempt / "logs" / "real-step.err",
+        stdout_path=attempt / "logs" / "execution-00000001" / "real-step.out",
+        stderr_path=attempt / "logs" / "execution-00000001" / "real-step.err",
     )
 
     process = SubprocessStepRunner().start(step)
@@ -106,18 +106,30 @@ def test_subprocess_runner_uses_restrictive_logs_and_rejects_symlink_root(tmp_pa
     assert step.stderr_path.read_text() == "err\n"
     assert step.stdout_path.stat().st_mode & 0o077 == 0
 
+    restarted = RuntimeStep(
+        step_id=step.step_id,
+        role=step.role,
+        command=step.command,
+        environment=step.environment,
+        stdout_path=attempt / "logs" / "execution-00000002" / "real-step.out",
+        stderr_path=attempt / "logs" / "execution-00000002" / "real-step.err",
+    )
+    restarted_process = SubprocessStepRunner().start(restarted)
+    assert restarted_process.wait(timeout=10) == 0
+    assert restarted.stdout_path.read_text() == "out\n"
+
     outside = tmp_path / "outside"
     outside.mkdir()
     symlink_attempt = tmp_path / "symlink-attempt"
-    symlink_attempt.mkdir()
+    symlink_attempt.mkdir(mode=0o700)
     (symlink_attempt / "logs").symlink_to(outside, target_is_directory=True)
     unsafe = RuntimeStep(
         step_id="unsafe-step",
         role=RuntimeStepRole.CLIENT,
         command=("true",),
         environment={"PATH": "/usr/bin"},
-        stdout_path=symlink_attempt / "logs" / "unsafe.out",
-        stderr_path=symlink_attempt / "logs" / "unsafe.err",
+        stdout_path=symlink_attempt / "logs" / "execution-00000001" / "unsafe.out",
+        stderr_path=symlink_attempt / "logs" / "execution-00000001" / "unsafe.err",
     )
     with pytest.raises(OSError, match="not a directory"):
         SubprocessStepRunner().start(unsafe)
@@ -147,8 +159,8 @@ def test_subprocess_cleanup_terminates_the_complete_step_process_group(tmp_path:
         role=RuntimeStepRole.SERVER,
         command=(sys.executable, "-c", parent_code),
         environment={"PATH": "/usr/bin"},
-        stdout_path=attempt / "logs" / "process-tree.out",
-        stderr_path=attempt / "logs" / "process-tree.err",
+        stdout_path=attempt / "logs" / "execution-00000001" / "process-tree.out",
+        stderr_path=attempt / "logs" / "execution-00000001" / "process-tree.err",
     )
     supervisor = StepSupervisor(
         SubprocessStepRunner(),

--- a/packages/data-designer-slurm/tests/runtime/test_supervisor.py
+++ b/packages/data-designer-slurm/tests/runtime/test_supervisor.py
@@ -6,15 +6,17 @@ from __future__ import annotations
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 from slurm_test_fakes import FakeClock
 
-from data_designer.slurm.runtime import supervisor as runtime_supervisor
+from data_designer.slurm.runtime import signals as runtime_signals
 from data_designer.slurm.runtime.errors import SlurmRuntimeError
 from data_designer.slurm.runtime.models import RuntimeStep, RuntimeStepRole
+from data_designer.slurm.runtime.signals import TerminationSignalCoordinator
 from data_designer.slurm.runtime.supervisor import StepSupervisor, SubprocessStepRunner
 
 
@@ -58,7 +60,7 @@ def test_cleanup_is_reverse_order_and_idempotent(tmp_path: Path, fake_clock: Fak
     first = _Process(1)
     second = _Process(2)
     runner = _Runner([first, second])
-    supervisor = StepSupervisor(runner, clock=fake_clock)
+    supervisor = StepSupervisor(runner, signals=TerminationSignalCoordinator(), clock=fake_clock)
     supervisor.start(_step(tmp_path, "first"))
     supervisor.start(_step(tmp_path, "second"))
 
@@ -74,7 +76,11 @@ def test_cleanup_is_reverse_order_and_idempotent(tmp_path: Path, fake_clock: Fak
 def test_wait_fails_when_required_service_exits(tmp_path: Path, fake_clock: FakeClock) -> None:
     service = _Process(1, returncode=19)
     target = _Process(2)
-    supervisor = StepSupervisor(_Runner([service, target]), clock=fake_clock)
+    supervisor = StepSupervisor(
+        _Runner([service, target]),
+        signals=TerminationSignalCoordinator(),
+        clock=fake_clock,
+    )
     managed_service = supervisor.start(_step(tmp_path, "service"))
     managed_target = supervisor.start(_step(tmp_path, "target"))
 
@@ -146,6 +152,7 @@ def test_subprocess_cleanup_terminates_the_complete_step_process_group(tmp_path:
     )
     supervisor = StepSupervisor(
         SubprocessStepRunner(),
+        signals=TerminationSignalCoordinator(),
         poll_interval_seconds=0.01,
         termination_grace_seconds=3,
     )
@@ -168,47 +175,73 @@ def test_start_normalizes_process_creation_failure(tmp_path: Path, fake_clock: F
             raise subprocess.SubprocessError("injected")
 
     with pytest.raises(SlurmRuntimeError, match="cannot start"):
-        StepSupervisor(_FailingRunner(), clock=fake_clock).start(_step(tmp_path, "failed"))
+        StepSupervisor(
+            _FailingRunner(),
+            signals=TerminationSignalCoordinator(),
+            clock=fake_clock,
+        ).start(_step(tmp_path, "failed"))
 
 
-def test_start_registers_process_before_restoring_termination_signals(
+def test_start_registers_process_before_replaying_deferred_termination(
     tmp_path: Path,
     fake_clock: FakeClock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process = _Process(1)
     installed_handlers: dict[object, object] = {}
+    signals = TerminationSignalCoordinator()
     supervisor: StepSupervisor
-
-    def previous_handler(signum: int, frame: object) -> None:
-        del signum, frame
-        assert len(supervisor.managed_steps) == 1
-        raise KeyboardInterrupt("deferred termination")
 
     def fake_getsignal(selected: object) -> object:
         del selected
-        return previous_handler
+        return runtime_signals.signal.SIG_DFL
 
     def fake_signal(selected: object, handler: object) -> object:
         installed_handlers[selected] = handler
-        return previous_handler
+        return runtime_signals.signal.SIG_DFL
+
+    def fake_kill(process_id: int, selected: object) -> None:
+        del process_id
+        assert len(supervisor.managed_steps) == 1
+        handler = installed_handlers[selected]
+        assert callable(handler)
+        handler(selected, None)
 
     class _InterruptingRunner(_Runner):
         def start(self, step: RuntimeStep) -> _Process:
             started = super().start(step)
-            handler = installed_handlers[runtime_supervisor.signal.SIGTERM]
+            handler = installed_handlers[runtime_signals.signal.SIGTERM]
             assert callable(handler)
-            handler(runtime_supervisor.signal.SIGTERM, None)
+            handler(runtime_signals.signal.SIGTERM, None)
             return started
 
-    monkeypatch.setattr(runtime_supervisor.signal, "getsignal", fake_getsignal)
-    monkeypatch.setattr(runtime_supervisor.signal, "signal", fake_signal)
-    supervisor = StepSupervisor(_InterruptingRunner([process]), clock=fake_clock)
+    monkeypatch.setattr(runtime_signals.signal, "getsignal", fake_getsignal)
+    monkeypatch.setattr(runtime_signals.signal, "signal", fake_signal)
+    monkeypatch.setattr(runtime_signals.os, "kill", fake_kill)
+    supervisor = StepSupervisor(_InterruptingRunner([process]), signals=signals, clock=fake_clock)
 
-    with pytest.raises(KeyboardInterrupt, match="deferred termination"):
+    with (
+        pytest.raises(KeyboardInterrupt),
+        signals.interrupt_on_termination(supervisor.cleanup),
+    ):
         supervisor.start(_step(tmp_path, "server"))
 
     assert supervisor.managed_steps[0].process is process
+    assert process.terminated == 1
+
+
+def test_start_can_register_from_a_worker_thread(tmp_path: Path, fake_clock: FakeClock) -> None:
+    signals = TerminationSignalCoordinator()
+    supervisor = StepSupervisor(_Runner([_Process(1)]), signals=signals, clock=fake_clock)
+
+    with (
+        signals.interrupt_on_termination(supervisor.cleanup),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        managed = executor.submit(supervisor.start, _step(tmp_path, "server")).result()
+
+    assert supervisor.managed_steps == (managed,)
+    supervisor.cleanup()
 
 
 def test_cleanup_remains_incomplete_while_a_process_is_still_running(
@@ -229,6 +262,7 @@ def test_cleanup_remains_incomplete_while_a_process_is_still_running(
     process = _StubbornProcess(1)
     supervisor = StepSupervisor(
         _Runner([process]),
+        signals=TerminationSignalCoordinator(),
         clock=fake_clock,
         poll_interval_seconds=1,
         termination_grace_seconds=1,

--- a/packages/data-designer-slurm/tests/state/test_validation.py
+++ b/packages/data-designer-slurm/tests/state/test_validation.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TypeVar
 
@@ -304,6 +304,33 @@ def test_readiness_cannot_move_backward_or_change_backend_count() -> None:
     )
     with pytest.raises(StateContractError, match="backend count"):
         validate_readiness_transition(ready, changed_count)
+
+
+def test_readiness_can_reset_only_through_an_explicit_restart_transition() -> None:
+    ready = _load(AttemptReadiness, "single_node_readiness.json")
+    restarting_deployment = _validated_copy(
+        ready.deployments[0],
+        state=ReadinessState.RESTARTING,
+        ready_backends=0,
+        endpoint_publication=EndpointPublicationState.PENDING,
+        last_probe=None,
+    )
+    restarting = _validated_copy(
+        ready,
+        revision=ready.revision + 1,
+        updated_at=ready.updated_at + timedelta(seconds=1),
+        state=ReadinessState.RESTARTING,
+        deployments=(restarting_deployment,),
+    )
+
+    assert validate_readiness_transition(ready, restarting) is restarting
+
+    starting = _validated_copy(restarting_deployment, state=ReadinessState.STARTING)
+    with pytest.raises(StateContractError, match="cannot move"):
+        validate_readiness_transition(
+            ready,
+            _validated_copy(restarting, state=ReadinessState.STARTING, deployments=(starting,)),
+        )
 
     stopped_deployment = _validated_copy(
         ready.deployments[0],


### PR DESCRIPTION
## Summary

Adds the one-node allocation-local runtime for resolved Slurm plans. It verifies persisted launch intent, launches server/endpoint/client steps, publishes monotonic state, proxies model traffic, and owns complete cleanup through focused runtime collaborators.

## Related Issue

Part of #868 (868#2).

## Merge Order and Dependencies

- The #908 state-writer prerequisite has merged into `feat/slurm-execution`. This branch is rebased directly onto that merged base.
- The client step targets the worker owned by #876. A real allocation E2E remains blocked until that worker is available in the client image.

## Changes

### Added

- A deterministic, content-addressed runtime bundle with restrictive atomic publication.
- One-node allocation preflight for scheduler identity, GPU shape, attempt ownership, artifact digests, writable mounts, and ports.
- Shell-free `srun` construction, process-group supervision, monotonic state publication, and a bounded loopback least-connections proxy.
- An entrypoint-owned `TerminationSignalCoordinator` for handler installation, spawn deferral, cleanup blocking, and deferred delivery.
- Explicit persisted `RESTARTING` readiness and execution-scoped restrictive log directories keyed by the restart revision.

### Changed

- Decomposed controller, supervisor, log ownership, step construction, record publication, and entrypoint workflows into short, single-purpose helpers.
- Bundled the complete `data_designer.slurm` package in a deterministic source manifest and import-checked every manifested module after extraction.
- Reused the public plan/state validation boundary for runtime completion and immutable winner finalization.
- Made the supervisor the sole owner of child-process cleanup and required its signal coordinator explicitly.
- Extracted runtime-archive publication behind a focused collaborator with concurrency-safe recovery.

### Fixed

- Resumed requeued `RUNNING` attempts through an explicit restart epoch while preserving monotonic readiness revisions.
- Reset stale `READY`/`PUBLISHED` state before restart preflight so observers do not see unavailable services as ready.
- Prevented requeues from colliding with fixed `O_EXCL` log filenames by isolating every execution's logs.
- Bound each server step with one Slurm `mask_gpu` covering its assigned GPUs without manually forwarding `CUDA_VISIBLE_DEVICES`.
- Tried each eligible proxy backend at most once and passed the final 429/`Retry-After` response to the caller.
- Deferred termination across child spawn/registration without calling main-thread-only signal APIs from the supervisor.
- Published `STOPPED` only after every managed process was confirmed exited.
- Preserved `CLIENT_FAILED` classification for partial or failed client results before candidate-manifest loading.
- Removed the compute-node runtime's dependency on an ambient `data-designer-slurm` installation.

## Attention Areas

> Reviewers: Please pay special attention to:

- `runtime/controller.py` — lifecycle ordering, explicit restart publication, and terminal-state publication.
- `runtime/logs.py` — execution-scoped path binding and restrictive descriptor-safe creation.
- `runtime/signals.py` — centralized signal ownership and deferred delivery.
- `runtime/supervisor.py` — process ownership and cleanup confirmation.
- `runtime/bundle.py` — deterministic complete-package source packaging.
- `integration.py` — shared plan-aware candidate validation.

## Testing

- [x] `make check-slurm`
- [x] `make test-slurm` — 1,183 passed after rebasing onto merged #908
- [x] `make test-slurm-wheel-install` — CLI overhead -0.001s
- [x] Focused bundle, supervisor, controller, restart-readiness, and integration regressions
- [ ] Allocation E2E — blocked on #876 and access to a Slurm allocation

## Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs: N/A — this implements the existing #868 runtime lane

---
*Description updated with AI*
