### PR TITLE
feat: add allocation-local Slurm client worker

### DIFF
--- a/packages/data-designer-slurm/src/data_designer/slurm/client/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/__init__.py
@@ -5,6 +5,26 @@
 
 from __future__ import annotations
 
-from data_designer.slurm.client.records import ClientOutcome, ClientResult
+from data_designer.slurm.client.records import (
+    ClientEnvironmentManifest,
+    ClientEnvironmentOutcome,
+    ClientErrorCode,
+    ClientInstallerOutcome,
+    ClientOutcome,
+    ClientPluginEntryPoint,
+    ClientProgress,
+    ClientProgressPhase,
+    ClientResult,
+)
 
-__all__ = ["ClientOutcome", "ClientResult"]
+__all__ = [
+    "ClientEnvironmentManifest",
+    "ClientEnvironmentOutcome",
+    "ClientErrorCode",
+    "ClientInstallerOutcome",
+    "ClientOutcome",
+    "ClientPluginEntryPoint",
+    "ClientProgress",
+    "ClientProgressPhase",
+    "ClientResult",
+]

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/environment.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/environment.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from packaging.tags import interpreter_name, interpreter_version
+from packaging.utils import canonicalize_name, parse_wheel_filename
+
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.filesystem import compute_file_sha256, ensure_private_directory, read_regular_bytes
+from data_designer.slurm.client.records import ClientErrorCode, ClientInstallerOutcome
+from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.contracts import ArtifactReference
+
+DistributionInventory = Callable[[Path | None], tuple[InstalledDistribution, ...]]
+CommandRunner = Callable[[tuple[str, ...]], None]
+
+
+@dataclass(frozen=True)
+class PreparedClientEnvironment:
+    run_id: str
+    shard_id: str
+    attempt_id: str
+    attempt_dir: Path
+    overlay_path: Path
+    dependency_lock: ArtifactReference
+    client_image_sha256: str
+    python_abi: str
+    installer_outcome: ClientInstallerOutcome
+    installed_distributions: tuple[InstalledDistribution, ...]
+
+
+class ClientEnvironmentBuilder:
+    """Prepare one immutable attempt-local package environment."""
+
+    def __init__(
+        self,
+        *,
+        inventory: DistributionInventory | None = None,
+        command_runner: CommandRunner | None = None,
+    ) -> None:
+        self._inventory = inventory or inspect_distributions
+        self._command_runner = command_runner or _run_installer
+
+    def prepare(
+        self,
+        plan_path: Path,
+        *,
+        shard_id: str,
+        attempt_id: str,
+        attempt_dir: Path,
+    ) -> PreparedClientEnvironment:
+        """Verify the plan and lock subset needed before plugin-aware imports."""
+        _validate_input_path(plan_path, "resolved plan")
+        _validate_input_path(attempt_dir, "attempt directory")
+        if not re.fullmatch(r"shard-[0-9]{5,}", shard_id):
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "shard identifier is invalid")
+        if not re.fullmatch(r"attempt-[0-9]{4,}", attempt_id) or int(attempt_id.removeprefix("attempt-")) < 1:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "attempt identifier is invalid")
+        plan = _load_json_object(plan_path, ClientErrorCode.INVALID_INPUT)
+        run_id = _require_string(plan, "run_id")
+        run_root = plan_path.parent
+        if plan_path.name != "resolved-plan.json" or run_root.name != run_id or run_root.parent.name != "runs":
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "resolved plan path is not canonical")
+        expected_attempt = run_root / "shards" / shard_id / "attempts" / attempt_id
+        if attempt_dir.as_posix() != expected_attempt.as_posix():
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "attempt directory does not match the plan")
+        ensure_private_directory(attempt_dir)
+
+        client = _require_object(plan, "client")
+        image = _require_object(client, "image")
+        image_sha256 = _require_digest(image, "sha256")
+        inspection_record = _require_object(image, "inspection")
+        inspection = _require_object(inspection_record, "inspection")
+        if inspection.get("kind") != "client":
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "resolved client image inspection is invalid")
+        python_abi = _require_string(inspection, "python_abi")
+        if python_abi != f"{interpreter_name()}{interpreter_version()}":
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "client Python ABI differs from the plan")
+        installer_path = Path(_require_string(inspection, "installer_path"))
+        if not installer_path.is_absolute() or installer_path.as_posix() == "/":
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client installer path is invalid")
+
+        lock_reference = _artifact_reference(_require_object(client, "dependency_lock"))
+        if Path(lock_reference.path).as_posix() != (run_root / "dependency-lock.json").as_posix():
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency lock path is not canonical")
+        lock_bytes = read_regular_bytes(
+            Path(lock_reference.path), missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING
+        )
+        if _sha256_bytes(lock_bytes) != lock_reference.sha256:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_DIGEST_MISMATCH, "dependency lock digest differs")
+        lock = _parse_json_bytes(lock_bytes, ClientErrorCode.DEPENDENCY_CONFLICT)
+        if _require_digest(lock, "client_image_sha256") != image_sha256:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency lock targets another image")
+        if _require_string(lock, "python_abi") != python_abi:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency lock targets another Python ABI")
+
+        expected_image = _parse_distributions(lock.get("image_distributions"))
+        inspected_image = _parse_distributions(inspection.get("distributions"))
+        try:
+            actual_image = self._inventory(None)
+        except ClientWorkerError:
+            raise
+        except Exception as error:
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_CONFLICT, "client image inventory cannot be verified"
+            ) from error
+        if expected_image != inspected_image or actual_image != expected_image:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "client image inventory differs from the lock")
+
+        source = lock.get("source")
+        if source is not None:
+            source_reference = _artifact_reference(_as_object(source))
+            _verify_input_artifact(source_reference, run_root / "inputs")
+
+        overlay_packages = _as_object_list(lock.get("overlay_packages"))
+        expected_overlay, wheels = _verify_wheels(overlay_packages, run_root / "dependencies", expected_image)
+        overlay_path = attempt_dir / "client-env" / "site-packages"
+        installer_outcome = self._install_overlay(installer_path, wheels, expected_overlay, overlay_path)
+        installed = tuple(sorted((*expected_image, *expected_overlay), key=lambda item: item.name))
+        return PreparedClientEnvironment(
+            run_id=run_id,
+            shard_id=shard_id,
+            attempt_id=attempt_id,
+            attempt_dir=attempt_dir,
+            overlay_path=overlay_path,
+            dependency_lock=lock_reference,
+            client_image_sha256=image_sha256,
+            python_abi=python_abi,
+            installer_outcome=installer_outcome,
+            installed_distributions=installed,
+        )
+
+    def _install_overlay(
+        self,
+        installer_path: Path,
+        wheels: tuple[Path, ...],
+        expected: tuple[InstalledDistribution, ...],
+        target: Path,
+    ) -> ClientInstallerOutcome:
+        ensure_private_directory(target)
+        existing = self._inventory(target)
+        if existing == expected and any(target.iterdir()):
+            return ClientInstallerOutcome.REUSED
+        if any(target.iterdir()):
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "attempt overlay contains unexpected files")
+        if not wheels:
+            return ClientInstallerOutcome.NOT_REQUIRED
+        try:
+            self._command_runner(
+                (
+                    installer_path.as_posix(),
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-deps",
+                    "--no-index",
+                    "--target",
+                    target.as_posix(),
+                    *(wheel.as_posix() for wheel in wheels),
+                )
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_INSTALL_FAILED, "client dependency installation failed"
+            ) from error
+        if self._inventory(target) != expected:
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_INSTALL_FAILED, "installed client dependencies differ from the lock"
+            )
+        return ClientInstallerOutcome.INSTALLED
+
+
+def inspect_distributions(path: Path | None) -> tuple[InstalledDistribution, ...]:
+    """Return an exact immutable distribution inventory."""
+    distributions = (
+        importlib.metadata.distributions() if path is None else importlib.metadata.distributions(path=[path.as_posix()])
+    )
+    installed: list[InstalledDistribution] = []
+    names: set[str] = set()
+    for distribution in distributions:
+        name = canonicalize_name(distribution.metadata["Name"] or "")
+        version = distribution.version
+        if not name or not version or name in names:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "installed distribution inventory is invalid")
+        direct_url = distribution.read_text("direct_url.json")
+        if direct_url is not None and _is_mutable_direct_url(direct_url):
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_CONFLICT, "mutable installed distributions are forbidden"
+            )
+        names.add(name)
+        installed.append(InstalledDistribution(name=name, version=version))
+    return tuple(sorted(installed, key=lambda item: item.name))
+
+
+def activate_environment(prepared: PreparedClientEnvironment) -> None:
+    """Activate one verified overlay and isolate Data Designer attempt state."""
+    home = prepared.attempt_dir / "data-designer-home"
+    cache = prepared.attempt_dir / "cache"
+    ensure_private_directory(home)
+    ensure_private_directory(cache)
+    os.environ["DATA_DESIGNER_HOME"] = home.as_posix()
+    os.environ["XDG_CACHE_HOME"] = cache.as_posix()
+    os.environ["PYTHONNOUSERSITE"] = "1"
+    os.environ["DISABLE_DATA_DESIGNER_PLUGINS"] = "false"
+    if prepared.overlay_path.as_posix() not in sys.path:
+        sys.path.append(prepared.overlay_path.as_posix())
+    importlib.invalidate_caches()
+
+
+def _validate_input_path(path: Path, label: str) -> None:
+    if not path.is_absolute() or path != Path(os.path.normpath(path.as_posix())):
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, f"{label} path is not canonical")
+
+
+def _run_installer(command: tuple[str, ...]) -> None:
+    subprocess.run(command, check=True, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _verify_wheels(
+    packages: list[dict[str, object]],
+    dependencies_root: Path,
+    image_distributions: tuple[InstalledDistribution, ...],
+) -> tuple[tuple[InstalledDistribution, ...], tuple[Path, ...]]:
+    expected: list[InstalledDistribution] = []
+    wheels: list[Path] = []
+    image_names = {item.name for item in image_distributions}
+    for package in packages:
+        name = canonicalize_name(_require_string(package, "name"))
+        version = _require_string(package, "version")
+        if name in image_names or name in {item.name for item in expected}:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency distributions overlap")
+        artifact = _artifact_reference(_require_object(package, "artifact"))
+        wheel = Path(artifact.path)
+        try:
+            wheel.relative_to(dependencies_root)
+        except ValueError as error:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency wheel path is not canonical") from error
+        if wheel.parent != dependencies_root or wheel.suffix != ".whl":
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency wheel path is not canonical")
+        if compute_file_sha256(wheel, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING) != artifact.sha256:
+            raise ClientWorkerError(ClientErrorCode.DEPENDENCY_DIGEST_MISMATCH, "dependency wheel digest differs")
+        try:
+            wheel_name, wheel_version, _, _ = parse_wheel_filename(wheel.name)
+        except ValueError as error:
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_CONFLICT, "dependency artifact is not a valid wheel"
+            ) from error
+        if canonicalize_name(wheel_name) != name or str(wheel_version) != version:
+            raise ClientWorkerError(
+                ClientErrorCode.DEPENDENCY_CONFLICT, "dependency wheel identity differs from the lock"
+            )
+        expected.append(InstalledDistribution(name=name, version=version))
+        wheels.append(wheel)
+    sorted_pairs = sorted(zip(expected, wheels, strict=True), key=lambda pair: pair[0].name)
+    if tuple(item.name for item in expected) != tuple(pair[0].name for pair in sorted_pairs):
+        raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency overlay is not sorted")
+    return tuple(pair[0] for pair in sorted_pairs), tuple(pair[1] for pair in sorted_pairs)
+
+
+def _verify_input_artifact(reference: ArtifactReference, root: Path) -> None:
+    path = Path(reference.path)
+    try:
+        path.relative_to(root)
+    except ValueError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency source path is not canonical") from error
+    if path.parent != root or path.suffix != ".json":
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency source path is not canonical")
+    if compute_file_sha256(path, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING) != reference.sha256:
+        raise ClientWorkerError(ClientErrorCode.DEPENDENCY_DIGEST_MISMATCH, "dependency source digest differs")
+
+
+def _parse_distributions(value: object) -> tuple[InstalledDistribution, ...]:
+    parsed = tuple(
+        InstalledDistribution(
+            name=canonicalize_name(_require_string(item, "name")), version=_require_string(item, "version")
+        )
+        for item in _as_object_list(value)
+    )
+    names = tuple(item.name for item in parsed)
+    if names != tuple(sorted(names)) or len(names) != len(set(names)):
+        raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency inventory is not sorted and unique")
+    return parsed
+
+
+def _load_json_object(path: Path, code: ClientErrorCode) -> dict[str, object]:
+    return _parse_json_bytes(read_regular_bytes(path, missing_code=code), code)
+
+
+def _parse_json_bytes(value: bytes, code: ClientErrorCode) -> dict[str, object]:
+    try:
+        return _as_object(json.loads(value))
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as error:
+        raise ClientWorkerError(code, "client JSON artifact is invalid") from error
+
+
+def _as_object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client JSON object is invalid")
+    return cast(dict[str, object], value)
+
+
+def _as_object_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency package list is invalid")
+    return [_as_object(item) for item in value]
+
+
+def _require_object(value: dict[str, object], key: str) -> dict[str, object]:
+    try:
+        return _as_object(value[key])
+    except KeyError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "required client plan field is missing") from error
+
+
+def _require_string(value: dict[str, object], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item or any(ord(character) < 32 for character in item):
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "required client string field is invalid")
+    return item
+
+
+def _require_digest(value: dict[str, object], key: str) -> str:
+    digest = _require_string(value, key)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "required client digest is invalid")
+    return digest
+
+
+def _artifact_reference(value: dict[str, object]) -> ArtifactReference:
+    try:
+        return ArtifactReference(path=_require_string(value, "path"), sha256=_require_digest(value, "sha256"))
+    except ValueError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client artifact reference is invalid") from error
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _is_mutable_direct_url(value: str) -> bool:
+    try:
+        direct_url = _as_object(json.loads(value))
+    except (json.JSONDecodeError, TypeError):
+        return True
+    if "dir_info" in direct_url or "vcs_info" in direct_url:
+        return True
+    archive_info = direct_url.get("archive_info")
+    if archive_info is None:
+        return True
+    if not isinstance(archive_info, dict):
+        return True
+    hashes = archive_info.get("hashes")
+    return not isinstance(hashes, dict) or not isinstance(hashes.get("sha256"), str)

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/environment.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/environment.py
@@ -21,8 +21,7 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 from data_designer.slurm.client.errors import ClientWorkerError
 from data_designer.slurm.client.filesystem import compute_file_sha256, ensure_private_directory, read_regular_bytes
 from data_designer.slurm.client.records import ClientErrorCode, ClientInstallerOutcome
-from data_designer.slurm.config.images import InstalledDistribution
-from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.contracts import ArtifactReference, InstalledDistribution
 
 DistributionInventory = Callable[[Path | None], tuple[InstalledDistribution, ...]]
 CommandRunner = Callable[[tuple[str, ...]], None]
@@ -40,6 +39,26 @@ class PreparedClientEnvironment:
     python_abi: str
     installer_outcome: ClientInstallerOutcome
     installed_distributions: tuple[InstalledDistribution, ...]
+
+
+@dataclass(frozen=True)
+class _BootstrapInputs:
+    run_id: str
+    run_root: Path
+    shard_id: str
+    attempt_id: str
+    attempt_dir: Path
+    client_image_sha256: str
+    python_abi: str
+    installer_path: Path
+    inspection: dict[str, object]
+    dependency_lock: ArtifactReference
+
+
+@dataclass(frozen=True)
+class _VerifiedDependencies:
+    image_distributions: tuple[InstalledDistribution, ...]
+    overlay_packages: tuple[dict[str, object], ...]
 
 
 class ClientEnvironmentBuilder:
@@ -63,6 +82,35 @@ class ClientEnvironmentBuilder:
         attempt_dir: Path,
     ) -> PreparedClientEnvironment:
         """Verify the plan and lock subset needed before plugin-aware imports."""
+        inputs = self._load_bootstrap_inputs(
+            plan_path,
+            shard_id=shard_id,
+            attempt_id=attempt_id,
+            attempt_dir=attempt_dir,
+        )
+        dependencies = self._verify_dependency_lock(inputs)
+        overlay_path, installer_outcome, installed = self._prepare_overlay(inputs, dependencies)
+        return PreparedClientEnvironment(
+            run_id=inputs.run_id,
+            shard_id=inputs.shard_id,
+            attempt_id=inputs.attempt_id,
+            attempt_dir=inputs.attempt_dir,
+            overlay_path=overlay_path,
+            dependency_lock=inputs.dependency_lock,
+            client_image_sha256=inputs.client_image_sha256,
+            python_abi=inputs.python_abi,
+            installer_outcome=installer_outcome,
+            installed_distributions=installed,
+        )
+
+    @staticmethod
+    def _load_bootstrap_inputs(
+        plan_path: Path,
+        *,
+        shard_id: str,
+        attempt_id: str,
+        attempt_dir: Path,
+    ) -> _BootstrapInputs:
         _validate_input_path(plan_path, "resolved plan")
         _validate_input_path(attempt_dir, "attempt directory")
         if not re.fullmatch(r"shard-[0-9]{5,}", shard_id):
@@ -96,19 +144,33 @@ class ClientEnvironmentBuilder:
         lock_reference = _artifact_reference(_require_object(client, "dependency_lock"))
         if Path(lock_reference.path).as_posix() != (run_root / "dependency-lock.json").as_posix():
             raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "dependency lock path is not canonical")
