### PR TITLE
docs: add install dependency notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Data Designer helps you create synthetic datasets that go beyond simple LLM prom
 pip install data-designer
 ```
 
+> [!NOTE]
+> This project will download and install additional third-party open source
+> software projects. Review the license terms of these open source projects
+> before use.
+
 Or install from source:
 
 ```bash

--- a/fern/versions/latest/pages/index.mdx
+++ b/fern/versions/latest/pages/index.mdx
@@ -28,6 +28,10 @@ Unlike raw LLM calls, Data Designer gives you statistical diversity, field corre
 pip install data-designer
 ```
 
+<Note>
+This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use.
+</Note>
+
 ## Setup
 
 Get an API key from one of the default providers and set it as an environment variable:


### PR DESCRIPTION
## 📋 Summary

Adds the required third-party open source software notice to both canonical installation surfaces: the Fern welcome page and the root README used as the PyPI long description. This reminds users to review dependency license terms before use wherever they encounter the primary install instructions.

## 🔗 Related Issue

N/A

## 🔄 Changes

- Add a Fern note directly below `pip install data-designer` on the documentation welcome page.
- Mirror the exact disclosure below the root README install block using a GitHub and PyPI-readable note.
- Leave secondary install references unchanged to avoid repeating the disclosure outside the canonical install surfaces.

## 🧪 Testing

- [x] `make check-fern-docs` passes
- [x] Internal links validated across 86 Fern pages
- [x] Fern MDX validation passes with 0 errors
- [ ] `make test` — N/A (documentation-only change)
- [ ] Unit tests added/updated — N/A (no testable logic)
- [ ] E2E tests added/updated — N/A (documentation-only change)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A (not applicable)

---
*Description updated with AI*