-        lock_bytes = read_regular_bytes(
-            Path(lock_reference.path), missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING
+        return _BootstrapInputs(
+            run_id=run_id,
+            run_root=run_root,
+            shard_id=shard_id,
+            attempt_id=attempt_id,
+            attempt_dir=attempt_dir,
+            client_image_sha256=image_sha256,
+            python_abi=python_abi,
+            installer_path=installer_path,
+            inspection=inspection,
+            dependency_lock=lock_reference,
         )
-        if _sha256_bytes(lock_bytes) != lock_reference.sha256:
+
+    def _verify_dependency_lock(self, inputs: _BootstrapInputs) -> _VerifiedDependencies:
+        lock_bytes = read_regular_bytes(
+            Path(inputs.dependency_lock.path), missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING
+        )
+        if _sha256_bytes(lock_bytes) != inputs.dependency_lock.sha256:
             raise ClientWorkerError(ClientErrorCode.DEPENDENCY_DIGEST_MISMATCH, "dependency lock digest differs")
         lock = _parse_json_bytes(lock_bytes, ClientErrorCode.DEPENDENCY_CONFLICT)
-        if _require_digest(lock, "client_image_sha256") != image_sha256:
+        if _require_digest(lock, "client_image_sha256") != inputs.client_image_sha256:
             raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency lock targets another image")
-        if _require_string(lock, "python_abi") != python_abi:
+        if _require_string(lock, "python_abi") != inputs.python_abi:
             raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "dependency lock targets another Python ABI")
 
         expected_image = _parse_distributions(lock.get("image_distributions"))
-        inspected_image = _parse_distributions(inspection.get("distributions"))
+        inspected_image = _parse_distributions(inputs.inspection.get("distributions"))
         try:
             actual_image = self._inventory(None)
         except ClientWorkerError:
@@ -123,25 +185,26 @@ class ClientEnvironmentBuilder:
         source = lock.get("source")
         if source is not None:
             source_reference = _artifact_reference(_as_object(source))
-            _verify_input_artifact(source_reference, run_root / "inputs")
-
-        overlay_packages = _as_object_list(lock.get("overlay_packages"))
-        expected_overlay, wheels = _verify_wheels(overlay_packages, run_root / "dependencies", expected_image)
-        overlay_path = attempt_dir / "client-env" / "site-packages"
-        installer_outcome = self._install_overlay(installer_path, wheels, expected_overlay, overlay_path)
-        installed = tuple(sorted((*expected_image, *expected_overlay), key=lambda item: item.name))
-        return PreparedClientEnvironment(
-            run_id=run_id,
-            shard_id=shard_id,
-            attempt_id=attempt_id,
-            attempt_dir=attempt_dir,
-            overlay_path=overlay_path,
-            dependency_lock=lock_reference,
-            client_image_sha256=image_sha256,
-            python_abi=python_abi,
-            installer_outcome=installer_outcome,
-            installed_distributions=installed,
+            _verify_input_artifact(source_reference, inputs.run_root / "inputs")
+        return _VerifiedDependencies(
+            image_distributions=expected_image,
+            overlay_packages=tuple(_as_object_list(lock.get("overlay_packages"))),
         )
+
+    def _prepare_overlay(
+        self,
+        inputs: _BootstrapInputs,
+        dependencies: _VerifiedDependencies,
+    ) -> tuple[Path, ClientInstallerOutcome, tuple[InstalledDistribution, ...]]:
+        expected_overlay, wheels = _verify_wheels(
+            dependencies.overlay_packages,
+            inputs.run_root / "dependencies",
+            dependencies.image_distributions,
+        )
+        overlay_path = inputs.attempt_dir / "client-env" / "site-packages"
+        outcome = self._install_overlay(inputs.installer_path, wheels, expected_overlay, overlay_path)
+        installed = tuple(sorted((*dependencies.image_distributions, *expected_overlay), key=lambda item: item.name))
+        return overlay_path, outcome, installed
 
     def _install_overlay(
         self,
@@ -229,7 +292,7 @@ def _run_installer(command: tuple[str, ...]) -> None:
 
 
 def _verify_wheels(
-    packages: list[dict[str, object]],
+    packages: tuple[dict[str, object], ...],
     dependencies_root: Path,
     image_distributions: tuple[InstalledDistribution, ...],
 ) -> tuple[tuple[InstalledDistribution, ...], tuple[Path, ...]]:

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/errors.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/errors.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.slurm.client.records import ClientErrorCode
+
+
+class ClientWorkerError(RuntimeError):
+    """Failure safe to classify at the allocation boundary."""
+
+    def __init__(self, code: ClientErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.redacted_message = message

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
@@ -80,6 +80,72 @@ class _ExecutionContext:
     dataset_path: Path
 
 
+@dataclass(frozen=True)
+class _ValidatedCreation:
+    requested_records: int
+    actual_records: int
+    dataset_path: Path
+    expected_path: Path
+    effective_resume: ResumeMode
+    early_shutdown: bool
+
+
+class _ProgressWriter:
+    def __init__(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        clock: Clock,
+        *,
+        revision: int = 0,
+    ) -> None:
+        self._context = context
+        self._prepared = prepared
+        self._clock = clock
+        self._revision = revision
+
+    def required(
+        self,
+        phase: ClientProgressPhase,
+        *,
+        completed_records: int | None = None,
+        error_code: ClientErrorCode | None = None,
+    ) -> None:
+        self._revision += 1
+        progress = ClientProgress(
+            schema_version=1,
+            run_id=self._context.plan.run_id,
+            shard_id=self._context.shard.shard_id,
+            attempt_id=self._prepared.attempt_id,
+            revision=self._revision,
+            updated_at=self._clock(),
+            phase=phase,
+            requested_records=self._context.shard.requested_records,
+            completed_records=completed_records,
+            error_code=error_code,
+        )
+        replace_private_text(self._prepared.attempt_dir / "client-progress.json", progress.serialize_json())
+
+    def best_effort(
+        self,
+        phase: ClientProgressPhase,
+        *,
+        completed_records: int | None = None,
+        error_code: ClientErrorCode | None = None,
+    ) -> None:
+        try:
+            self.required(phase, completed_records=completed_records, error_code=error_code)
+        except Exception:
+            logger.warning("Could not persist client %s progress", phase.value)
+
+    def on_batch_complete(self, path: Path) -> None:
+        generated_records = sum(lazy.pq.read_metadata(item).num_rows for item in path.parent.glob("*.parquet"))
+        self.best_effort(
+            ClientProgressPhase.GENERATING,
+            completed_records=min(generated_records, self._context.shard.requested_records),
+        )
+
+
 class ClientWorker:
     """Validate and execute one planned Data Designer shard."""
 
@@ -103,22 +169,14 @@ class ClientWorker:
         """Validate packages, plugins, assets, and config without generation."""
         try:
             context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
-            self._write_progress(context, prepared, 1, ClientProgressPhase.VALIDATING_PLUGINS)
-            self._write_progress(context, prepared, 2, ClientProgressPhase.VALIDATING_CONFIG)
+            progress = _ProgressWriter(context, prepared, self._clock)
+            progress.required(ClientProgressPhase.VALIDATING_PLUGINS)
+            progress.required(ClientProgressPhase.VALIDATING_CONFIG)
             context.designer.validate(context.builder)
-            manifest = ClientEnvironmentManifest(
-                schema_version=1,
-                run_id=context.plan.run_id,
-                shard_id=context.shard.shard_id,
-                attempt_id=prepared.attempt_id,
+            manifest = ClientEnvironmentManifest.from_prepared(
+                prepared,
                 created_at=self._clock(),
                 outcome=ClientEnvironmentOutcome.READY,
-                dependency_lock=prepared.dependency_lock,
-                client_image_sha256=prepared.client_image_sha256,
-                python_abi=prepared.python_abi,
-                overlay_path=prepared.overlay_path.as_posix(),
-                installer_outcome=prepared.installer_outcome,
-                installed_distributions=prepared.installed_distributions,
                 plugins=plugins,
             )
             replace_private_text(prepared.attempt_dir / "client-environment.json", manifest.serialize_json())
@@ -141,90 +199,39 @@ class ClientWorker:
     ) -> ClientResult:
         """Invoke the public Data Designer generation contract and persist its result."""
         context: _ExecutionContext | None = None
-        revision = 2
+        progress: _ProgressWriter | None = None
         try:
             context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
-            active_context = context
+            progress = _ProgressWriter(context, prepared, self._clock, revision=2)
             self._validate_environment_manifest(context, prepared, plugins)
-            revision = 3
-            self._write_progress(context, prepared, revision, ClientProgressPhase.GENERATING, completed_records=0)
-            if context.dataset_path.parent == prepared.attempt_dir:
-                ensure_private_directory(context.dataset_path.parent)
-            elif not context.dataset_path.parent.is_dir():
-                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "shard dataset workspace is unavailable")
-            if context.requested_resume is not ResumeMode.NEVER:
-                ensure_private_directory(context.dataset_path)
-            if context.requested_resume is ResumeMode.NEVER and context.dataset_path.exists():
-                if not context.dataset_path.is_dir() or any(context.dataset_path.iterdir()):
-                    raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "attempt dataset workspace is not empty")
-
-            generated_records = 0
-
-            def on_batch_complete(path: Path) -> None:
-                nonlocal generated_records, revision
-                generated_records = sum(lazy.pq.read_metadata(item).num_rows for item in path.parent.glob("*.parquet"))
-                revision += 1
-                try:
-                    self._write_progress(
-                        active_context,
-                        prepared,
-                        revision,
-                        ClientProgressPhase.GENERATING,
-                        completed_records=min(generated_records, active_context.shard.requested_records),
-                    )
-                except Exception:
-                    logger.warning("Could not persist client generation progress")
-
-            results = cast(
-                CreationResults,
-                context.designer.create(
-                    context.builder,
-                    num_records=context.shard.requested_records,
-                    dataset_name=context.dataset_path.name,
-                    resume=context.requested_resume,
-                    artifact_path=context.dataset_path.parent,
-                    on_batch_complete=on_batch_complete,
-                ),
-            )
-            revision += 1
-            self._write_progress(
-                context,
-                prepared,
-                revision,
-                ClientProgressPhase.FINALIZING,
-                completed_records=results.actual_num_records,
-            )
+            progress.required(ClientProgressPhase.GENERATING, completed_records=0)
+            self._prepare_dataset_workspace(context, prepared)
+            results = self._generate_dataset(context, progress)
+            progress.required(ClientProgressPhase.FINALIZING, completed_records=results.actual_num_records)
             try:
                 result = self._finalize(context, prepared, results)
             except ClientWorkerError:
                 raise
             except Exception as error:
                 raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer output is invalid") from error
-            revision += 1
-            try:
-                self._write_progress(
-                    context,
-                    prepared,
-                    revision,
-                    ClientProgressPhase.COMPLETE,
-                    completed_records=cast(int, result.actual_records),
-                )
-            except Exception:
-                logger.warning("Could not persist client completion progress")
+            progress.best_effort(
+                ClientProgressPhase.COMPLETE,
+                completed_records=cast(int, result.actual_records),
+            )
             return result
         except ClientWorkerError as error:
             if context is not None:
-                self._write_failure(context, prepared, error, revision=revision + 1)
+                self._write_failure(context, prepared, error, progress=progress)
             raise
         except (KeyboardInterrupt, SystemExit) as error:
             failure = ClientWorkerError(ClientErrorCode.INTERRUPTED, "Data Designer generation was interrupted")
             if context is not None:
-                self._write_failure(context, prepared, failure, revision=revision + 1)
+                self._write_failure(context, prepared, failure, progress=progress)
             raise failure from error
         except Exception as error:
             failure = ClientWorkerError(ClientErrorCode.GENERATION_FAILED, "Data Designer generation failed")
             if context is not None:
-                self._write_failure(context, prepared, failure, revision=revision + 1)
+                self._write_failure(context, prepared, failure, progress=progress)
             raise failure from error
 
     def _build_context(
@@ -264,6 +271,7 @@ class ClientWorker:
             builder_payload = self._load_builder(plan)
             builder = DataDesignerConfigBuilder.from_config(builder_payload)
             providers = self._materialize_model_endpoints(plan, builder, endpoints)
+            self._validate_model_references(builder)
             self._materialize_seed(plan, shard, builder)
             mcp_providers = self._materialize_mcp_providers(plan)
             self._validate_assets(plan)
@@ -360,6 +368,16 @@ class ClientWorker:
         return providers
 
     @staticmethod
+    def _validate_model_references(builder: DataDesignerConfigBuilder) -> None:
+        available = {config.alias for config in builder.model_configs}
+        referenced = {alias for column in builder.get_column_configs() for alias in column.get_model_aliases()}
+        referenced.update(
+            profiler.model_alias for profiler in builder.get_profilers() if hasattr(profiler, "model_alias")
+        )
+        if not referenced.issubset(available):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "builder references unavailable model aliases")
+
+    @staticmethod
     def _materialize_seed(
         plan: ResolvedSlurmRunPlan,
         shard: PlannedShard,
@@ -442,12 +460,62 @@ class ClientWorker:
             raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "resume workspace is invalid")
         return resume_path
 
+    @staticmethod
+    def _prepare_dataset_workspace(
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+    ) -> None:
+        if context.dataset_path.parent == prepared.attempt_dir:
+            ensure_private_directory(context.dataset_path.parent)
+        elif not context.dataset_path.parent.is_dir():
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "shard dataset workspace is unavailable")
+        if context.requested_resume is not ResumeMode.NEVER:
+            ensure_private_directory(context.dataset_path)
+        if context.requested_resume is ResumeMode.NEVER and context.dataset_path.exists():
+            if not context.dataset_path.is_dir() or any(context.dataset_path.iterdir()):
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "attempt dataset workspace is not empty")
+
+    @staticmethod
+    def _generate_dataset(
+        context: _ExecutionContext,
+        progress: _ProgressWriter,
+    ) -> CreationResults:
+        try:
+            return cast(
+                CreationResults,
+                context.designer.create(
+                    context.builder,
+                    num_records=context.shard.requested_records,
+                    dataset_name=context.dataset_path.name,
+                    resume=context.requested_resume,
+                    artifact_path=context.dataset_path.parent,
+                    on_batch_complete=progress.on_batch_complete,
+                ),
+            )
+        except ClientWorkerError:
+            raise
+        except (KeyboardInterrupt, SystemExit) as error:
+            raise ClientWorkerError(ClientErrorCode.INTERRUPTED, "Data Designer generation was interrupted") from error
+        except Exception as error:
+            raise ClientWorkerError(ClientErrorCode.GENERATION_FAILED, "Data Designer generation failed") from error
+
     def _finalize(
         self,
         context: _ExecutionContext,
         prepared: PreparedClientEnvironment,
         results: CreationResults,
     ) -> ClientResult:
+        creation = self._validate_creation_result(context, prepared, results)
+        dataset_path, exported_path = self._place_dataset(creation, results)
+        candidate = self._build_candidate_manifest(context, prepared, creation, dataset_path, exported_path)
+        return self._publish_success(context, prepared, creation, candidate)
+
+    @staticmethod
+    def _validate_creation_result(
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        results: CreationResults,
+    ) -> _ValidatedCreation:
         requested = context.shard.requested_records
         actual = results.actual_num_records
         if results.requested_num_records != requested or actual > requested:
@@ -478,23 +546,47 @@ class ClientWorker:
             )
         ):
             raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
-        exported_path: Path | None = None
-        if actual:
-            exported_path = results.export(dataset_path / "part-00000.parquet", format="parquet")
-        if dataset_path != expected_path:
-            ensure_private_directory(expected_path.parent)
-            dataset_path.rename(expected_path)
-            if exported_path is not None:
-                exported_path = expected_path / exported_path.relative_to(dataset_path)
-            dataset_path = expected_path
-        if dataset_path != expected_path:
-            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
+        return _ValidatedCreation(
+            requested_records=requested,
+            actual_records=actual,
+            dataset_path=dataset_path,
+            expected_path=expected_path,
+            effective_resume=effective_resume,
+            early_shutdown=results.early_shutdown,
+        )
 
+    @staticmethod
+    def _place_dataset(
+        creation: _ValidatedCreation,
+        results: CreationResults,
+    ) -> tuple[Path, Path | None]:
+        dataset_path = creation.dataset_path
+        exported_path: Path | None = None
+        if creation.actual_records:
+            exported_path = results.export(dataset_path / "part-00000.parquet", format="parquet")
+        if dataset_path != creation.expected_path:
+            ensure_private_directory(creation.expected_path.parent)
+            dataset_path.rename(creation.expected_path)
+            if exported_path is not None:
+                exported_path = creation.expected_path / exported_path.relative_to(dataset_path)
+            dataset_path = creation.expected_path
+        if dataset_path != creation.expected_path:
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
+        return dataset_path, exported_path
+
+    def _build_candidate_manifest(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        creation: _ValidatedCreation,
+        dataset_path: Path,
+        exported_path: Path | None,
+    ) -> CandidateOutputManifest:
         files: tuple[CandidateOutputFile, ...] = ()
         schema_digest = context.plan.builder.content_sha256
         if exported_path is not None:
             metadata = lazy.pq.read_metadata(exported_path)
-            if metadata.num_rows != actual:
+            if metadata.num_rows != creation.actual_records:
                 raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "exported record count differs")
             schema_digest = hashlib.sha256(lazy.pq.read_schema(exported_path).serialize().to_pybytes()).hexdigest()
             files = (
@@ -502,7 +594,7 @@ class ClientWorker:
                     relative_path=exported_path.relative_to(dataset_path).as_posix(),
                     sha256=compute_file_sha256(exported_path, missing_code=ClientErrorCode.OUTPUT_INVALID),
                     byte_size=exported_path.stat().st_size,
-                    record_count=actual,
+                    record_count=creation.actual_records,
                 ),
             )
         created_at = self._clock()
@@ -518,7 +610,7 @@ class ClientWorker:
                 "shard_id": context.shard.shard_id,
             }
         )
-        candidate = CandidateOutputManifest(
+        return CandidateOutputManifest(
             schema_version=1,
             run_id=context.plan.run_id,
             shard_id=context.shard.shard_id,
@@ -526,19 +618,27 @@ class ClientWorker:
             attempt_ordinal=int(prepared.attempt_id.removeprefix("attempt-")),
             created_at=created_at,
             dataset_path=dataset_path.as_posix(),
-            requested_records=requested,
-            actual_records=actual,
+            requested_records=creation.requested_records,
+            actual_records=creation.actual_records,
             outcome=(
                 CandidateOutcome.EMPTY
-                if actual == 0
+                if creation.actual_records == 0
                 else CandidateOutcome.COMPLETE
-                if actual == requested
+                if creation.actual_records == creation.requested_records
                 else CandidateOutcome.PARTIAL
             ),
             files=files,
             dataset_schema_digest=schema_digest,
             provenance_digest=provenance_digest,
         )
+
+    def _publish_success(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        creation: _ValidatedCreation,
+        candidate: CandidateOutputManifest,
+    ) -> ClientResult:
         candidate_path = prepared.attempt_dir / "output-manifest.json"
         publish_private_text(candidate_path, candidate.serialize_json())
         result = ClientResult(
@@ -547,13 +647,17 @@ class ClientWorker:
             shard_id=context.shard.shard_id,
             attempt_id=prepared.attempt_id,
             completed_at=self._clock(),
-            requested_records=requested,
-            actual_records=actual,
-            outcome=ClientOutcome.COMPLETE if actual == requested else ClientOutcome.PARTIAL,
-            dataset_path=dataset_path.as_posix(),
-            early_shutdown=results.early_shutdown,
+            requested_records=creation.requested_records,
+            actual_records=creation.actual_records,
+            outcome=(
+                ClientOutcome.COMPLETE
+                if creation.actual_records == creation.requested_records
+                else ClientOutcome.PARTIAL
+            ),
+            dataset_path=candidate.dataset_path,
+            early_shutdown=creation.early_shutdown,
             requested_resume_mode=context.requested_resume.value,
-            effective_resume_mode=effective_resume.value,
+            effective_resume_mode=creation.effective_resume.value,
             candidate_output_manifest=ArtifactReference(
                 path=candidate_path.as_posix(), sha256=candidate.compute_sha256()
             ),
@@ -598,19 +702,10 @@ class ClientWorker:
         plugins: tuple[ClientPluginEntryPoint, ...],
         error: ClientWorkerError,
     ) -> None:
-        manifest = ClientEnvironmentManifest(
-            schema_version=1,
-            run_id=prepared.run_id,
-            shard_id=prepared.shard_id,
-            attempt_id=prepared.attempt_id,
+        manifest = ClientEnvironmentManifest.from_prepared(
+            prepared,
             created_at=self._clock(),
             outcome=ClientEnvironmentOutcome.FAILED,
-            dependency_lock=prepared.dependency_lock,
-            client_image_sha256=prepared.client_image_sha256,
-            python_abi=prepared.python_abi,
-            overlay_path=prepared.overlay_path.as_posix(),
-            installer_outcome=prepared.installer_outcome,
-            installed_distributions=prepared.installed_distributions,
             plugins=plugins,
             error_code=error.code,
             redacted_message=error.redacted_message,
@@ -620,7 +715,7 @@ class ClientWorker:
             context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
         except ClientWorkerError:
             return
-        self._write_failure(context, prepared, error, revision=3)
+        self._write_failure(context, prepared, error, progress=None)
 
     def _write_failure(
         self,
@@ -628,7 +723,7 @@ class ClientWorker:
         prepared: PreparedClientEnvironment,
         error: ClientWorkerError,
         *,
-        revision: int,
+        progress: _ProgressWriter | None,
     ) -> None:
         result = ClientResult(
             schema_version=1,
@@ -644,40 +739,8 @@ class ClientWorker:
             redacted_message=error.redacted_message,
         )
         publish_private_text(prepared.attempt_dir / "client-result.json", result.serialize_json())
-        try:
-            self._write_progress(
-                context,
-                prepared,
-                revision,
-                ClientProgressPhase.FAILED,
-                error_code=error.code,
-            )
-        except Exception:
-            logger.warning("Could not persist client failure progress")
-
-    def _write_progress(
-        self,
-        context: _ExecutionContext,
-        prepared: PreparedClientEnvironment,
-        revision: int,
-        phase: ClientProgressPhase,
-        *,
-        completed_records: int | None = None,
-        error_code: ClientErrorCode | None = None,
-    ) -> None:
-        progress = ClientProgress(
-            schema_version=1,
-            run_id=context.plan.run_id,
-            shard_id=context.shard.shard_id,
-            attempt_id=prepared.attempt_id,
-            revision=revision,
-            updated_at=self._clock(),
-            phase=phase,
-            requested_records=context.shard.requested_records,
-            completed_records=completed_records,
-            error_code=error_code,
-        )
-        replace_private_text(prepared.attempt_dir / "client-progress.json", progress.serialize_json())
+        progress = progress or _ProgressWriter(context, prepared, self._clock, revision=2)
+        progress.best_effort(ClientProgressPhase.FAILED, error_code=error.code)
 
 
 def _resolve_secret(reference: SecretRef) -> str:

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
@@ -1,0 +1,687 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, cast
+from urllib.parse import urlsplit
+
+from pydantic import ValidationError
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config import (
+    DataDesignerConfigBuilder,
+    LocalStdioMCPProvider,
+    MCPProvider,
+    ModelProvider,
+    PartitionBlock,
+    ResumeMode,
+    RunConfig,
+)
+from data_designer.interface import DataDesigner
+from data_designer.slurm.client.environment import PreparedClientEnvironment
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.filesystem import (
+    compute_file_sha256,
+    ensure_private_directory,
+    publish_private_text,
+    read_regular_bytes,
+    replace_private_text,
+)
+from data_designer.slurm.client.records import (
+    ClientEnvironmentManifest,
+    ClientEnvironmentOutcome,
+    ClientErrorCode,
+    ClientOutcome,
+    ClientPluginEntryPoint,
+    ClientProgress,
+    ClientProgressPhase,
+    ClientResult,
+)
+from data_designer.slurm.config.environment import LiteralEnvironmentBinding, SecretRef
+from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.config.run import LocalStdioMCPProviderConfig, RemoteMCPProviderConfig
+from data_designer.slurm.contracts import ArtifactReference, compute_canonical_json_sha256
+from data_designer.slurm.planning import PlannedShard, ResolvedDependencyLock, ResolvedSlurmRunPlan
+from data_designer.slurm.state import CandidateOutcome, CandidateOutputFile, CandidateOutputManifest
+
+Clock = Callable[[], datetime]
+DataDesignerFactory = Callable[..., DataDesigner]
+logger = logging.getLogger(__name__)
+
+
+class CreationResults(Protocol):
+    dataset_path: Path
+    requested_num_records: int
+    actual_num_records: int
+    early_shutdown: bool | None
+    requested_resume_mode: ResumeMode | None
+    effective_resume_mode: ResumeMode | None
+
+    def export(self, path: Path, *, format: str) -> Path:
+        """Export the generated dataset."""
+
+
+@dataclass(frozen=True)
+class _ExecutionContext:
+    plan: ResolvedSlurmRunPlan
+    shard: PlannedShard
+    builder: DataDesignerConfigBuilder
+    designer: DataDesigner
+    requested_resume: ResumeMode
+    dataset_path: Path
+
+
+class ClientWorker:
+    """Validate and execute one planned Data Designer shard."""
+
+    def __init__(
+        self,
+        *,
+        data_designer_factory: DataDesignerFactory = DataDesigner,
+        clock: Clock | None = None,
+    ) -> None:
+        self._data_designer_factory = data_designer_factory
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+
+    def preflight(
+        self,
+        plan_path: Path,
+        *,
+        prepared: PreparedClientEnvironment,
+        endpoints: Mapping[str, str],
+        plugins: tuple[ClientPluginEntryPoint, ...],
+    ) -> ClientEnvironmentManifest:
+        """Validate packages, plugins, assets, and config without generation."""
+        try:
+            context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
+            self._write_progress(context, prepared, 1, ClientProgressPhase.VALIDATING_PLUGINS)
+            self._write_progress(context, prepared, 2, ClientProgressPhase.VALIDATING_CONFIG)
+            context.designer.validate(context.builder)
+            manifest = ClientEnvironmentManifest(
+                schema_version=1,
+                run_id=context.plan.run_id,
+                shard_id=context.shard.shard_id,
+                attempt_id=prepared.attempt_id,
+                created_at=self._clock(),
+                outcome=ClientEnvironmentOutcome.READY,
+                dependency_lock=prepared.dependency_lock,
+                client_image_sha256=prepared.client_image_sha256,
+                python_abi=prepared.python_abi,
+                overlay_path=prepared.overlay_path.as_posix(),
+                installer_outcome=prepared.installer_outcome,
+                installed_distributions=prepared.installed_distributions,
+                plugins=plugins,
+            )
+            replace_private_text(prepared.attempt_dir / "client-environment.json", manifest.serialize_json())
+            return manifest
+        except ClientWorkerError as error:
+            self._write_preflight_failure(plan_path, prepared, endpoints, plugins, error)
+            raise
+        except Exception as error:
+            failure = ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "Data Designer configuration is invalid")
+            self._write_preflight_failure(plan_path, prepared, endpoints, plugins, failure)
+            raise failure from error
+
+    def run(
+        self,
+        plan_path: Path,
+        *,
+        prepared: PreparedClientEnvironment,
+        endpoints: Mapping[str, str],
+        plugins: tuple[ClientPluginEntryPoint, ...],
+    ) -> ClientResult:
+        """Invoke the public Data Designer generation contract and persist its result."""
+        context: _ExecutionContext | None = None
+        revision = 2
+        try:
+            context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
+            active_context = context
+            self._validate_environment_manifest(context, prepared, plugins)
+            revision = 3
+            self._write_progress(context, prepared, revision, ClientProgressPhase.GENERATING, completed_records=0)
+            if context.dataset_path.parent == prepared.attempt_dir:
+                ensure_private_directory(context.dataset_path.parent)
+            elif not context.dataset_path.parent.is_dir():
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "shard dataset workspace is unavailable")
+            if context.requested_resume is not ResumeMode.NEVER:
+                ensure_private_directory(context.dataset_path)
+            if context.requested_resume is ResumeMode.NEVER and context.dataset_path.exists():
+                if not context.dataset_path.is_dir() or any(context.dataset_path.iterdir()):
+                    raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "attempt dataset workspace is not empty")
+
+            generated_records = 0
+
+            def on_batch_complete(path: Path) -> None:
+                nonlocal generated_records, revision
+                generated_records = sum(lazy.pq.read_metadata(item).num_rows for item in path.parent.glob("*.parquet"))
+                revision += 1
+                try:
+                    self._write_progress(
+                        active_context,
+                        prepared,
+                        revision,
+                        ClientProgressPhase.GENERATING,
+                        completed_records=min(generated_records, active_context.shard.requested_records),
+                    )
+                except Exception:
+                    logger.warning("Could not persist client generation progress")
+
+            results = cast(
+                CreationResults,
+                context.designer.create(
+                    context.builder,
+                    num_records=context.shard.requested_records,
+                    dataset_name=context.dataset_path.name,
+                    resume=context.requested_resume,
+                    artifact_path=context.dataset_path.parent,
+                    on_batch_complete=on_batch_complete,
+                ),
+            )
+            revision += 1
+            self._write_progress(
+                context,
+                prepared,
+                revision,
+                ClientProgressPhase.FINALIZING,
+                completed_records=results.actual_num_records,
+            )
+            try:
+                result = self._finalize(context, prepared, results)
+            except ClientWorkerError:
+                raise
+            except Exception as error:
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer output is invalid") from error
+            revision += 1
+            try:
+                self._write_progress(
+                    context,
+                    prepared,
+                    revision,
+                    ClientProgressPhase.COMPLETE,
+                    completed_records=cast(int, result.actual_records),
+                )
+            except Exception:
+                logger.warning("Could not persist client completion progress")
+            return result
+        except ClientWorkerError as error:
+            if context is not None:
+                self._write_failure(context, prepared, error, revision=revision + 1)
+            raise
+        except (KeyboardInterrupt, SystemExit) as error:
+            failure = ClientWorkerError(ClientErrorCode.INTERRUPTED, "Data Designer generation was interrupted")
+            if context is not None:
+                self._write_failure(context, prepared, failure, revision=revision + 1)
+            raise failure from error
+        except Exception as error:
+            failure = ClientWorkerError(ClientErrorCode.GENERATION_FAILED, "Data Designer generation failed")
+            if context is not None:
+                self._write_failure(context, prepared, failure, revision=revision + 1)
+            raise failure from error
+
+    def _build_context(
+        self,
+        plan_path: Path,
+        *,
+        prepared: PreparedClientEnvironment,
+        endpoints: Mapping[str, str],
+    ) -> _ExecutionContext:
+        try:
+            plan = ResolvedSlurmRunPlan.model_validate_json(
+                read_regular_bytes(plan_path, missing_code=ClientErrorCode.INVALID_INPUT)
+            )
+            shard = next(item for item in plan.shards if item.shard_id == prepared.shard_id)
+            self._validate_prepared(plan, shard, prepared)
+            lock = ResolvedDependencyLock.model_validate_json(
+                read_regular_bytes(
+                    Path(plan.client.dependency_lock.path), missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING
+                )
+            )
+            if lock.compute_sha256() != plan.client.dependency_lock.sha256:
+                raise ClientWorkerError(ClientErrorCode.DEPENDENCY_DIGEST_MISMATCH, "dependency lock digest differs")
+            expected_distributions = tuple(
+                sorted(
+                    (
+                        *lock.image_distributions,
+                        *(
+                            InstalledDistribution(name=package.name, version=package.version)
+                            for package in lock.overlay_packages
+                        ),
+                    ),
+                    key=lambda item: item.name,
+                )
+            )
+            if prepared.installed_distributions != expected_distributions:
+                raise ClientWorkerError(ClientErrorCode.DEPENDENCY_CONFLICT, "client environment differs from the lock")
+            builder_payload = self._load_builder(plan)
+            builder = DataDesignerConfigBuilder.from_config(builder_payload)
+            providers = self._materialize_model_endpoints(plan, builder, endpoints)
+            self._materialize_seed(plan, shard, builder)
+            mcp_providers = self._materialize_mcp_providers(plan)
+            self._validate_assets(plan)
+            requested_resume = ResumeMode(plan.invocation.authored.resume)
+            dataset_path = self._dataset_path(shard, prepared, requested_resume)
+            designer = self._data_designer_factory(
+                artifact_path=dataset_path.parent,
+                model_providers=providers,
+                managed_assets_path=plan.invocation.effective_input_bindings.managed_assets_path,
+                mcp_providers=mcp_providers,
+                auto_configure_logging=False,
+            )
+            designer.set_run_config(RunConfig.model_validate(plan.invocation.effective_run_config))
+            return _ExecutionContext(plan, shard, builder, designer, requested_resume, dataset_path)
+        except ClientWorkerError:
+            raise
+        except (StopIteration, ValidationError, ValueError, OSError, KeyError, TypeError) as error:
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "Data Designer configuration is invalid") from error
+
+    @staticmethod
+    def _validate_prepared(
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        prepared: PreparedClientEnvironment,
+    ) -> None:
+        expected_attempt = Path(shard.resume_workspace.path).parent / "attempts" / prepared.attempt_id
+        inspection = plan.client.image.inspection_facts
+        if (
+            plan.run_id != prepared.run_id
+            or prepared.attempt_dir != expected_attempt
+            or plan.client.dependency_lock != prepared.dependency_lock
+            or plan.client.image.sha256 != prepared.client_image_sha256
+            or inspection.python_abi != prepared.python_abi
+        ):
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "prepared client environment differs from the plan")
+
+    @staticmethod
+    def _load_builder(plan: ResolvedSlurmRunPlan) -> dict[str, object]:
+        if plan.builder.inline is not None:
+            return cast(dict[str, object], plan.builder.inline)
+        assert plan.builder.source is not None
+        payload = read_regular_bytes(Path(plan.builder.source.path), missing_code=ClientErrorCode.INVALID_INPUT)
+        if hashlib.sha256(payload).hexdigest() != plan.builder.source.sha256:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "builder artifact digest differs")
+        try:
+            loaded = json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "builder artifact is invalid") from error
+        if not isinstance(loaded, dict):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "builder artifact is invalid")
+        return cast(dict[str, object], loaded)
+
+    @staticmethod
+    def _materialize_model_endpoints(
+        plan: ResolvedSlurmRunPlan,
+        builder: DataDesignerConfigBuilder,
+        endpoints: Mapping[str, str],
+    ) -> list[ModelProvider]:
+        aliases = tuple(deployment.authored.model_alias for deployment in plan.deployments)
+        if set(endpoints) != set(aliases):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "runtime endpoints do not match model aliases")
+        configs = {config.alias: config for config in builder.model_configs}
+        if set(configs) != set(aliases):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "builder model aliases do not match the plan")
+        updated = []
+        providers = []
+        for deployment, port in zip(plan.deployments, plan.client.ports, strict=True):
+            alias = deployment.authored.model_alias
+            endpoint = endpoints[alias]
+            expected_endpoint = f"http://127.0.0.1:{port.port}/v1"
+            parsed = urlsplit(endpoint)
+            if endpoint != expected_endpoint or parsed.username is not None or parsed.password is not None:
+                raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "runtime model endpoint is invalid")
+            provider_name = f"slurm-{alias}"
+            model_config = configs[alias]
+            inference = model_config.inference_parameters
+            concurrency = plan.invocation.authored.model_concurrency.get(alias)
+            if concurrency is not None:
+                inference = inference.model_copy(update={"max_parallel_requests": concurrency})
+            updated.append(
+                model_config.model_copy(
+                    update={
+                        "model": deployment.served_model_name,
+                        "provider": provider_name,
+                        "inference_parameters": inference,
+                    }
+                )
+            )
+            providers.append(ModelProvider(name=provider_name, endpoint=endpoint, provider_type="openai"))
+        for model_config in tuple(builder.model_configs):
+            builder.delete_model_config(model_config.alias)
+        for model_config in updated:
+            builder.add_model_config(model_config)
+        return providers
+
+    @staticmethod
+    def _materialize_seed(
+        plan: ResolvedSlurmRunPlan,
+        shard: PlannedShard,
+        builder: DataDesignerConfigBuilder,
+    ) -> None:
+        seed_path = plan.invocation.effective_input_bindings.seed_path
+        if seed_path is None:
+            return
+        seed = builder.get_seed_config()
+        if seed is None or "path" not in type(seed.source).model_fields:
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "seed binding does not match the builder")
+        path = Path(seed_path)
+        if not path.exists() or not os.access(path, os.R_OK):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "seed input is unavailable")
+        if shard.input_partition is None:
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "seed partition artifact is missing")
+        payload = read_regular_bytes(Path(shard.input_partition.path), missing_code=ClientErrorCode.INVALID_INPUT)
+        if hashlib.sha256(payload).hexdigest() != shard.input_partition.sha256:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "seed partition artifact digest differs")
+        source = seed.source.model_copy(update={"path": seed_path})
+        builder.with_seed_dataset(
+            source,
+            sampling_strategy=seed.sampling_strategy,
+            selection_strategy=PartitionBlock(index=shard.shard_index, num_partitions=len(plan.shards)),
+        )
+
+    @staticmethod
+    def _materialize_mcp_providers(
+        plan: ResolvedSlurmRunPlan,
+    ) -> list[MCPProvider | LocalStdioMCPProvider]:
+        providers: list[MCPProvider | LocalStdioMCPProvider] = []
+        for provider in plan.invocation.authored.mcp_providers:
+            if isinstance(provider, RemoteMCPProviderConfig):
+                api_key = _resolve_secret(provider.api_key) if provider.api_key is not None else None
+                providers.append(
+                    MCPProvider(
+                        provider_type=provider.provider_type,
+                        name=provider.name,
+                        endpoint=provider.endpoint,
+                        api_key=api_key,
+                    )
+                )
+            elif isinstance(provider, LocalStdioMCPProviderConfig):
+                environment = {
+                    name: binding.value if isinstance(binding, LiteralEnvironmentBinding) else _resolve_secret(binding)
+                    for name, binding in provider.environment.items()
+                }
+                providers.append(
+                    LocalStdioMCPProvider(
+                        name=provider.name,
+                        command=provider.command,
+                        args=list(provider.args),
+                        env=environment,
+                    )
+                )
+        return providers
+
+    @staticmethod
+    def _validate_assets(plan: ResolvedSlurmRunPlan) -> None:
+        value = plan.invocation.effective_input_bindings.managed_assets_path
+        assert value is not None
+        path = Path(value)
+        if not path.is_dir() or not os.access(path, os.R_OK | os.X_OK):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "managed assets are unavailable")
+
+    @staticmethod
+    def _dataset_path(
+        shard: PlannedShard,
+        prepared: PreparedClientEnvironment,
+        resume: ResumeMode,
+    ) -> Path:
+        resume_path = Path(shard.resume_workspace.path)
+        if resume_path.is_symlink():
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "resume workspace is invalid")
+        if resume is ResumeMode.ALWAYS and (not resume_path.is_dir() or not any(resume_path.iterdir())):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "required resume workspace is unavailable")
+        if resume is ResumeMode.NEVER:
+            return prepared.attempt_dir / "dataset"
+        if resume_path.exists() and not resume_path.is_dir():
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "resume workspace is invalid")
+        return resume_path
+
+    def _finalize(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        results: CreationResults,
+    ) -> ClientResult:
+        requested = context.shard.requested_records
+        actual = results.actual_num_records
+        if results.requested_num_records != requested or actual > requested:
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer result counts are invalid")
+        if results.early_shutdown is None or results.effective_resume_mode is None:
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer result metadata is incomplete")
+        if results.requested_resume_mode is not context.requested_resume:
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer resume metadata differs")
+
+        dataset_path = Path(results.dataset_path)
+        effective_resume = results.effective_resume_mode
+        shared_path = Path(context.shard.resume_workspace.path)
+        expected_path = shared_path if effective_resume is ResumeMode.ALWAYS else prepared.attempt_dir / "dataset"
+        if (
+            not dataset_path.is_absolute()
+            or dataset_path != Path(os.path.normpath(dataset_path.as_posix()))
+            or not dataset_path.is_dir()
+            or dataset_path.is_symlink()
+        ):
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
+        if dataset_path != expected_path and (
+            effective_resume is not ResumeMode.NEVER
+            or expected_path.exists()
+            or not (
+                dataset_path.parent == prepared.attempt_dir
+                or dataset_path == shared_path
+                or (dataset_path.parent == shared_path.parent and dataset_path.name.startswith(f"{shared_path.name}_"))
+            )
+        ):
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
+        exported_path: Path | None = None
+        if actual:
+            exported_path = results.export(dataset_path / "part-00000.parquet", format="parquet")
+        if dataset_path != expected_path:
+            ensure_private_directory(expected_path.parent)
+            dataset_path.rename(expected_path)
+            if exported_path is not None:
+                exported_path = expected_path / exported_path.relative_to(dataset_path)
+            dataset_path = expected_path
+        if dataset_path != expected_path:
+            raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer dataset path is invalid")
+
+        files: tuple[CandidateOutputFile, ...] = ()
+        schema_digest = context.plan.builder.content_sha256
+        if exported_path is not None:
+            metadata = lazy.pq.read_metadata(exported_path)
+            if metadata.num_rows != actual:
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "exported record count differs")
+            schema_digest = hashlib.sha256(lazy.pq.read_schema(exported_path).serialize().to_pybytes()).hexdigest()
+            files = (
+                CandidateOutputFile(
+                    relative_path=exported_path.relative_to(dataset_path).as_posix(),
+                    sha256=compute_file_sha256(exported_path, missing_code=ClientErrorCode.OUTPUT_INVALID),
+                    byte_size=exported_path.stat().st_size,
+                    record_count=actual,
+                ),
+            )
+        created_at = self._clock()
+        provenance_digest = compute_canonical_json_sha256(
+            {
+                "builder_sha256": context.plan.builder.content_sha256,
+                "client_image_sha256": prepared.client_image_sha256,
+                "dependency_lock_sha256": prepared.dependency_lock.sha256,
+                "files": [file.model_dump(mode="json") for file in files],
+                "attempt_id": prepared.attempt_id,
+                "resolved_plan_sha256": context.plan.compute_sha256(),
+                "run_id": context.plan.run_id,
+                "shard_id": context.shard.shard_id,
+            }
+        )
+        candidate = CandidateOutputManifest(
+            schema_version=1,
+            run_id=context.plan.run_id,
+            shard_id=context.shard.shard_id,
+            attempt_id=prepared.attempt_id,
+            attempt_ordinal=int(prepared.attempt_id.removeprefix("attempt-")),
+            created_at=created_at,
+            dataset_path=dataset_path.as_posix(),
+            requested_records=requested,
+            actual_records=actual,
+            outcome=(
+                CandidateOutcome.EMPTY
+                if actual == 0
+                else CandidateOutcome.COMPLETE
+                if actual == requested
+                else CandidateOutcome.PARTIAL
+            ),
+            files=files,
+            dataset_schema_digest=schema_digest,
+            provenance_digest=provenance_digest,
+        )
+        candidate_path = prepared.attempt_dir / "output-manifest.json"
+        publish_private_text(candidate_path, candidate.serialize_json())
+        result = ClientResult(
+            schema_version=1,
+            run_id=context.plan.run_id,
+            shard_id=context.shard.shard_id,
+            attempt_id=prepared.attempt_id,
+            completed_at=self._clock(),
+            requested_records=requested,
+            actual_records=actual,
+            outcome=ClientOutcome.COMPLETE if actual == requested else ClientOutcome.PARTIAL,
+            dataset_path=dataset_path.as_posix(),
+            early_shutdown=results.early_shutdown,
+            requested_resume_mode=context.requested_resume.value,
+            effective_resume_mode=effective_resume.value,
+            candidate_output_manifest=ArtifactReference(
+                path=candidate_path.as_posix(), sha256=candidate.compute_sha256()
+            ),
+        )
+        publish_private_text(prepared.attempt_dir / "client-result.json", result.serialize_json())
+        return result
+
+    def _validate_environment_manifest(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        plugins: tuple[ClientPluginEntryPoint, ...],
+    ) -> None:
+        try:
+            manifest = ClientEnvironmentManifest.model_validate_json(
+                read_regular_bytes(
+                    prepared.attempt_dir / "client-environment.json",
+                    missing_code=ClientErrorCode.CONFIG_INVALID,
+                )
+            )
+        except ValidationError as error:
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "client environment manifest is invalid") from error
+        if (
+            manifest.outcome is not ClientEnvironmentOutcome.READY
+            or manifest.run_id != context.plan.run_id
+            or manifest.shard_id != context.shard.shard_id
+            or manifest.attempt_id != prepared.attempt_id
+            or manifest.dependency_lock != prepared.dependency_lock
+            or manifest.client_image_sha256 != prepared.client_image_sha256
+            or manifest.python_abi != prepared.python_abi
+            or manifest.overlay_path != prepared.overlay_path.as_posix()
+            or manifest.installed_distributions != prepared.installed_distributions
+            or manifest.plugins != plugins
+        ):
+            raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "client environment manifest differs")
+
+    def _write_preflight_failure(
+        self,
+        plan_path: Path,
+        prepared: PreparedClientEnvironment,
+        endpoints: Mapping[str, str],
+        plugins: tuple[ClientPluginEntryPoint, ...],
+        error: ClientWorkerError,
+    ) -> None:
+        manifest = ClientEnvironmentManifest(
+            schema_version=1,
+            run_id=prepared.run_id,
+            shard_id=prepared.shard_id,
+            attempt_id=prepared.attempt_id,
+            created_at=self._clock(),
+            outcome=ClientEnvironmentOutcome.FAILED,
+            dependency_lock=prepared.dependency_lock,
+            client_image_sha256=prepared.client_image_sha256,
+            python_abi=prepared.python_abi,
+            overlay_path=prepared.overlay_path.as_posix(),
+            installer_outcome=prepared.installer_outcome,
+            installed_distributions=prepared.installed_distributions,
+            plugins=plugins,
+            error_code=error.code,
+            redacted_message=error.redacted_message,
+        )
+        replace_private_text(prepared.attempt_dir / "client-environment.json", manifest.serialize_json())
+        try:
+            context = self._build_context(plan_path, prepared=prepared, endpoints=endpoints)
+        except ClientWorkerError:
+            return
+        self._write_failure(context, prepared, error, revision=3)
+
+    def _write_failure(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        error: ClientWorkerError,
+        *,
+        revision: int,
+    ) -> None:
+        result = ClientResult(
+            schema_version=1,
+            run_id=context.plan.run_id,
+            shard_id=context.shard.shard_id,
+            attempt_id=prepared.attempt_id,
+            completed_at=self._clock(),
+            requested_records=context.shard.requested_records,
+            actual_records=None,
+            outcome=ClientOutcome.FAILED,
+            requested_resume_mode=context.requested_resume.value,
+            error_code=error.code.value,
+            redacted_message=error.redacted_message,
+        )
+        publish_private_text(prepared.attempt_dir / "client-result.json", result.serialize_json())
+        try:
+            self._write_progress(
+                context,
+                prepared,
+                revision,
+                ClientProgressPhase.FAILED,
+                error_code=error.code,
+            )
+        except Exception:
+            logger.warning("Could not persist client failure progress")
+
+    def _write_progress(
+        self,
+        context: _ExecutionContext,
+        prepared: PreparedClientEnvironment,
+        revision: int,
+        phase: ClientProgressPhase,
+        *,
+        completed_records: int | None = None,
+        error_code: ClientErrorCode | None = None,
+    ) -> None:
+        progress = ClientProgress(
+            schema_version=1,
+            run_id=context.plan.run_id,
+            shard_id=context.shard.shard_id,
+            attempt_id=prepared.attempt_id,
+            revision=revision,
+            updated_at=self._clock(),
+            phase=phase,
+            requested_records=context.shard.requested_records,
+            completed_records=completed_records,
+            error_code=error_code,
+        )
+        replace_private_text(prepared.attempt_dir / "client-progress.json", progress.serialize_json())
+
+
+def _resolve_secret(reference: SecretRef) -> str:
+    try:
+        return os.environ[reference.environment]
+    except KeyError as error:
+        raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "required client secret is unavailable") from error

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/execution.py
@@ -207,9 +207,10 @@ class ClientWorker:
             progress.required(ClientProgressPhase.GENERATING, completed_records=0)
             self._prepare_dataset_workspace(context, prepared)
             results = self._generate_dataset(context, progress)
-            progress.required(ClientProgressPhase.FINALIZING, completed_records=results.actual_num_records)
             try:
-                result = self._finalize(context, prepared, results)
+                creation = self._validate_creation_result(context, prepared, results)
+                progress.required(ClientProgressPhase.FINALIZING, completed_records=creation.actual_records)
+                result = self._finalize(context, prepared, results, creation)
             except ClientWorkerError:
                 raise
             except Exception as error:
@@ -288,7 +289,7 @@ class ClientWorker:
             return _ExecutionContext(plan, shard, builder, designer, requested_resume, dataset_path)
         except ClientWorkerError:
             raise
-        except (StopIteration, ValidationError, ValueError, OSError, KeyError, TypeError) as error:
+        except Exception as error:
             raise ClientWorkerError(ClientErrorCode.CONFIG_INVALID, "Data Designer configuration is invalid") from error
 
     @staticmethod
@@ -504,8 +505,8 @@ class ClientWorker:
         context: _ExecutionContext,
         prepared: PreparedClientEnvironment,
         results: CreationResults,
+        creation: _ValidatedCreation,
     ) -> ClientResult:
-        creation = self._validate_creation_result(context, prepared, results)
         dataset_path, exported_path = self._place_dataset(creation, results)
         candidate = self._build_candidate_manifest(context, prepared, creation, dataset_path, exported_path)
         return self._publish_success(context, prepared, creation, candidate)
@@ -518,7 +519,7 @@ class ClientWorker:
     ) -> _ValidatedCreation:
         requested = context.shard.requested_records
         actual = results.actual_num_records
-        if results.requested_num_records != requested or actual > requested:
+        if results.requested_num_records != requested or not 0 <= actual <= requested:
             raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer result counts are invalid")
         if results.early_shutdown is None or results.effective_resume_mode is None:
             raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "Data Designer result metadata is incomplete")

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import uuid
+from pathlib import Path
+
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.records import ClientErrorCode
+
+_MAXIMUM_RECORD_SIZE = 16 * 1024 * 1024
+
+
+def ensure_private_directory(path: Path) -> None:
+    """Create one private directory tree and reject symlink components."""
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    current = path
+    while current != current.parent:
+        info = current.lstat()
+        if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client workspace is not a regular directory")
+        if current.parent == path.anchor:
+            break
+        current = current.parent
+    path.chmod(0o700)
+
+
+def read_regular_bytes(path: Path, *, missing_code: ClientErrorCode) -> bytes:
+    """Read one bounded regular file without following a final symlink."""
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input is not a regular file")
+        if info.st_size > _MAXIMUM_RECORD_SIZE:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input exceeds the size limit")
+        return path.read_bytes()
+    except FileNotFoundError as error:
+        raise ClientWorkerError(missing_code, "required client artifact is missing") from error
+    except OSError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "required client artifact is unreadable") from error
+
+
+def compute_file_sha256(path: Path, *, missing_code: ClientErrorCode) -> str:
+    """Hash one regular file without retaining its contents."""
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client artifact is not a regular file")
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except FileNotFoundError as error:
+        raise ClientWorkerError(missing_code, "required client artifact is missing") from error
+    except OSError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "required client artifact is unreadable") from error
+
+
+def replace_private_text(path: Path, text: str) -> None:
+    """Atomically replace one private attempt-local record."""
+    payload = text.encode("utf-8")
+    if len(payload) > _MAXIMUM_RECORD_SIZE:
+        raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "client record exceeds the size limit")
+    ensure_private_directory(path.parent)
+    temporary = path.parent / f".client.{uuid.uuid4().hex}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def publish_private_text(path: Path, text: str) -> None:
+    """Convergently publish one immutable private attempt-local record."""
+    payload = text.encode("utf-8")
+    if len(payload) > _MAXIMUM_RECORD_SIZE:
+        raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "client record exceeds the size limit")
+    ensure_private_directory(path.parent)
+    temporary = path.parent / f".client.{uuid.uuid4().hex}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            if read_regular_bytes(path, missing_code=ClientErrorCode.OUTPUT_INVALID) != payload:
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "immutable client record already differs")
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
@@ -7,37 +7,39 @@ import hashlib
 import os
 import stat
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from data_designer.slurm.client.errors import ClientWorkerError
 from data_designer.slurm.client.records import ClientErrorCode
 
 _MAXIMUM_RECORD_SIZE = 16 * 1024 * 1024
+_DIRECTORY_MODE = 0o700
+_FILE_MODE = 0o600
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+_FILE_READ_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
 
 
 def ensure_private_directory(path: Path) -> None:
     """Create one private directory tree and reject symlink components."""
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
-    current = path
-    while current != current.parent:
-        info = current.lstat()
-        if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
-            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client workspace is not a regular directory")
-        if current.parent == path.anchor:
-            break
-        current = current.parent
-    path.chmod(0o700)
+    try:
+        with _open_directory(path, create=True) as descriptor:
+            os.fchmod(descriptor, _DIRECTORY_MODE)
+    except OSError as error:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client workspace is not a regular directory") from error
 
 
 def read_regular_bytes(path: Path, *, missing_code: ClientErrorCode) -> bytes:
     """Read one bounded regular file without following a final symlink."""
     try:
-        info = path.lstat()
-        if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
-            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input is not a regular file")
-        if info.st_size > _MAXIMUM_RECORD_SIZE:
-            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input exceeds the size limit")
-        return path.read_bytes()
+        with _open_directory(path.parent, create=False) as directory_descriptor:
+            with _open_regular_file(directory_descriptor, path.name) as (descriptor, info):
+                if not stat.S_ISREG(info.st_mode):
+                    raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input is not a regular file")
+                return _read_bounded_bytes(descriptor, info)
+    except ClientWorkerError:
+        raise
     except FileNotFoundError as error:
         raise ClientWorkerError(missing_code, "required client artifact is missing") from error
     except OSError as error:
@@ -47,14 +49,16 @@ def read_regular_bytes(path: Path, *, missing_code: ClientErrorCode) -> bytes:
 def compute_file_sha256(path: Path, *, missing_code: ClientErrorCode) -> str:
     """Hash one regular file without retaining its contents."""
     try:
-        info = path.lstat()
-        if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
-            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client artifact is not a regular file")
-        digest = hashlib.sha256()
-        with path.open("rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(chunk)
-        return digest.hexdigest()
+        with _open_directory(path.parent, create=False) as directory_descriptor:
+            with _open_regular_file(directory_descriptor, path.name) as (descriptor, info):
+                if not stat.S_ISREG(info.st_mode):
+                    raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client artifact is not a regular file")
+                digest = hashlib.sha256()
+                while chunk := os.read(descriptor, 1024 * 1024):
+                    digest.update(chunk)
+                return digest.hexdigest()
+    except ClientWorkerError:
+        raise
     except FileNotFoundError as error:
         raise ClientWorkerError(missing_code, "required client artifact is missing") from error
     except OSError as error:
@@ -63,44 +67,131 @@ def compute_file_sha256(path: Path, *, missing_code: ClientErrorCode) -> str:
 
 def replace_private_text(path: Path, text: str) -> None:
     """Atomically replace one private attempt-local record."""
-    _, temporary = _write_private_temporary(path, text)
-    try:
-        os.replace(temporary, path)
-        path.chmod(0o600)
-    finally:
-        try:
-            temporary.unlink()
-        except FileNotFoundError:
-            pass
+    with _write_private_temporary(path, text) as (_, directory_descriptor, temporary_name):
+        os.replace(
+            temporary_name,
+            path.name,
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+        )
 
 
 def publish_private_text(path: Path, text: str) -> None:
     """Convergently publish one immutable private attempt-local record."""
-    payload, temporary = _write_private_temporary(path, text)
-    try:
+    with _write_private_temporary(path, text) as (payload, directory_descriptor, temporary_name):
         try:
-            os.link(temporary, path)
+            os.link(
+                temporary_name,
+                path.name,
+                src_dir_fd=directory_descriptor,
+                dst_dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
         except FileExistsError:
-            if read_regular_bytes(path, missing_code=ClientErrorCode.OUTPUT_INVALID) != payload:
-                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "immutable client record already differs")
-        path.chmod(0o600)
-    finally:
-        temporary.unlink(missing_ok=True)
+            try:
+                with _open_regular_file(directory_descriptor, path.name) as (descriptor, info):
+                    if not stat.S_ISREG(info.st_mode):
+                        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input is not a regular file")
+                    if _read_bounded_bytes(descriptor, info) != payload:
+                        raise ClientWorkerError(
+                            ClientErrorCode.OUTPUT_INVALID, "immutable client record already differs"
+                        )
+                    os.fchmod(descriptor, _FILE_MODE)
+            except ClientWorkerError:
+                raise
+            except FileNotFoundError as error:
+                raise ClientWorkerError(
+                    ClientErrorCode.OUTPUT_INVALID, "required client artifact is missing"
+                ) from error
+            except OSError as error:
+                raise ClientWorkerError(
+                    ClientErrorCode.INVALID_INPUT, "required client artifact is unreadable"
+                ) from error
 
 
-def _write_private_temporary(path: Path, text: str) -> tuple[bytes, Path]:
+@contextmanager
+def _write_private_temporary(path: Path, text: str) -> Iterator[tuple[bytes, int, str]]:
     payload = text.encode("utf-8")
     if len(payload) > _MAXIMUM_RECORD_SIZE:
         raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "client record exceeds the size limit")
-    ensure_private_directory(path.parent)
-    temporary = path.parent / f".client.{uuid.uuid4().hex}.tmp"
-    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    with _open_directory(path.parent, create=True) as directory_descriptor:
+        os.fchmod(directory_descriptor, _DIRECTORY_MODE)
+        temporary_name = f".client.{uuid.uuid4().hex}.tmp"
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            _FILE_MODE,
+            dir_fd=directory_descriptor,
+        )
+        try:
+            try:
+                os.fchmod(descriptor, _FILE_MODE)
+                remaining = memoryview(payload)
+                while remaining:
+                    written = os.write(descriptor, remaining)
+                    if written == 0:
+                        raise OSError("client temporary file write made no progress")
+                    remaining = remaining[written:]
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            yield payload, directory_descriptor, temporary_name
+        finally:
+            try:
+                os.unlink(temporary_name, dir_fd=directory_descriptor)
+            except FileNotFoundError:
+                pass
+
+
+@contextmanager
+def _open_directory(path: Path, *, create: bool) -> Iterator[int]:
+    start = path.anchor or "."
+    parts = path.parts[1:] if path.anchor else path.parts
+    descriptor = os.open(start, _DIRECTORY_FLAGS)
     try:
-        with os.fdopen(descriptor, "wb", closefd=True) as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        return payload, temporary
-    except Exception:
-        temporary.unlink(missing_ok=True)
-        raise
+        for part in parts:
+            if part in ("", ".", ".."):
+                raise OSError("client directory path is not canonical")
+            try:
+                child_descriptor = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, _DIRECTORY_MODE, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+                child_descriptor = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+            try:
+                if not stat.S_ISDIR(os.fstat(child_descriptor).st_mode):
+                    raise OSError("client workspace component is not a directory")
+            except BaseException:
+                os.close(child_descriptor)
+                raise
+            previous_descriptor = descriptor
+            descriptor = child_descriptor
+            os.close(previous_descriptor)
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _open_regular_file(directory_descriptor: int, name: str) -> Iterator[tuple[int, os.stat_result]]:
+    descriptor = os.open(name, _FILE_READ_FLAGS, dir_fd=directory_descriptor)
+    try:
+        yield descriptor, os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _read_bounded_bytes(descriptor: int, info: os.stat_result) -> bytes:
+    if info.st_size > _MAXIMUM_RECORD_SIZE:
+        raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input exceeds the size limit")
+    payload = bytearray()
+    while len(payload) <= _MAXIMUM_RECORD_SIZE:
+        chunk = os.read(descriptor, min(1024 * 1024, _MAXIMUM_RECORD_SIZE + 1 - len(payload)))
+        if not chunk:
+            return bytes(payload)
+        payload.extend(chunk)
+    raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "client input exceeds the size limit")

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/filesystem.py
@@ -63,17 +63,8 @@ def compute_file_sha256(path: Path, *, missing_code: ClientErrorCode) -> str:
 
 def replace_private_text(path: Path, text: str) -> None:
     """Atomically replace one private attempt-local record."""
-    payload = text.encode("utf-8")
-    if len(payload) > _MAXIMUM_RECORD_SIZE:
-        raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "client record exceeds the size limit")
-    ensure_private_directory(path.parent)
-    temporary = path.parent / f".client.{uuid.uuid4().hex}.tmp"
-    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    _, temporary = _write_private_temporary(path, text)
     try:
-        with os.fdopen(descriptor, "wb", closefd=True) as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
         os.replace(temporary, path)
         path.chmod(0o600)
     finally:
@@ -85,6 +76,19 @@ def replace_private_text(path: Path, text: str) -> None:
 
 def publish_private_text(path: Path, text: str) -> None:
     """Convergently publish one immutable private attempt-local record."""
+    payload, temporary = _write_private_temporary(path, text)
+    try:
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            if read_regular_bytes(path, missing_code=ClientErrorCode.OUTPUT_INVALID) != payload:
+                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "immutable client record already differs")
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _write_private_temporary(path: Path, text: str) -> tuple[bytes, Path]:
     payload = text.encode("utf-8")
     if len(payload) > _MAXIMUM_RECORD_SIZE:
         raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "client record exceeds the size limit")
@@ -96,11 +100,7 @@ def publish_private_text(path: Path, text: str) -> None:
             stream.write(payload)
             stream.flush()
             os.fsync(stream.fileno())
-        try:
-            os.link(temporary, path)
-        except FileExistsError:
-            if read_regular_bytes(path, missing_code=ClientErrorCode.OUTPUT_INVALID) != payload:
-                raise ClientWorkerError(ClientErrorCode.OUTPUT_INVALID, "immutable client record already differs")
-        path.chmod(0o600)
-    finally:
+        return payload, temporary
+    except Exception:
         temporary.unlink(missing_ok=True)
+        raise

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/plugins.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/plugins.py
@@ -8,10 +8,9 @@ from importlib.metadata import entry_points
 from packaging.utils import canonicalize_name
 
 from data_designer.plugins import Plugin
-from data_designer.plugins.registry import PluginRegistry
 from data_designer.slurm.client.errors import ClientWorkerError
 from data_designer.slurm.client.records import ClientErrorCode, ClientPluginEntryPoint
-from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.contracts import InstalledDistribution
 
 
 def discover_plugins(
@@ -47,10 +46,6 @@ def discover_plugins(
                     plugin_type=plugin.plugin_type.value,
                 )
             )
-        PluginRegistry.reset()
-        registered = PluginRegistry()
-        for plugin in discovered:
-            registered.get_plugin(plugin.plugin_name)
     except ClientWorkerError:
         raise
     except Exception as error:

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/plugins.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/plugins.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+from packaging.utils import canonicalize_name
+
+from data_designer.plugins import Plugin
+from data_designer.plugins.registry import PluginRegistry
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.records import ClientErrorCode, ClientPluginEntryPoint
+from data_designer.slurm.config.images import InstalledDistribution
+
+
+def discover_plugins(
+    installed_distributions: tuple[InstalledDistribution, ...],
+) -> tuple[ClientPluginEntryPoint, ...]:
+    """Load and validate every installed Data Designer plugin entry point."""
+    installed = {distribution.name: distribution.version for distribution in installed_distributions}
+    discovered: list[ClientPluginEntryPoint] = []
+    plugin_names: set[str] = set()
+    try:
+        for entry_point in entry_points(group="data_designer.plugins"):
+            if entry_point.dist is None:
+                raise ValueError("plugin entry point has no owning distribution")
+            distribution = canonicalize_name(entry_point.dist.name)
+            version = entry_point.dist.version
+            if installed.get(distribution) != version:
+                raise ValueError("plugin entry point is outside the verified environment")
+            plugin = entry_point.load()
+            if not isinstance(plugin, Plugin):
+                raise TypeError("plugin entry point did not load a Plugin")
+            plugin.config_cls
+            plugin.impl_cls
+            if plugin.name in plugin_names:
+                raise ValueError("plugin names must be unique")
+            plugin_names.add(plugin.name)
+            discovered.append(
+                ClientPluginEntryPoint(
+                    entry_point=entry_point.name,
+                    value=entry_point.value,
+                    distribution=distribution,
+                    distribution_version=version,
+                    plugin_name=plugin.name,
+                    plugin_type=plugin.plugin_type.value,
+                )
+            )
+        PluginRegistry.reset()
+        registered = PluginRegistry()
+        for plugin in discovered:
+            registered.get_plugin(plugin.plugin_name)
+    except ClientWorkerError:
+        raise
+    except Exception as error:
+        raise ClientWorkerError(ClientErrorCode.PLUGIN_LOAD_FAILED, "Data Designer plugin validation failed") from error
+    return tuple(sorted(discovered, key=lambda plugin: (plugin.distribution, plugin.entry_point)))

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/records.py
@@ -9,14 +9,141 @@ from typing import Annotated, Literal
 
 from pydantic import NonNegativeInt, PositiveInt, StringConstraints, field_validator, model_validator
 
+from data_designer.slurm.config.images import InstalledDistribution
 from data_designer.slurm.contracts import (
     ArtifactReference,
     AttemptId,
     ContractRecord,
+    ContractValue,
     Identifier,
+    Sha256Digest,
     ShardId,
     validate_absolute_path,
+    validate_plain_text,
 )
+
+
+class ClientErrorCode(str, Enum):
+    INVALID_INPUT = "invalid_input"
+    DEPENDENCY_ARTIFACT_MISSING = "dependency_artifact_missing"
+    DEPENDENCY_DIGEST_MISMATCH = "dependency_digest_mismatch"
+    DEPENDENCY_CONFLICT = "dependency_conflict"
+    DEPENDENCY_INSTALL_FAILED = "dependency_install_failed"
+    PLUGIN_LOAD_FAILED = "plugin_load_failed"
+    CONFIG_INVALID = "config_invalid"
+    GENERATION_FAILED = "generation_failed"
+    INTERRUPTED = "interrupted"
+    OUTPUT_INVALID = "output_invalid"
+
+
+class ClientEnvironmentOutcome(str, Enum):
+    READY = "ready"
+    FAILED = "failed"
+
+
+class ClientInstallerOutcome(str, Enum):
+    NOT_REQUIRED = "not_required"
+    INSTALLED = "installed"
+    REUSED = "reused"
+
+
+class ClientProgressPhase(str, Enum):
+    PREPARING_ENVIRONMENT = "preparing_environment"
+    VALIDATING_PLUGINS = "validating_plugins"
+    VALIDATING_CONFIG = "validating_config"
+    GENERATING = "generating"
+    FINALIZING = "finalizing"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+class ClientPluginEntryPoint(ContractValue):
+    entry_point: Annotated[str, StringConstraints(min_length=1, max_length=256)]
+    value: Annotated[str, StringConstraints(min_length=1, max_length=512)]
+    distribution: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    distribution_version: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    plugin_name: Identifier
+    plugin_type: Literal["column-generator", "seed-reader", "processor"]
+
+    @field_validator("entry_point", "value", "distribution", "distribution_version")
+    @classmethod
+    def validate_text(cls, value: str) -> str:
+        return validate_plain_text(value, field_name="plugin entry point")
+
+
+class ClientEnvironmentManifest(ContractRecord):
+    run_id: Identifier
+    shard_id: ShardId
+    attempt_id: AttemptId
+    created_at: datetime
+    outcome: ClientEnvironmentOutcome
+    dependency_lock: ArtifactReference
+    client_image_sha256: Sha256Digest
+    python_abi: Identifier
+    overlay_path: str
+    installer_outcome: ClientInstallerOutcome
+    installed_distributions: tuple[InstalledDistribution, ...]
+    plugins: tuple[ClientPluginEntryPoint, ...]
+    error_code: ClientErrorCode | None = None
+    redacted_message: Annotated[str, StringConstraints(max_length=512)] | None = None
+
+    _overlay_path_is_absolute = field_validator("overlay_path")(validate_absolute_path)
+
+    @field_validator("created_at")
+    @classmethod
+    def validate_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() != timedelta(0):
+            raise ValueError("created_at must be timezone-aware UTC")
+        return value
+
+    @field_validator("redacted_message")
+    @classmethod
+    def validate_redacted_message(cls, value: str | None) -> str | None:
+        return None if value is None else validate_plain_text(value, field_name="redacted message")
+
+    @model_validator(mode="after")
+    def validate_environment(self) -> ClientEnvironmentManifest:
+        distribution_names = tuple(distribution.name for distribution in self.installed_distributions)
+        if distribution_names != tuple(sorted(distribution_names)) or len(distribution_names) != len(
+            set(distribution_names)
+        ):
+            raise ValueError("installed distributions must be sorted and unique")
+        plugin_keys = tuple((plugin.distribution, plugin.entry_point) for plugin in self.plugins)
+        if plugin_keys != tuple(sorted(plugin_keys)) or len(plugin_keys) != len(set(plugin_keys)):
+            raise ValueError("plugin entry points must be sorted and unique")
+        if self.outcome is ClientEnvironmentOutcome.READY:
+            if self.error_code is not None or self.redacted_message is not None:
+                raise ValueError("ready client environments cannot contain failure details")
+        elif self.error_code is None:
+            raise ValueError("failed client environments require error_code")
+        return self
+
+
+class ClientProgress(ContractRecord):
+    run_id: Identifier
+    shard_id: ShardId
+    attempt_id: AttemptId
+    revision: PositiveInt
+    updated_at: datetime
+    phase: ClientProgressPhase
+    requested_records: PositiveInt
+    completed_records: NonNegativeInt | None = None
+    error_code: ClientErrorCode | None = None
+
+    @field_validator("updated_at")
+    @classmethod
+    def validate_updated_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() != timedelta(0):
+            raise ValueError("updated_at must be timezone-aware UTC")
+        return value
+
+    @model_validator(mode="after")
+    def validate_progress(self) -> ClientProgress:
+        if self.completed_records is not None and self.completed_records > self.requested_records:
+            raise ValueError("completed_records must not exceed requested_records")
+        if (self.phase is ClientProgressPhase.FAILED) != (self.error_code is not None):
+            raise ValueError("only failed progress requires an error code")
+        return self
 
 
 class ClientOutcome(str, Enum):
@@ -66,11 +193,8 @@ class ClientResult(ContractRecord):
     def validate_outcome(self) -> ClientResult:
         if self.actual_records is not None and self.actual_records > self.requested_records:
             raise ValueError("actual_records must not exceed requested_records")
-        if self.requested_resume_mode != "if_possible" and self.effective_resume_mode not in {
-            None,
-            self.requested_resume_mode,
-        }:
-            raise ValueError("effective resume mode must match a fixed requested mode")
+        if self.requested_resume_mode == "never" and self.effective_resume_mode not in {None, "never"}:
+            raise ValueError("resume mode never cannot become effective resume")
         if self.outcome is not ClientOutcome.FAILED:
             if self.early_shutdown is None or self.effective_resume_mode is None:
                 raise ValueError("non-failed client results require resume and early-shutdown facts")

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/records.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/records.py
@@ -5,22 +5,25 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import NonNegativeInt, PositiveInt, StringConstraints, field_validator, model_validator
 
-from data_designer.slurm.config.images import InstalledDistribution
 from data_designer.slurm.contracts import (
     ArtifactReference,
     AttemptId,
     ContractRecord,
     ContractValue,
     Identifier,
+    InstalledDistribution,
     Sha256Digest,
     ShardId,
     validate_absolute_path,
     validate_plain_text,
 )
+
+if TYPE_CHECKING:
+    from data_designer.slurm.client.environment import PreparedClientEnvironment
 
 
 class ClientErrorCode(str, Enum):
@@ -88,6 +91,35 @@ class ClientEnvironmentManifest(ContractRecord):
     redacted_message: Annotated[str, StringConstraints(max_length=512)] | None = None
 
     _overlay_path_is_absolute = field_validator("overlay_path")(validate_absolute_path)
+
+    @classmethod
+    def from_prepared(
+        cls,
+        prepared: PreparedClientEnvironment,
+        *,
+        created_at: datetime,
+        outcome: ClientEnvironmentOutcome,
+        plugins: tuple[ClientPluginEntryPoint, ...],
+        error_code: ClientErrorCode | None = None,
+        redacted_message: str | None = None,
+    ) -> ClientEnvironmentManifest:
+        return cls(
+            schema_version=1,
+            run_id=prepared.run_id,
+            shard_id=prepared.shard_id,
+            attempt_id=prepared.attempt_id,
+            created_at=created_at,
+            outcome=outcome,
+            dependency_lock=prepared.dependency_lock,
+            client_image_sha256=prepared.client_image_sha256,
+            python_abi=prepared.python_abi,
+            overlay_path=prepared.overlay_path.as_posix(),
+            installer_outcome=prepared.installer_outcome,
+            installed_distributions=prepared.installed_distributions,
+            plugins=plugins,
+            error_code=error_code,
+            redacted_message=redacted_message,
+        )
 
     @field_validator("created_at")
     @classmethod

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
@@ -85,7 +85,7 @@ def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
 def _parse_endpoints(values: list[str]) -> dict[str, str]:
     endpoints: dict[str, str] = {}
     for value in values:
-        alias, separator, endpoint = value.partition("=")
+        alias, separator, endpoint = value.rpartition("=")
         if not separator or not alias or not endpoint or alias in endpoints:
             raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "runtime endpoint argument is invalid")
         endpoints[alias] = endpoint

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
@@ -97,19 +97,10 @@ def _write_plugin_failure(
     plugins: tuple[ClientPluginEntryPoint, ...],
     error: ClientWorkerError,
 ) -> None:
-    manifest = ClientEnvironmentManifest(
-        schema_version=1,
-        run_id=prepared.run_id,
-        shard_id=prepared.shard_id,
-        attempt_id=prepared.attempt_id,
+    manifest = ClientEnvironmentManifest.from_prepared(
+        prepared,
         created_at=datetime.now(timezone.utc),
         outcome=ClientEnvironmentOutcome.FAILED,
-        dependency_lock=prepared.dependency_lock,
-        client_image_sha256=prepared.client_image_sha256,
-        python_abi=prepared.python_abi,
-        overlay_path=prepared.overlay_path.as_posix(),
-        installer_outcome=prepared.installer_outcome,
-        installed_distributions=prepared.installed_distributions,
         plugins=plugins,
         error_code=error.code,
         redacted_message=error.redacted_message,

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/worker.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import signal
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+
+from data_designer.slurm.client.environment import (
+    ClientEnvironmentBuilder,
+    PreparedClientEnvironment,
+    activate_environment,
+)
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.filesystem import replace_private_text
+from data_designer.slurm.client.records import (
+    ClientEnvironmentManifest,
+    ClientEnvironmentOutcome,
+    ClientErrorCode,
+    ClientPluginEntryPoint,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one allocation-local client preflight or generation operation."""
+    arguments = _parse_arguments(argv)
+    previous_sigterm_handler = signal.signal(signal.SIGTERM, _handle_sigterm)
+    prepared: PreparedClientEnvironment | None = None
+    plugins: tuple[ClientPluginEntryPoint, ...] = ()
+    try:
+        endpoints = _parse_endpoints(arguments.endpoint)
+        prepared = ClientEnvironmentBuilder().prepare(
+            arguments.plan,
+            shard_id=arguments.shard_id,
+            attempt_id=arguments.attempt_id,
+            attempt_dir=arguments.attempt_dir,
+        )
+        activate_environment(prepared)
+        plugins_module = importlib.import_module("data_designer.slurm.client.plugins")
+        discover_plugins = getattr(plugins_module, "discover_plugins")
+        plugins = discover_plugins(prepared.installed_distributions)
+        execution_module = importlib.import_module("data_designer.slurm.client.execution")
+        ClientWorker = getattr(execution_module, "ClientWorker")
+        worker = ClientWorker()
+        if arguments.operation == "preflight":
+            worker.preflight(arguments.plan, prepared=prepared, endpoints=endpoints, plugins=plugins)
+        else:
+            worker.run(arguments.plan, prepared=prepared, endpoints=endpoints, plugins=plugins)
+        return 0
+    except ClientWorkerError as error:
+        if prepared is not None and error.code is ClientErrorCode.PLUGIN_LOAD_FAILED:
+            _write_plugin_failure(prepared, plugins, error)
+        print(f"client worker failed: {error.code.value}", file=sys.stderr)
+        return 2
+    except (KeyboardInterrupt, SystemExit):
+        print(f"client worker failed: {ClientErrorCode.INTERRUPTED.value}", file=sys.stderr)
+        return 2
+    except Exception:
+        print(f"client worker failed: {ClientErrorCode.INVALID_INPUT.value}", file=sys.stderr)
+        return 2
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm_handler)
+
+
+def _handle_sigterm(_signum: int, _frame: object) -> None:
+    raise KeyboardInterrupt
+
+
+def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="python -m data_designer.slurm.client.worker")
+    parser.add_argument("operation", choices=("preflight", "run"))
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--shard-id", required=True)
+    parser.add_argument("--attempt-id", required=True)
+    parser.add_argument("--attempt-dir", required=True, type=Path)
+    parser.add_argument("--endpoint", action="append", default=[])
+    return parser.parse_args(argv)
+
+
+def _parse_endpoints(values: list[str]) -> dict[str, str]:
+    endpoints: dict[str, str] = {}
+    for value in values:
+        alias, separator, endpoint = value.partition("=")
+        if not separator or not alias or not endpoint or alias in endpoints:
+            raise ClientWorkerError(ClientErrorCode.INVALID_INPUT, "runtime endpoint argument is invalid")
+        endpoints[alias] = endpoint
+    return endpoints
+
+
+def _write_plugin_failure(
+    prepared: PreparedClientEnvironment,
+    plugins: tuple[ClientPluginEntryPoint, ...],
+    error: ClientWorkerError,
+) -> None:
+    manifest = ClientEnvironmentManifest(
+        schema_version=1,
+        run_id=prepared.run_id,
+        shard_id=prepared.shard_id,
+        attempt_id=prepared.attempt_id,
+        created_at=datetime.now(timezone.utc),
+        outcome=ClientEnvironmentOutcome.FAILED,
+        dependency_lock=prepared.dependency_lock,
+        client_image_sha256=prepared.client_image_sha256,
+        python_abi=prepared.python_abi,
+        overlay_path=prepared.overlay_path.as_posix(),
+        installer_outcome=prepared.installer_outcome,
+        installed_distributions=prepared.installed_distributions,
+        plugins=plugins,
+        error_code=error.code,
+        redacted_message=error.redacted_message,
+    )
+    replace_private_text(prepared.attempt_dir / "client-environment.json", manifest.serialize_json())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/data-designer-slurm/src/data_designer/slurm/config/images.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/config/images.py
@@ -14,19 +14,11 @@ from data_designer.slurm.contracts import (
     ContractRecord,
     ContractValue,
     Identifier,
+    InstalledDistribution,
     Sha256Digest,
     validate_absolute_path,
     validate_plain_text,
 )
-
-DistributionName = Annotated[
-    str,
-    StringConstraints(
-        min_length=1,
-        max_length=128,
-        pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
-    ),
-]
 
 
 class ImageKind(str, Enum):
@@ -73,11 +65,6 @@ class ImageBuildRequest(AuthoredConfig):
         if not re.fullmatch(r"[^\s]+@sha256:[0-9a-f]{64}", value):
             raise ValueError("OCI image source must be digest-qualified")
         return value
-
-
-class InstalledDistribution(ContractValue):
-    name: DistributionName
-    version: Annotated[str, StringConstraints(min_length=1, max_length=128)]
 
 
 class ClientImageInspection(ContractValue):

--- a/packages/data-designer-slurm/src/data_designer/slurm/contracts.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/contracts.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import posixpath
 from collections.abc import Mapping
-from typing import TypeVar
+from typing import Annotated, TypeVar
 from urllib.parse import urlsplit
 
 from pydantic import (
@@ -17,6 +17,7 @@ from pydantic import (
     ConfigDict,
     NonNegativeInt,
     PositiveInt,
+    StringConstraints,
     field_validator,
     model_validator,
 )
@@ -105,6 +106,21 @@ class ContractValue(BaseModel):
     @classmethod
     def freeze_collections(cls, value: object) -> object:
         return _freeze_collections(value)
+
+
+DistributionName = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+    ),
+]
+
+
+class InstalledDistribution(ContractValue):
+    name: DistributionName
+    version: Annotated[str, StringConstraints(min_length=1, max_length=128)]
 
 
 class AuthoredConfig(ContractValue):

--- a/packages/data-designer-slurm/src/data_designer/slurm/planning/models.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/planning/models.py
@@ -16,7 +16,6 @@ from data_designer.config import RunConfig
 from data_designer.slurm.config.environment import validate_no_plaintext_secrets
 from data_designer.slurm.config.images import (
     ClientImageInspection,
-    DistributionName,
     ImageInspectionRecord,
     ImageKind,
     ImageRef,
@@ -37,6 +36,7 @@ from data_designer.slurm.contracts import (
     ArtifactReference,
     ContractRecord,
     ContractValue,
+    DistributionName,
     Identifier,
     ModelAlias,
     RecordRange,

--- a/packages/data-designer-slurm/tests/client/conftest.py
+++ b/packages/data-designer-slurm/tests/client/conftest.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from data_designer.config import ResumeMode
+from data_designer.slurm.client.environment import PreparedClientEnvironment
+from data_designer.slurm.client.records import ClientInstallerOutcome
+from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.contracts import compute_canonical_json_sha256
+from data_designer.slurm.planning import ResolvedDependencyLock, ResolvedSlurmRunPlan
+
+GOLDEN_DIRECTORY = Path(__file__).parents[1] / "contracts" / "golden"
+
+
+@dataclass(frozen=True)
+class ClientWorkerCase:
+    plan: ResolvedSlurmRunPlan
+    plan_path: Path
+    lock: ResolvedDependencyLock
+    attempt_dir: Path
+    prepared: PreparedClientEnvironment
+    endpoints: dict[str, str]
+
+
+class FakeCreationResults:
+    def __init__(
+        self,
+        dataset_path: Path,
+        *,
+        requested: int,
+        actual: int,
+        resume: ResumeMode,
+    ) -> None:
+        self.dataset_path = dataset_path
+        self.requested_num_records = requested
+        self.actual_num_records = actual
+        self.early_shutdown = actual < requested
+        self.requested_resume_mode = resume
+        self.effective_resume_mode = ResumeMode.NEVER
+
+    def export(self, path: Path, *, format: str) -> Path:
+        assert format == "parquet"
+        pq.write_table(pa.table({"value": tuple(range(self.actual_num_records))}), path)
+        return path
+
+
+class FakeDataDesigner:
+    def __init__(
+        self,
+        *,
+        actual_records: int | None = None,
+        create_error: BaseException | None = None,
+        create_error_after_batch: BaseException | None = None,
+        effective_resume: ResumeMode = ResumeMode.NEVER,
+        **kwargs: object,
+    ) -> None:
+        self.actual_records = actual_records
+        self.create_error = create_error
+        self.create_error_after_batch = create_error_after_batch
+        self.effective_resume = effective_resume
+        self.initialization = kwargs
+        self.run_config = None
+        self.validated_builder = None
+
+    def set_run_config(self, run_config: object) -> None:
+        self.run_config = run_config
+
+    def validate(self, config_builder: object) -> None:
+        self.validated_builder = config_builder
+
+    def create(
+        self,
+        config_builder: object,
+        *,
+        num_records: int,
+        dataset_name: str,
+        resume: ResumeMode,
+        artifact_path: Path,
+        on_batch_complete: object,
+    ) -> FakeCreationResults:
+        del config_builder
+        if self.create_error is not None:
+            raise self.create_error
+        actual = num_records if self.actual_records is None else self.actual_records
+        dataset_path = artifact_path / dataset_name
+        dataset_path.mkdir(parents=True, exist_ok=True)
+        batch_path = dataset_path / "batch.parquet"
+        pq.write_table(pa.table({"value": tuple(range(actual))}), batch_path)
+        on_batch_complete(batch_path)
+        if self.create_error_after_batch is not None:
+            raise self.create_error_after_batch
+        results = FakeCreationResults(dataset_path, requested=num_records, actual=actual, resume=resume)
+        results.effective_resume_mode = self.effective_resume
+        return results
+
+
+@pytest.fixture
+def client_worker_case(tmp_path: Path) -> ClientWorkerCase:
+    workspace = tmp_path / "workspace"
+    payload = json.loads(
+        (GOLDEN_DIRECTORY / "single_node_plan.json").read_text().replace("/workspace/primary", workspace.as_posix())
+    )
+    payload["selected_profile"]["profile_sha256"] = compute_canonical_json_sha256(
+        payload["selected_profile"]["profile"]
+    )
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    lock = ResolvedDependencyLock.model_validate_json((GOLDEN_DIRECTORY / "dependency_lock_single.json").read_text())
+    plan_path = workspace / "runs" / plan.run_id / "resolved-plan.json"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text(plan.serialize_json())
+    lock_path = Path(plan.client.dependency_lock.path)
+    lock_path.write_text(lock.serialize_json())
+    Path(plan.invocation.effective_input_bindings.managed_assets_path).mkdir(parents=True)
+    shard = plan.shards[0]
+    attempt_dir = Path(shard.resume_workspace.path).parent / "attempts" / "attempt-0001"
+    overlay_path = attempt_dir / "client-env" / "site-packages"
+    overlay_path.mkdir(parents=True)
+    prepared = PreparedClientEnvironment(
+        run_id=plan.run_id,
+        shard_id=shard.shard_id,
+        attempt_id="attempt-0001",
+        attempt_dir=attempt_dir,
+        overlay_path=overlay_path,
+        dependency_lock=plan.client.dependency_lock,
+        client_image_sha256=plan.client.image.sha256,
+        python_abi=lock.python_abi,
+        installer_outcome=ClientInstallerOutcome.NOT_REQUIRED,
+        installed_distributions=tuple(
+            InstalledDistribution(name=distribution.name, version=distribution.version)
+            for distribution in lock.image_distributions
+        ),
+    )
+    endpoints = {plan.deployments[0].authored.model_alias: f"http://127.0.0.1:{plan.client.ports[0].port}/v1"}
+    return ClientWorkerCase(plan, plan_path, lock, attempt_dir, prepared, endpoints)

--- a/packages/data-designer-slurm/tests/client/conftest.py
+++ b/packages/data-designer-slurm/tests/client/conftest.py
@@ -4,18 +4,19 @@
 from __future__ import annotations
 
 import json
+import platform
 from dataclasses import dataclass
 from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from packaging.tags import interpreter_name, interpreter_version
 
 from data_designer.config import ResumeMode
 from data_designer.slurm.client.environment import PreparedClientEnvironment
 from data_designer.slurm.client.records import ClientInstallerOutcome
-from data_designer.slurm.config.images import InstalledDistribution
-from data_designer.slurm.contracts import compute_canonical_json_sha256
+from data_designer.slurm.contracts import InstalledDistribution, compute_canonical_json_sha256
 from data_designer.slurm.planning import ResolvedDependencyLock, ResolvedSlurmRunPlan
 
 GOLDEN_DIRECTORY = Path(__file__).parents[1] / "contracts" / "golden"
@@ -109,11 +110,18 @@ def client_worker_case(tmp_path: Path) -> ClientWorkerCase:
     payload = json.loads(
         (GOLDEN_DIRECTORY / "single_node_plan.json").read_text().replace("/workspace/primary", workspace.as_posix())
     )
+    python_abi = f"{interpreter_name()}{interpreter_version()}"
+    payload["client"]["image"]["inspection"]["inspection"].update(
+        {"python_abi": python_abi, "python_version": platform.python_version()}
+    )
+    lock_payload = json.loads((GOLDEN_DIRECTORY / "dependency_lock_single.json").read_text())
+    lock_payload["python_abi"] = python_abi
+    lock = ResolvedDependencyLock.model_validate_json(json.dumps(lock_payload))
+    payload["client"]["dependency_lock"]["sha256"] = lock.compute_sha256()
     payload["selected_profile"]["profile_sha256"] = compute_canonical_json_sha256(
         payload["selected_profile"]["profile"]
     )
     plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
-    lock = ResolvedDependencyLock.model_validate_json((GOLDEN_DIRECTORY / "dependency_lock_single.json").read_text())
     plan_path = workspace / "runs" / plan.run_id / "resolved-plan.json"
     plan_path.parent.mkdir(parents=True)
     plan_path.write_text(plan.serialize_json())

--- a/packages/data-designer-slurm/tests/client/test_environment.py
+++ b/packages/data-designer-slurm/tests/client/test_environment.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from conftest import ClientWorkerCase
+
+from data_designer.plugins.registry import PluginRegistry
+from data_designer.slurm.client.environment import ClientEnvironmentBuilder, inspect_distributions
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.plugins import discover_plugins
+from data_designer.slurm.client.records import ClientErrorCode, ClientInstallerOutcome
+from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+
+
+def test_environment_prepares_empty_verified_overlay(client_worker_case: ClientWorkerCase) -> None:
+    def inventory(path: Path | None) -> tuple[InstalledDistribution, ...]:
+        return client_worker_case.lock.image_distributions if path is None else ()
+
+    prepared = ClientEnvironmentBuilder(inventory=inventory).prepare(
+        client_worker_case.plan_path,
+        shard_id=client_worker_case.plan.shards[0].shard_id,
+        attempt_id="attempt-0001",
+        attempt_dir=client_worker_case.attempt_dir,
+    )
+
+    assert prepared.installer_outcome is ClientInstallerOutcome.NOT_REQUIRED
+    assert prepared.installed_distributions == client_worker_case.lock.image_distributions
+
+
+def test_inspect_distributions_omits_path_for_active_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def distributions(**kwargs: object) -> tuple[()]:
+        calls.append(kwargs)
+        return ()
+
+    monkeypatch.setattr("data_designer.slurm.client.environment.importlib.metadata.distributions", distributions)
+
+    assert inspect_distributions(None) == ()
+    assert calls == [{}]
+
+
+def test_inspect_distributions_rejects_unhashed_direct_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    distribution = Mock(
+        metadata={"Name": "example"},
+        version="1.0.0",
+    )
+    distribution.read_text.return_value = '{"url":"https://example.test/example.whl"}'
+    monkeypatch.setattr(
+        "data_designer.slurm.client.environment.importlib.metadata.distributions",
+        lambda: (distribution,),
+    )
+
+    with pytest.raises(ClientWorkerError) as error:
+        inspect_distributions(None)
+
+    assert error.value.code is ClientErrorCode.DEPENDENCY_CONFLICT
+
+
+def test_environment_rejects_client_image_inventory_conflict(client_worker_case: ClientWorkerCase) -> None:
+    conflicting = (InstalledDistribution(name="unexpected", version="1.0"),)
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientEnvironmentBuilder(inventory=lambda _: conflicting).prepare(
+            client_worker_case.plan_path,
+            shard_id=client_worker_case.plan.shards[0].shard_id,
+            attempt_id="attempt-0001",
+            attempt_dir=client_worker_case.attempt_dir,
+        )
+
+    assert error.value.code is ClientErrorCode.DEPENDENCY_CONFLICT
+
+
+@pytest.mark.parametrize(
+    ("shard_id", "attempt_id", "attempt_dir"),
+    (
+        ("../escaped", "attempt-0001", "../escaped/attempts/attempt-0001"),
+        ("shard-00000", "attempt-0000", "shard-00000/attempts/attempt-0000"),
+    ),
+)
+def test_environment_rejects_invalid_identity_before_creating_attempt(
+    client_worker_case: ClientWorkerCase,
+    shard_id: str,
+    attempt_id: str,
+    attempt_dir: str,
+) -> None:
+    path = client_worker_case.plan_path.parent / "shards" / attempt_dir
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientEnvironmentBuilder().prepare(
+            client_worker_case.plan_path,
+            shard_id=shard_id,
+            attempt_id=attempt_id,
+            attempt_dir=path,
+        )
+
+    assert error.value.code is ClientErrorCode.INVALID_INPUT
+    assert not path.exists()
+
+
+def test_environment_rejects_missing_locked_wheel(client_worker_case: ClientWorkerCase) -> None:
+    plan_payload = client_worker_case.plan.model_dump(mode="json")
+    lock_payload = client_worker_case.lock.model_dump(mode="json")
+    wheel_path = client_worker_case.plan_path.parent / "dependencies" / "missing_plugin-1.0.0-py3-none-any.whl"
+    lock_payload["authored_requirements"] = ["missing-plugin==1.0.0"]
+    lock_payload["overlay_packages"] = [
+        {
+            "name": "missing-plugin",
+            "version": "1.0.0",
+            "artifact": {"path": wheel_path.as_posix(), "sha256": "a" * 64},
+        }
+    ]
+    lock = client_worker_case.lock.model_validate_json(json.dumps(lock_payload))
+    Path(client_worker_case.plan.client.dependency_lock.path).write_text(lock.serialize_json())
+    plan_payload["client"]["dependency_lock"]["sha256"] = lock.compute_sha256()
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(plan_payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+
+    def inventory(path: Path | None) -> tuple[InstalledDistribution, ...]:
+        return lock.image_distributions if path is None else ()
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientEnvironmentBuilder(inventory=inventory).prepare(
+            client_worker_case.plan_path,
+            shard_id=plan.shards[0].shard_id,
+            attempt_id="attempt-0001",
+            attempt_dir=client_worker_case.attempt_dir,
+        )
+
+    assert error.value.code is ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING
+
+
+def test_environment_installs_verified_wheel_overlay(client_worker_case: ClientWorkerCase) -> None:
+    plan_payload = client_worker_case.plan.model_dump(mode="json")
+    lock_payload = client_worker_case.lock.model_dump(mode="json")
+    wheel_path = client_worker_case.plan_path.parent / "dependencies" / "example_plugin-1.0.0-py3-none-any.whl"
+    wheel_path.parent.mkdir()
+    wheel_path.write_bytes(b"immutable wheel artifact")
+    lock_payload["authored_requirements"] = ["example-plugin==1.0.0"]
+    lock_payload["overlay_packages"] = [
+        {
+            "name": "example-plugin",
+            "version": "1.0.0",
+            "artifact": {
+                "path": wheel_path.as_posix(),
+                "sha256": hashlib.sha256(wheel_path.read_bytes()).hexdigest(),
+            },
+        }
+    ]
+    lock = client_worker_case.lock.model_validate_json(json.dumps(lock_payload))
+    Path(client_worker_case.plan.client.dependency_lock.path).write_text(lock.serialize_json())
+    plan_payload["client"]["dependency_lock"]["sha256"] = lock.compute_sha256()
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(plan_payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    commands: list[tuple[str, ...]] = []
+
+    def inventory(path: Path | None) -> tuple[InstalledDistribution, ...]:
+        if path is None:
+            return lock.image_distributions
+        return (InstalledDistribution(name="example-plugin", version="1.0.0"),) if commands else ()
+
+    prepared = ClientEnvironmentBuilder(inventory=inventory, command_runner=commands.append).prepare(
+        client_worker_case.plan_path,
+        shard_id=plan.shards[0].shard_id,
+        attempt_id="attempt-0001",
+        attempt_dir=client_worker_case.attempt_dir,
+    )
+
+    assert prepared.installer_outcome is ClientInstallerOutcome.INSTALLED
+    assert "--no-index" in commands[0]
+    assert "--no-deps" in commands[0]
+
+
+def test_discover_plugins_loads_verified_entry_point(
+    fake_plugin_overlay: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.syspath_prepend(fake_plugin_overlay.as_posix())
+    monkeypatch.setattr("data_designer.plugins.registry.PLUGINS_DISABLED", False)
+    importlib.invalidate_caches()
+    PluginRegistry.reset()
+
+    plugins = discover_plugins((InstalledDistribution(name="fake-data-designer-plugin", version="1.0.0"),))
+
+    assert len(plugins) == 1
+    assert plugins[0].plugin_name == "fake-slurm-column"
+    PluginRegistry.reset()

--- a/packages/data-designer-slurm/tests/client/test_environment.py
+++ b/packages/data-designer-slurm/tests/client/test_environment.py
@@ -6,18 +6,19 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 from conftest import ClientWorkerCase
 
-from data_designer.plugins.registry import PluginRegistry
 from data_designer.slurm.client.environment import ClientEnvironmentBuilder, inspect_distributions
 from data_designer.slurm.client.errors import ClientWorkerError
 from data_designer.slurm.client.plugins import discover_plugins
 from data_designer.slurm.client.records import ClientErrorCode, ClientInstallerOutcome
-from data_designer.slurm.config.images import InstalledDistribution
+from data_designer.slurm.contracts import InstalledDistribution
 from data_designer.slurm.planning import ResolvedSlurmRunPlan
 
 
@@ -185,12 +186,60 @@ def test_discover_plugins_loads_verified_entry_point(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.syspath_prepend(fake_plugin_overlay.as_posix())
-    monkeypatch.setattr("data_designer.plugins.registry.PLUGINS_DISABLED", False)
     importlib.invalidate_caches()
-    PluginRegistry.reset()
 
     plugins = discover_plugins((InstalledDistribution(name="fake-data-designer-plugin", version="1.0.0"),))
 
     assert len(plugins) == 1
     assert plugins[0].plugin_name == "fake-slurm-column"
-    PluginRegistry.reset()
+
+
+def test_worker_bootstrap_loads_overlay_plugin_before_config_import(
+    fake_plugin_overlay: Path,
+    tmp_path: Path,
+) -> None:
+    script = """
+import sys
+from pathlib import Path
+
+import data_designer.slurm.client.worker as worker
+
+assert "data_designer.config.column_types" not in sys.modules
+from data_designer.slurm.client.environment import PreparedClientEnvironment
+from data_designer.slurm.client.records import ClientInstallerOutcome
+from data_designer.slurm.contracts import ArtifactReference, InstalledDistribution
+
+prepared = PreparedClientEnvironment(
+    run_id="run-test",
+    shard_id="shard-00000",
+    attempt_id="attempt-0001",
+    attempt_dir=Path(sys.argv[2]),
+    overlay_path=Path(sys.argv[1]),
+    dependency_lock=ArtifactReference(path=(Path(sys.argv[2]) / "dependency-lock.json").as_posix(), sha256="a" * 64),
+    client_image_sha256="b" * 64,
+    python_abi="test",
+    installer_outcome=ClientInstallerOutcome.REUSED,
+    installed_distributions=(InstalledDistribution(name="fake-data-designer-plugin", version="1.0.0"),),
+)
+worker.activate_environment(prepared)
+
+from data_designer.slurm.client.plugins import discover_plugins
+
+plugins = discover_plugins(prepared.installed_distributions)
+assert plugins[0].plugin_name == "fake-slurm-column"
+
+from data_designer.config import DataDesignerConfigBuilder
+
+builder = DataDesignerConfigBuilder.from_config(
+    {"data_designer": {"columns": [{"name": "custom", "column_type": "fake-slurm-column"}], "model_configs": []}}
+)
+assert builder.get_column_configs()[0].column_type == "fake-slurm-column"
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, fake_plugin_overlay.as_posix(), (tmp_path / "attempt").as_posix()],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/packages/data-designer-slurm/tests/client/test_filesystem.py
+++ b/packages/data-designer-slurm/tests/client/test_filesystem.py
@@ -7,8 +7,9 @@ from pathlib import Path
 
 import pytest
 
+import data_designer.slurm.client.filesystem as filesystem_module
 from data_designer.slurm.client.errors import ClientWorkerError
-from data_designer.slurm.client.filesystem import ensure_private_directory, publish_private_text
+from data_designer.slurm.client.filesystem import ensure_private_directory, publish_private_text, replace_private_text
 from data_designer.slurm.client.records import ClientErrorCode
 
 
@@ -24,6 +25,48 @@ def test_ensure_private_directory_rejects_symlink(tmp_path: Path) -> None:
     assert error.value.code is ClientErrorCode.INVALID_INPUT
 
 
+def test_ensure_private_directory_does_not_follow_intermediate_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ClientWorkerError) as error:
+        ensure_private_directory(link / "nested")
+
+    assert error.value.code is ClientErrorCode.INVALID_INPUT
+    assert not (target / "nested").exists()
+
+
+@pytest.mark.parametrize("operation_name", ("read_regular_bytes", "compute_file_sha256"))
+def test_regular_file_operation_rejects_swap_to_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation_name: str,
+) -> None:
+    path = tmp_path / "input.json"
+    path.write_text("original")
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text("replacement")
+    original_open = filesystem_module.os.open
+    swapped = False
+
+    def swapping_open(name: object, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        nonlocal swapped
+        if name == path.name and dir_fd is not None and not swapped:
+            swapped = True
+            path.unlink()
+            path.symlink_to(replacement)
+        return original_open(name, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(filesystem_module.os, "open", swapping_open)
+
+    with pytest.raises(ClientWorkerError) as error:
+        getattr(filesystem_module, operation_name)(path, missing_code=ClientErrorCode.INVALID_INPUT)
+
+    assert error.value.code is ClientErrorCode.INVALID_INPUT
+
+
 def test_publish_private_text_is_convergent_and_immutable(tmp_path: Path) -> None:
     path = tmp_path / "record.json"
     publish_private_text(path, "same")
@@ -34,3 +77,20 @@ def test_publish_private_text_is_convergent_and_immutable(tmp_path: Path) -> Non
 
     assert error.value.code is ClientErrorCode.OUTPUT_INVALID
     assert path.read_text() == "same"
+
+
+@pytest.mark.parametrize("interruption", (KeyboardInterrupt, SystemExit))
+def test_replace_private_text_cleans_temporary_file_on_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: type[BaseException],
+) -> None:
+    def interrupt_write(_descriptor: int, _payload: object) -> int:
+        raise interruption
+
+    monkeypatch.setattr(filesystem_module.os, "write", interrupt_write)
+
+    with pytest.raises(interruption):
+        replace_private_text(tmp_path / "record.json", "value")
+
+    assert not tuple(tmp_path.glob(".client.*.tmp"))

--- a/packages/data-designer-slurm/tests/client/test_filesystem.py
+++ b/packages/data-designer-slurm/tests/client/test_filesystem.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.filesystem import ensure_private_directory, publish_private_text
+from data_designer.slurm.client.records import ClientErrorCode
+
+
+def test_ensure_private_directory_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ClientWorkerError) as error:
+        ensure_private_directory(link)
+
+    assert error.value.code is ClientErrorCode.INVALID_INPUT
+
+
+def test_publish_private_text_is_convergent_and_immutable(tmp_path: Path) -> None:
+    path = tmp_path / "record.json"
+    publish_private_text(path, "same")
+    publish_private_text(path, "same")
+
+    with pytest.raises(ClientWorkerError) as error:
+        publish_private_text(path, "different")
+
+    assert error.value.code is ClientErrorCode.OUTPUT_INVALID
+    assert path.read_text() == "same"

--- a/packages/data-designer-slurm/tests/client/test_worker.py
+++ b/packages/data-designer-slurm/tests/client/test_worker.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
@@ -24,7 +26,7 @@ from data_designer.slurm.client.records import (
     ClientResult,
 )
 from data_designer.slurm.contracts import compute_serialized_json_sha256
-from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.planning import ResolvedDependencyLock, ResolvedSlurmRunPlan
 from data_designer.slurm.state import CandidateOutputManifest
 
 
@@ -269,6 +271,123 @@ def test_preflight_rejects_builder_with_missing_plugin(client_worker_case: Clien
     payload = client_worker_case.plan.model_dump(mode="json")
     builder = payload["builder"]["inline"]
     builder["data_designer"]["columns"] = [{"name": "custom", "column_type": "missing-plugin"}]
+    payload["builder"]["content_sha256"] = compute_serialized_json_sha256(builder)
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientWorker(data_designer_factory=FakeDataDesigner).preflight(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.CONFIG_INVALID
+
+
+def test_preflight_rejects_plugin_secondary_model_alias(
+    client_worker_case: ClientWorkerCase,
+    fake_plugin_overlay: Path,
+) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    builder = payload["builder"]["inline"]
+    builder["data_designer"]["columns"] = [{"name": "custom", "column_type": "fake-slurm-column"}]
+    payload["builder"]["content_sha256"] = compute_serialized_json_sha256(builder)
+    lock_payload = client_worker_case.lock.model_dump(mode="json")
+    wheel_path = (
+        client_worker_case.plan_path.parent / "dependencies" / "fake_data_designer_plugin-1.0.0-py3-none-any.whl"
+    )
+    lock_payload["authored_requirements"] = ["fake-data-designer-plugin==1.0.0"]
+    lock_payload["overlay_packages"] = [
+        {
+            "name": "fake-data-designer-plugin",
+            "version": "1.0.0",
+            "artifact": {"path": wheel_path.as_posix(), "sha256": "a" * 64},
+        }
+    ]
+    lock = ResolvedDependencyLock.model_validate_json(json.dumps(lock_payload))
+    Path(client_worker_case.plan.client.dependency_lock.path).write_text(lock.serialize_json())
+    payload["client"]["dependency_lock"]["sha256"] = lock.compute_sha256()
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    script = """
+import json
+import sys
+from pathlib import Path
+
+import data_designer.slurm.client.worker as worker
+from data_designer.slurm.client.environment import PreparedClientEnvironment
+from data_designer.slurm.client.records import ClientErrorCode, ClientInstallerOutcome
+from data_designer.slurm.contracts import ArtifactReference, InstalledDistribution
+
+plan_path = Path(sys.argv[1])
+attempt_dir = Path(sys.argv[2])
+plan = json.loads(plan_path.read_text())
+lock = json.loads(Path(plan["client"]["dependency_lock"]["path"]).read_text())
+installed = tuple(
+    sorted(
+        (
+            *(InstalledDistribution(**item) for item in lock["image_distributions"]),
+            *(InstalledDistribution(name=item["name"], version=item["version"]) for item in lock["overlay_packages"]),
+        ),
+        key=lambda item: item.name,
+    )
+)
+prepared = PreparedClientEnvironment(
+    run_id=plan["run_id"],
+    shard_id=plan["shards"][0]["shard_id"],
+    attempt_id="attempt-0001",
+    attempt_dir=attempt_dir,
+    overlay_path=Path(sys.argv[3]),
+    dependency_lock=ArtifactReference(**plan["client"]["dependency_lock"]),
+    client_image_sha256=plan["client"]["image"]["sha256"],
+    python_abi=lock["python_abi"],
+    installer_outcome=ClientInstallerOutcome.REUSED,
+    installed_distributions=installed,
+)
+worker.activate_environment(prepared)
+
+from data_designer.slurm.client.plugins import discover_plugins
+
+plugins = discover_plugins(installed)
+from data_designer.slurm.client.execution import ClientWorker
+from data_designer.slurm.client.errors import ClientWorkerError
+
+try:
+    ClientWorker().preflight(
+        plan_path,
+        prepared=prepared,
+        endpoints={"generator": "http://127.0.0.1:17000/v1"},
+        plugins=plugins,
+    )
+except ClientWorkerError as error:
+    assert error.code is ClientErrorCode.CONFIG_INVALID
+    assert error.redacted_message == "builder references unavailable model aliases"
+else:
+    raise AssertionError("preflight accepted a missing secondary model alias")
+"""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            client_worker_case.plan_path.as_posix(),
+            client_worker_case.attempt_dir.as_posix(),
+            fake_plugin_overlay.as_posix(),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_preflight_rejects_profiler_model_alias(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    builder = payload["builder"]["inline"]
+    builder["data_designer"]["profilers"] = [{"model_alias": "missing"}]
     payload["builder"]["content_sha256"] = compute_serialized_json_sha256(builder)
     plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
     client_worker_case.plan_path.write_text(plan.serialize_json())

--- a/packages/data-designer-slurm/tests/client/test_worker.py
+++ b/packages/data-designer-slurm/tests/client/test_worker.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from functools import partial
+from pathlib import Path
+
+import pytest
+from conftest import ClientWorkerCase, FakeDataDesigner
+
+from data_designer.config import ResumeMode
+from data_designer.slurm.client.errors import ClientWorkerError
+from data_designer.slurm.client.execution import ClientWorker
+from data_designer.slurm.client.records import (
+    ClientEnvironmentManifest,
+    ClientEnvironmentOutcome,
+    ClientErrorCode,
+    ClientOutcome,
+    ClientProgress,
+    ClientProgressPhase,
+    ClientResult,
+)
+from data_designer.slurm.contracts import compute_serialized_json_sha256
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.state import CandidateOutputManifest
+
+
+def test_preflight_materializes_endpoint_and_ready_environment(client_worker_case: ClientWorkerCase) -> None:
+    designers: list[FakeDataDesigner] = []
+
+    def factory(**kwargs: object) -> FakeDataDesigner:
+        designer = FakeDataDesigner(**kwargs)
+        designers.append(designer)
+        return designer
+
+    manifest = ClientWorker(data_designer_factory=factory).preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert manifest.outcome is ClientEnvironmentOutcome.READY
+    assert designers[0].validated_builder is not None
+    model_config = designers[0].validated_builder.model_configs[0]
+    assert model_config.model == client_worker_case.plan.deployments[0].served_model_name
+    assert model_config.provider == "slurm-generator"
+    assert designers[0].initialization["model_providers"][0].endpoint == next(
+        iter(client_worker_case.endpoints.values())
+    )
+
+
+def test_preflight_rejects_missing_managed_assets(client_worker_case: ClientWorkerCase) -> None:
+    Path(client_worker_case.plan.invocation.effective_input_bindings.managed_assets_path).rmdir()
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientWorker(data_designer_factory=FakeDataDesigner).preflight(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.CONFIG_INVALID
+    manifest = ClientEnvironmentManifest.model_validate_json(
+        (client_worker_case.attempt_dir / "client-environment.json").read_text()
+    )
+    assert manifest.outcome is ClientEnvironmentOutcome.FAILED
+
+
+@pytest.mark.parametrize(
+    ("record_delta", "expected_outcome"),
+    ((0, ClientOutcome.COMPLETE), (-1, ClientOutcome.PARTIAL)),
+)
+def test_run_persists_semantic_result_and_candidate(
+    client_worker_case: ClientWorkerCase,
+    record_delta: int,
+    expected_outcome: ClientOutcome,
+) -> None:
+    actual_records = client_worker_case.plan.shards[0].requested_records + record_delta
+    worker = ClientWorker(data_designer_factory=partial(FakeDataDesigner, actual_records=actual_records))
+    worker.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+    result = worker.run(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert result.outcome is expected_outcome
+    assert result.actual_records == actual_records
+    persisted = ClientResult.model_validate_json((client_worker_case.attempt_dir / "client-result.json").read_text())
+    candidate = CandidateOutputManifest.model_validate_json(
+        (client_worker_case.attempt_dir / "output-manifest.json").read_text()
+    )
+    progress = ClientProgress.model_validate_json((client_worker_case.attempt_dir / "client-progress.json").read_text())
+    assert persisted == result
+    assert candidate.actual_records == actual_records
+    assert result.candidate_output_manifest.sha256 == candidate.compute_sha256()
+    assert progress.phase is ClientProgressPhase.COMPLETE
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    (
+        (RuntimeError("credential=do-not-persist"), ClientErrorCode.GENERATION_FAILED),
+        (KeyboardInterrupt(), ClientErrorCode.INTERRUPTED),
+    ),
+)
+def test_run_normalizes_generation_failures(
+    client_worker_case: ClientWorkerCase,
+    failure: BaseException,
+    expected_code: ClientErrorCode,
+) -> None:
+    worker = ClientWorker(data_designer_factory=partial(FakeDataDesigner, create_error=failure))
+    worker.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    with pytest.raises(ClientWorkerError) as error:
+        worker.run(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is expected_code
+    persisted = (client_worker_case.attempt_dir / "client-result.json").read_text()
+    assert "do-not-persist" not in persisted
+    assert ClientResult.model_validate_json(persisted).error_code == expected_code.value
+
+
+def test_preflight_rejects_required_resume_without_workspace(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    payload["invocation"]["authored"]["resume"] = "always"
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientWorker(data_designer_factory=FakeDataDesigner).preflight(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.CONFIG_INVALID
+
+
+def test_run_relocates_completed_resume_downgrade(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    payload["invocation"]["authored"]["resume"] = "always"
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    resume_path = Path(plan.shards[0].resume_workspace.path)
+    resume_path.mkdir()
+    (resume_path / "partial").touch()
+    worker = ClientWorker(data_designer_factory=FakeDataDesigner)
+    worker.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    result = worker.run(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert result.effective_resume_mode == "never"
+    assert not resume_path.exists()
+    assert (client_worker_case.attempt_dir / "dataset").is_dir()
+
+
+def test_if_possible_without_workspace_uses_attempt_dataset(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    payload["invocation"]["authored"]["resume"] = "if_possible"
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    worker = ClientWorker(data_designer_factory=FakeDataDesigner)
+    worker.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    result = worker.run(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert result.requested_resume_mode == "if_possible"
+    assert result.effective_resume_mode == "never"
+    assert result.dataset_path == (client_worker_case.attempt_dir / "dataset").as_posix()
+
+
+def test_if_possible_interruption_preserves_workspace_for_retry(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    payload["invocation"]["authored"]["resume"] = "if_possible"
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    interrupted = ClientWorker(
+        data_designer_factory=partial(FakeDataDesigner, create_error_after_batch=KeyboardInterrupt())
+    )
+    interrupted.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    with pytest.raises(ClientWorkerError):
+        interrupted.run(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    resume_path = Path(plan.shards[0].resume_workspace.path)
+    assert (resume_path / "batch.parquet").is_file()
+    attempt_dir = resume_path.parent / "attempts" / "attempt-0002"
+    overlay_path = attempt_dir / "client-env" / "site-packages"
+    overlay_path.mkdir(parents=True)
+    prepared = replace(
+        client_worker_case.prepared,
+        attempt_id="attempt-0002",
+        attempt_dir=attempt_dir,
+        overlay_path=overlay_path,
+    )
+    retry = ClientWorker(data_designer_factory=partial(FakeDataDesigner, effective_resume=ResumeMode.ALWAYS))
+    retry.preflight(
+        client_worker_case.plan_path,
+        prepared=prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    result = retry.run(
+        client_worker_case.plan_path,
+        prepared=prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert result.effective_resume_mode == "always"
+    assert result.dataset_path == resume_path.as_posix()
+
+
+def test_preflight_rejects_builder_with_missing_plugin(client_worker_case: ClientWorkerCase) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    builder = payload["builder"]["inline"]
+    builder["data_designer"]["columns"] = [{"name": "custom", "column_type": "missing-plugin"}]
+    payload["builder"]["content_sha256"] = compute_serialized_json_sha256(builder)
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientWorker(data_designer_factory=FakeDataDesigner).preflight(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.CONFIG_INVALID
+
+
+def test_preflight_keeps_mcp_secret_out_of_records(
+    client_worker_case: ClientWorkerCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = client_worker_case.plan.model_dump(mode="json")
+    payload["invocation"]["authored"]["mcp_providers"] = [
+        {
+            "provider_type": "sse",
+            "name": "private-mcp",
+            "endpoint": "https://mcp.example.test/events",
+            "api_key": {"type": "secret", "environment": "WORKER_SECRET"},
+        }
+    ]
+    plan = ResolvedSlurmRunPlan.model_validate_json(json.dumps(payload))
+    client_worker_case.plan_path.write_text(plan.serialize_json())
+    monkeypatch.setenv("WORKER_SECRET", "private-value")
+    designers: list[FakeDataDesigner] = []
+
+    def factory(**kwargs: object) -> FakeDataDesigner:
+        designer = FakeDataDesigner(**kwargs)
+        designers.append(designer)
+        return designer
+
+    ClientWorker(data_designer_factory=factory).preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    assert designers[0].initialization["mcp_providers"][0].api_key == "private-value"
+    assert "private-value" not in (client_worker_case.attempt_dir / "client-environment.json").read_text()

--- a/packages/data-designer-slurm/tests/client/test_worker.py
+++ b/packages/data-designer-slurm/tests/client/test_worker.py
@@ -9,10 +9,13 @@ import sys
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from conftest import ClientWorkerCase, FakeDataDesigner
 
+import data_designer.slurm.client.worker as worker_module
 from data_designer.config import ResumeMode
 from data_designer.slurm.client.errors import ClientWorkerError
 from data_designer.slurm.client.execution import ClientWorker
@@ -71,6 +74,60 @@ def test_preflight_rejects_missing_managed_assets(client_worker_case: ClientWork
         (client_worker_case.attempt_dir / "client-environment.json").read_text()
     )
     assert manifest.outcome is ClientEnvironmentOutcome.FAILED
+
+
+def test_preflight_normalizes_context_construction_failure(client_worker_case: ClientWorkerCase) -> None:
+    def factory(**_: object) -> FakeDataDesigner:
+        raise RuntimeError("credential=do-not-persist")
+
+    with pytest.raises(ClientWorkerError) as error:
+        ClientWorker(data_designer_factory=factory).preflight(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.CONFIG_INVALID
+    persisted = (client_worker_case.attempt_dir / "client-environment.json").read_text()
+    assert "do-not-persist" not in persisted
+    assert ClientEnvironmentManifest.model_validate_json(persisted).error_code == ClientErrorCode.CONFIG_INVALID.value
+
+
+def test_main_preserves_equals_in_model_alias(
+    client_worker_case: ClientWorkerCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_builder = Mock()
+    environment_builder.prepare.return_value = client_worker_case.prepared
+    worker = Mock()
+    modules = {
+        "data_designer.slurm.client.plugins": SimpleNamespace(discover_plugins=lambda _: ()),
+        "data_designer.slurm.client.execution": SimpleNamespace(ClientWorker=lambda: worker),
+    }
+    monkeypatch.setattr(worker_module, "ClientEnvironmentBuilder", lambda: environment_builder)
+    monkeypatch.setattr(worker_module, "activate_environment", lambda _: None)
+    monkeypatch.setattr(worker_module, "importlib", SimpleNamespace(import_module=modules.__getitem__))
+    endpoint = "http://127.0.0.1:17000/v1"
+
+    result = worker_module.main(
+        [
+            "preflight",
+            "--plan",
+            client_worker_case.plan_path.as_posix(),
+            "--shard-id",
+            client_worker_case.prepared.shard_id,
+            "--attempt-id",
+            client_worker_case.prepared.attempt_id,
+            "--attempt-dir",
+            client_worker_case.attempt_dir.as_posix(),
+            "--endpoint",
+            f"judge=v2={endpoint}",
+        ]
+    )
+
+    assert result == 0
+    assert worker.preflight.call_args.kwargs["endpoints"] == {"judge=v2": endpoint}
 
 
 @pytest.mark.parametrize(
@@ -142,6 +199,29 @@ def test_run_normalizes_generation_failures(
     persisted = (client_worker_case.attempt_dir / "client-result.json").read_text()
     assert "do-not-persist" not in persisted
     assert ClientResult.model_validate_json(persisted).error_code == expected_code.value
+
+
+def test_run_rejects_overcount_as_invalid_output(client_worker_case: ClientWorkerCase) -> None:
+    actual_records = client_worker_case.plan.shards[0].requested_records + 1
+    worker = ClientWorker(data_designer_factory=partial(FakeDataDesigner, actual_records=actual_records))
+    worker.preflight(
+        client_worker_case.plan_path,
+        prepared=client_worker_case.prepared,
+        endpoints=client_worker_case.endpoints,
+        plugins=(),
+    )
+
+    with pytest.raises(ClientWorkerError) as error:
+        worker.run(
+            client_worker_case.plan_path,
+            prepared=client_worker_case.prepared,
+            endpoints=client_worker_case.endpoints,
+            plugins=(),
+        )
+
+    assert error.value.code is ClientErrorCode.OUTPUT_INVALID
+    persisted = ClientResult.model_validate_json((client_worker_case.attempt_dir / "client-result.json").read_text())
+    assert persisted.error_code == ClientErrorCode.OUTPUT_INVALID.value
 
 
 def test_preflight_rejects_required_resume_without_workspace(client_worker_case: ClientWorkerCase) -> None:

--- a/packages/data-designer-slurm/tests/contracts/test_shared_records.py
+++ b/packages/data-designer-slurm/tests/contracts/test_shared_records.py
@@ -156,6 +156,13 @@ def test_if_possible_uses_effective_resume_dataset_location(
     assert ClientResult.model_validate_json(json.dumps(payload)).dataset_path == dataset_path
 
 
+def test_always_allows_engine_resume_downgrade(client_result_payload: dict[str, object]) -> None:
+    payload = deepcopy(client_result_payload)
+    payload["requested_resume_mode"] = "always"
+
+    assert ClientResult.model_validate_json(json.dumps(payload)).effective_resume_mode == "never"
+
+
 def test_benchmark_manifest_rejects_duplicate_child_identity() -> None:
     payload = {
         "schema_version": 1,

--- a/packages/data-designer-slurm/tests/fixtures/fake_plugin_overlay/fake_data_designer_plugin/plugin.py
+++ b/packages/data-designer-slurm/tests/fixtures/fake_plugin_overlay/fake_data_designer_plugin/plugin.py
@@ -13,6 +13,19 @@ class FakePluginConfig(SingleColumnConfig):
     """Minimal custom column configuration."""
 
     column_type: Literal["fake-slurm-column"] = "fake-slurm-column"
+    model_alias: str = "generator"
+    judge_model_alias: str = "judge"
+
+    @property
+    def required_columns(self) -> list[str]:
+        return []
+
+    @property
+    def side_effect_columns(self) -> list[str]:
+        return []
+
+    def get_model_aliases(self) -> list[str]:
+        return [self.model_alias, self.judge_model_alias]
 
 
 class FakePluginImplementation:


### PR DESCRIPTION
## Summary

- prepare exact allocation-local client environments from immutable wheels
- validate plugins, configuration, and assets before generation using public DataDesigner APIs
- persist semantic result, progress, environment, and candidate artifacts with resume and interruption support

## Validation

- `.venv/bin/ruff check --fix .`
- `.venv/bin/ruff format .`
- Slurm test suite: 1093 passed
- isolated wheel installation and CLI startup benchmark
- PDX login node 2: preflight job 6847753, run job 6847754, verification job 6847756

Closes #876
