### PR TITLE
feat: add streaming chat completions

### DIFF
--- a/fern/versions/latest/pages/concepts/models/inference-parameters.mdx
+++ b/fern/versions/latest/pages/concepts/models/inference-parameters.mdx
@@ -20,8 +20,9 @@ The `ChatCompletionInferenceParams` class controls how models generate text comp
 | `temperature` | `float` or `Distribution` | No | Controls randomness in generation (0.0 to 2.0). Higher values = more creative/random |
 | `top_p` | `float` or `Distribution` | No | Nucleus sampling parameter (0.0 to 1.0). Controls diversity by filtering low-probability tokens |
 | `max_tokens` | `int` | No | Maximum number of tokens to generate in the response (≥ 1) |
+| `stream` | `bool` | No | Enable [streaming responses](#streaming-responses), assembled internally into a complete result (default: `False`). |
 | `max_parallel_requests` | `int` | No | Maximum concurrent API requests to this model (default: 4, ≥ 1). See [Concurrency Control](#concurrency-control) below. |
-| `timeout` | `int` | No | API request timeout in seconds (≥ 1) |
+| `timeout` | `int` | No | API operation timeout in seconds (≥ 1). During streaming reads, limits inactivity between reads. |
 | `extra_body` | `dict[str, Any]` | No | Additional parameters to include in the API request body |
 
 <Note>
@@ -52,6 +53,47 @@ inference_parameters = dd.ChatCompletionInferenceParams(
 )
 ```
 </Tip>
+
+### Streaming Responses
+
+Set `stream=True` in `ChatCompletionInferenceParams` to receive the model response
+incrementally over server-sent events (SSE). Streaming is disabled by default.
+Use your existing model ID and configured provider name:
+
+```python
+import data_designer.config as dd
+
+model_config = dd.ModelConfig(
+    alias="streaming-model",
+    model="your-model-id",
+    provider="your-provider",
+    inference_parameters=dd.ChatCompletionInferenceParams(
+        stream=True,
+        timeout=120,  # Maximum inactivity between network reads, in seconds.
+    ),
+)
+```
+
+Pass this configuration to your builder's `model_configs` and reference
+`model_alias="streaming-model"` in text, code, structured-output, or judge columns.
+See [Model Providers](/concepts/models/model-providers) for provider setup.
+
+- **Supported providers:** OpenAI-compatible (`provider_type="openai"`) and Anthropic
+  Messages (`provider_type="anthropic"`) endpoints that support SSE, with both synchronous
+  and asynchronous generation.
+- **Returned results:** Data Designer assembles the complete response before parsing
+  structured output, executing tool calls, or writing the row. Your code receives the
+  same complete results and dataset format, rather than a token iterator.
+- **Timeouts:** With `timeout=120`, a streaming read can wait up to 120 seconds for more
+  data. The full response can take longer while data continues to arrive. If a stream
+  ends prematurely, its partial result is discarded and the existing retry policy
+  applies to a fresh request.
+
+<Note>
+OpenAI-compatible streaming requests ask for token usage with
+`stream_options={"include_usage": True}`. If your endpoint rejects this option, add
+`extra_body={"stream_options": None}` to `ChatCompletionInferenceParams` to omit it.
+</Note>
 
 ### Temperature and Top P Guidelines
 

--- a/packages/data-designer-config/src/data_designer/config/models.py
+++ b/packages/data-designer-config/src/data_designer/config/models.py
@@ -497,16 +497,23 @@ class ChatCompletionInferenceParams(BaseInferenceParams):
         temperature: Sampling temperature (0.0-2.0). Can be a fixed value or a distribution for dynamic sampling.
         top_p: Nucleus sampling probability (0.0-1.0). Can be a fixed value or a distribution for dynamic sampling.
         max_tokens: Maximum number of tokens to generate in the response.
+        stream: Receive chat responses incrementally over SSE, then return the complete
+            result to the generation pipeline. The timeout limits network inactivity,
+            not the total duration of an actively streaming response.
     """
 
     generation_type: Literal[GenerationType.CHAT_COMPLETION] = GenerationType.CHAT_COMPLETION
     temperature: float | DistributionT | None = None
     top_p: float | DistributionT | None = None
     max_tokens: int | None = Field(default=None, ge=1)
+    stream: bool = False
 
     @property
     def generate_kwargs(self) -> dict[str, Any]:
+        """Return sampled chat parameters, enabling streaming only when requested."""
         result = super().generate_kwargs
+        if self.stream:
+            result["stream"] = True
         if self.temperature is not None:
             result["temperature"] = (
                 self.temperature.sample() if hasattr(self.temperature, "sample") else self.temperature

--- a/packages/data-designer-config/tests/config/test_models.py
+++ b/packages/data-designer-config/tests/config/test_models.py
@@ -820,7 +820,8 @@ def test_get_formatted_params():
     result = params.get_formatted_params()
 
     assert isinstance(result, list)
-    assert len(result) == 5  # generation_type, max_parallel_requests, temperature, top_p, max_tokens
+    assert len(result) == 6  # generation_type, max_parallel_requests, temperature, top_p, max_tokens, stream
+    assert "stream=False" in result
 
     assert any("generation_type=chat-completion" in part for part in result)
     assert any("temperature=0.70" in part for part in result)

--- a/packages/data-designer-config/tests/config/test_streaming.py
+++ b/packages/data-designer-config/tests/config/test_streaming.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_streaming_config_round_trip_and_request_parameters(stream: bool) -> None:
+    """A stream flag survives config serialization and enables incremental chat transport."""
+    config = ModelConfig(
+        alias="test", model="test", provider="test", inference_parameters=ChatCompletionInferenceParams(stream=stream)
+    )
+    restored = ModelConfig.model_validate_json(config.model_dump_json())
+    assert restored.inference_parameters.stream is stream
+    assert restored.inference_parameters.generate_kwargs.get("stream", False) is stream
+
+
+def test_streaming_is_opt_in() -> None:
+    """Default inference kwargs preserve the existing provider request body."""
+    assert "stream" not in ChatCompletionInferenceParams().generate_kwargs

--- a/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/custom.py
+++ b/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/custom.py
@@ -149,7 +149,11 @@ class _AsyncBridgedModelFacade:
                 raise asyncio.CancelledError from exc
             except concurrent.futures.TimeoutError as exc:
                 if future.done():
-                    raise  # The coroutine itself raised TimeoutError; this is not a polling timeout.
+                    # Completion can race with a polling timeout; retrieve the actual result or error.
+                    try:
+                        return future.result()
+                    except concurrent.futures.CancelledError as cancelled:
+                        raise asyncio.CancelledError from cancelled
                 if is_run_cancellation_requested():
                     future.cancel()
                     raise asyncio.CancelledError from exc

--- a/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/custom.py
+++ b/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/custom.py
@@ -68,6 +68,21 @@ class _AsyncBridgedModelFacade:
         object.__setattr__(self, "_facade", facade)
 
     def generate(self, *args: Any, **kwargs: Any) -> tuple[Any, list]:
+        """Generate through the wrapped model, bridging async clients from a worker thread.
+
+        Args:
+            *args: Positional arguments forwarded to ModelFacade.generate/agenerate.
+            **kwargs: Generation parameters and per-call inference overrides.
+
+        Returns:
+            Parsed model output and conversation trace. Streaming calls rely on HTTP
+            inactivity timeouts while the bridge continues polling for run cancellation.
+
+        Raises:
+            ModelTimeoutError: If a non-streaming bridge exceeds its derived deadline.
+            asyncio.CancelledError: If the run is cancelled, also cancelling the model call.
+            RuntimeError: If a synchronous bridge is attempted from the event loop.
+        """
         from data_designer.engine.models.clients.errors import SyncClientUnavailableError
 
         facade = object.__getattribute__(self, "_facade")
@@ -101,11 +116,15 @@ class _AsyncBridgedModelFacade:
         correction_steps = int(kwargs.get("max_correction_steps", 0) or 0)
         conversation_restarts = int(kwargs.get("max_conversation_restarts", 0) or 0)
         bridge_timeout = _compute_bridge_timeout(per_request_timeout, correction_steps, conversation_restarts)
+        if facade.is_streaming_enabled(**kwargs) is True:
+            # A read timeout bounds silence between chunks, not the response's total duration.
+            bridge_timeout = float("inf")
 
         if is_run_cancellation_requested():
             raise asyncio.CancelledError
 
         async def agenerate_with_cancellation_check() -> tuple[Any, list]:
+            """Return the forwarded async generation, or propagate cancellation before starting I/O."""
             if is_run_cancellation_requested():
                 raise asyncio.CancelledError
             return await facade.agenerate(*args, **kwargs)
@@ -129,6 +148,8 @@ class _AsyncBridgedModelFacade:
             except concurrent.futures.CancelledError as exc:
                 raise asyncio.CancelledError from exc
             except concurrent.futures.TimeoutError as exc:
+                if future.done():
+                    raise  # The coroutine itself raised TimeoutError; this is not a polling timeout.
                 if is_run_cancellation_requested():
                     future.cancel()
                     raise asyncio.CancelledError from exc

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/anthropic.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from data_designer.engine.models.clients.adapters.anthropic_translation import (
     UnsupportedAnthropicMediaBlockError,
     build_anthropic_payload,
@@ -17,6 +15,7 @@ from data_designer.engine.models.clients.errors import (
     ProviderError,
     ProviderErrorKind,
 )
+from data_designer.engine.models.clients.streaming import AnthropicMessageStream
 from data_designer.engine.models.clients.types import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -71,20 +70,43 @@ class AnthropicClient(HttpModelClient):
     # -------------------------------------------------------------------
 
     def completion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        payload = self._build_payload_or_raise(request)
-        transport = TransportKwargs.from_request(request, exclude=self._TRANSPORT_EXCLUDE)
-        payload.update(transport.body)
+        """Send request and return a complete Messages response, aggregating SSE if enabled.
+
+        Args:
+            request: Canonical chat parameters including messages and optional streaming.
+
+        Raises:
+            ProviderError: If translation, HTTP transport, or stream assembly fails.
+        """
+        transport, stream = self._prepare_completion(request)
         response_json = self._post_sync(
-            self._get_messages_route(), payload, transport.headers, request.model, transport.timeout
+            self._get_messages_route(),
+            transport.body,
+            transport.headers,
+            request.model,
+            transport.timeout,
+            stream=stream,
         )
         return parse_anthropic_response(response_json)
 
     async def acompletion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        payload = self._build_payload_or_raise(request)
-        transport = TransportKwargs.from_request(request, exclude=self._TRANSPORT_EXCLUDE)
-        payload.update(transport.body)
+        """Asynchronously send request and return an assembled Messages response.
+
+        Args:
+            request: Canonical chat parameters including messages and optional streaming.
+
+        Raises:
+            ProviderError: If translation, HTTP transport, or stream assembly fails.
+            asyncio.CancelledError: If cancelled; the stream connection is released.
+        """
+        transport, stream = self._prepare_completion(request)
         response_json = await self._apost(
-            self._get_messages_route(), payload, transport.headers, request.model, transport.timeout
+            self._get_messages_route(),
+            transport.body,
+            transport.headers,
+            request.model,
+            transport.timeout,
+            stream=stream,
         )
         return parse_anthropic_response(response_json)
 
@@ -104,9 +126,22 @@ class AnthropicClient(HttpModelClient):
     async def agenerate_image(self, request: ImageGenerationRequest) -> ImageGenerationResponse:
         raise ProviderError.unsupported_capability(provider_name=self.provider_name, operation="image-generation")
 
-    def _build_payload_or_raise(self, request: ChatCompletionRequest) -> dict[str, Any]:
+    def _prepare_completion(
+        self, request: ChatCompletionRequest
+    ) -> tuple[TransportKwargs, AnthropicMessageStream | None]:
+        """Translate request into Messages HTTP arguments and an optional fresh SSE accumulator.
+
+        Args:
+            request: Canonical chat parameters; extra_body overrides translated fields.
+
+        Returns:
+            Complete transport arguments and a stream when the final body enables it.
+
+        Raises:
+            ProviderError: If messages or media cannot be represented by the Messages API.
+        """
         try:
-            return build_anthropic_payload(request)
+            payload = build_anthropic_payload(request)
         except UnsupportedAnthropicMediaBlockError as exc:
             raise ProviderError.unsupported_capability(
                 provider_name=self.provider_name,
@@ -125,6 +160,11 @@ class AnthropicClient(HttpModelClient):
                 model_name=request.model,
                 cause=exc,
             ) from exc
+
+        transport = TransportKwargs.from_request(request, exclude=self._TRANSPORT_EXCLUDE)
+        transport.body = {**payload, **transport.body}
+        stream = AnthropicMessageStream(self.provider_name, request.model) if transport.body.get("stream") else None
+        return transport, stream
 
     def _build_headers(self, extra_headers: dict[str, str]) -> dict[str, str]:
         headers: dict[str, str] = {

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/http_model_client.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/http_model_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import data_designer.lazy_heavy_imports as lazy
@@ -14,11 +16,18 @@ from data_designer.engine.models.clients.adapters.http_helpers import (
     resolve_timeout,
     wrap_transport_error,
 )
-from data_designer.engine.models.clients.errors import SyncClientUnavailableError, map_http_error_to_provider_error
+from data_designer.engine.models.clients.errors import (
+    ProviderError,
+    ProviderErrorKind,
+    SyncClientUnavailableError,
+    map_http_error_to_provider_error,
+)
 from data_designer.engine.models.clients.retry import RetryConfig, RetryTransport, create_retry_transport
 
 if TYPE_CHECKING:
     import httpx
+
+    from data_designer.engine.models.clients.streaming import ChatStream
 
 
 class ClientConcurrencyMode(StrEnum):
@@ -171,24 +180,48 @@ class HttpModelClient(ABC):
         extra_headers: dict[str, str],
         model_name: str,
         timeout: float | None = None,
+        *,
+        stream: ChatStream | None = None,
     ) -> dict[str, Any]:
-        url = f"{self._endpoint}{route}"
-        headers = self._build_headers(extra_headers)
+        """POST JSON or SSE and return the complete response, closing the connection.
+
+        Args:
+            route: Provider route appended to the configured endpoint.
+            payload: Provider-specific JSON request body.
+            extra_headers: Per-request headers merged with provider authentication.
+            model_name: Model identifier for errors.
+            timeout: Optional per-operation timeout in seconds, including read inactivity.
+            stream: Fresh accumulator for SSE; None selects an ordinary JSON response.
+
+        Returns:
+            Decoded JSON or the assembled streaming response.
+
+        Raises:
+            ProviderError: For HTTP errors, malformed events, timeouts, or interrupted streams.
+        """
         client = self._get_sync_client()
-        try:
-            response = client.post(
-                url,
-                json=payload,
-                headers=headers,
-                timeout=resolve_timeout(self._timeout_s, timeout),
-            )
-        except Exception as exc:
-            raise wrap_transport_error(exc, self.provider_name, model_name) from exc
-        if response.status_code >= 400:
-            raise map_http_error_to_provider_error(
-                response=response, provider_name=self.provider_name, model_name=model_name
-            )
-        return parse_json_body(response, self.provider_name, model_name)
+        headers = self._build_headers(extra_headers)
+        if stream is not None:
+            headers = {"Accept": "text/event-stream", **headers}
+        url = f"{self._endpoint}{route}"
+        with self._request_errors(model_name, stream):
+            request_kwargs: dict[str, Any] = {
+                "json": payload,
+                "headers": headers,
+                "timeout": resolve_timeout(self._timeout_s, timeout),
+            }
+            if stream is None:
+                response = client.post(url, **request_kwargs)
+                self._validate_response(response, model_name, stream)
+                return parse_json_body(response, self.provider_name, model_name)
+            with client.stream("POST", url, **request_kwargs) as response:
+                if response.status_code >= 400:
+                    response.read()
+                self._validate_response(response, model_name, stream)
+                for line in response.iter_lines():
+                    if stream.feed_line(line):
+                        break
+                return stream.finish()
 
     async def _apost(
         self,
@@ -197,21 +230,95 @@ class HttpModelClient(ABC):
         extra_headers: dict[str, str],
         model_name: str,
         timeout: float | None = None,
+        *,
+        stream: ChatStream | None = None,
     ) -> dict[str, Any]:
-        url = f"{self._endpoint}{route}"
+        """Asynchronously POST JSON or SSE and return the complete provider response.
+
+        Args:
+            route: Provider route appended to the configured endpoint.
+            payload: Provider-specific JSON request body.
+            extra_headers: Per-request headers merged with provider authentication.
+            model_name: Model identifier for errors.
+            timeout: Optional per-operation timeout in seconds, including read inactivity.
+            stream: Fresh accumulator for SSE; None selects an ordinary JSON response.
+
+        Returns:
+            Decoded JSON or the assembled streaming response, with the connection closed.
+
+        Raises:
+            ProviderError: For HTTP, protocol, timeout, or connection failures.
+            asyncio.CancelledError: Cancellation propagates after closing the response.
+        """
+        client = self._get_async_client()
         headers = self._build_headers(extra_headers)
-        async_client = self._get_async_client()
-        try:
-            response = await async_client.post(
-                url,
-                json=payload,
-                headers=headers,
-                timeout=resolve_timeout(self._timeout_s, timeout),
-            )
-        except Exception as exc:
-            raise wrap_transport_error(exc, self.provider_name, model_name) from exc
+        if stream is not None:
+            headers = {"Accept": "text/event-stream", **headers}
+        url = f"{self._endpoint}{route}"
+        with self._request_errors(model_name, stream):
+            request_kwargs: dict[str, Any] = {
+                "json": payload,
+                "headers": headers,
+                "timeout": resolve_timeout(self._timeout_s, timeout),
+            }
+            if stream is None:
+                response = await client.post(url, **request_kwargs)
+                self._validate_response(response, model_name, stream)
+                return parse_json_body(response, self.provider_name, model_name)
+            async with client.stream("POST", url, **request_kwargs) as response:
+                if response.status_code >= 400:
+                    await response.aread()
+                self._validate_response(response, model_name, stream)
+                async for line in response.aiter_lines():
+                    if stream.feed_line(line):
+                        break
+                return stream.finish()
+
+    def _validate_response(
+        self,
+        response: httpx.Response,
+        model_name: str,
+        stream: ChatStream | None,
+    ) -> None:
+        """Check HTTP status and set UTF-8 decoding for a successful SSE response.
+
+        Args:
+            response: HTTP response, with its body already read when the status is an error.
+            model_name: Model identifier attached to HTTP errors.
+            stream: SSE accumulator, or None to skip SSE checks for a JSON response.
+
+        Raises:
+            ProviderError: For HTTP failures or an unexpected SSE content type.
+        """
         if response.status_code >= 400:
             raise map_http_error_to_provider_error(
                 response=response, provider_name=self.provider_name, model_name=model_name
             )
-        return parse_json_body(response, self.provider_name, model_name)
+        if stream is not None:
+            if response.headers.get("content-type", "").split(";")[0].strip().lower() != "text/event-stream":
+                stream.fail("Expected text/event-stream for a streaming chat request")
+            response.encoding = "utf-8"
+
+    @contextmanager
+    def _request_errors(self, model_name: str, stream: ChatStream | None) -> Iterator[None]:
+        """Normalize request failures for both execution modes, leaving cancellation untouched.
+
+        Args:
+            model_name: Model identifier attached to normalized transport errors.
+            stream: SSE accumulator; its transport failures must retry the complete request.
+
+        Yields:
+            Control to HTTP I/O and parsing; failures leave the context as ProviderError.
+        """
+        try:
+            yield
+        except ProviderError:
+            raise
+        except Exception as exc:
+            if (
+                stream is not None
+                and isinstance(exc, lazy.httpx.TransportError)
+                and not isinstance(exc, lazy.httpx.TimeoutException)
+            ):
+                stream.fail("Chat stream connection interrupted", kind=ProviderErrorKind.API_CONNECTION, cause=exc)
+            raise wrap_transport_error(exc, self.provider_name, model_name) from exc

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/openai_compatible.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/adapters/openai_compatible.py
@@ -20,6 +20,7 @@ from data_designer.engine.models.clients.parsing import (
     extract_usage,
     parse_chat_completion_response,
 )
+from data_designer.engine.models.clients.streaming import OpenAIChatStream
 from data_designer.engine.models.clients.types import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -62,28 +63,64 @@ class OpenAICompatibleClient(HttpModelClient):
     # -------------------------------------------------------------------
 
     def completion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        transport = TransportKwargs.from_request(request)
-        messages = translate_openai_compatible_messages(
-            request.messages,
-            provider_name=self.provider_name,
-            model_name=request.model,
+        """Send a chat request, returning a complete response after any SSE aggregation.
+
+        Args:
+            request: Canonical chat parameters, messages, and optional streaming flag.
+
+        Returns:
+            Parsed assistant choices and usage; partial stream results are never returned.
+
+        Raises:
+            ProviderError: If the provider or stream fails.
+        """
+        transport, stream = self._prepare_completion(request)
+        response_json = self._post_sync(
+            self._ROUTE_CHAT, transport.body, transport.headers, request.model, transport.timeout, stream=stream
         )
-        payload = {"model": request.model, "messages": messages, **transport.body}
-        response_json = self._post_sync(self._ROUTE_CHAT, payload, transport.headers, request.model, transport.timeout)
         return parse_chat_completion_response(response_json)
 
     async def acompletion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
-        transport = TransportKwargs.from_request(request)
-        messages = translate_openai_compatible_messages(
-            request.messages,
-            provider_name=self.provider_name,
-            model_name=request.model,
-        )
-        payload = {"model": request.model, "messages": messages, **transport.body}
+        """Send a chat request asynchronously and return assembled choices and usage.
+
+        Args:
+            request: Canonical chat parameters, messages, and optional streaming flag.
+
+        Raises:
+            ProviderError: If the provider or stream fails.
+            asyncio.CancelledError: If cancelled; the stream connection is released.
+        """
+        transport, stream = self._prepare_completion(request)
         response_json = await self._apost(
-            self._ROUTE_CHAT, payload, transport.headers, request.model, transport.timeout
+            self._ROUTE_CHAT, transport.body, transport.headers, request.model, transport.timeout, stream=stream
         )
         return await aparse_chat_completion_response(response_json)
+
+    def _prepare_completion(self, request: ChatCompletionRequest) -> tuple[TransportKwargs, OpenAIChatStream | None]:
+        """Translate request into HTTP arguments and an optional fresh SSE accumulator.
+
+        Args:
+            request: Canonical chat parameters; extra_body overrides typed fields.
+
+        Returns:
+            Complete transport arguments and a stream when the final body enables it.
+            Usage is requested by default; explicit stream_options overrides are preserved.
+
+        Raises:
+            ProviderError: If the request contains unsupported media.
+        """
+        transport = TransportKwargs.from_request(request)
+        messages = translate_openai_compatible_messages(
+            request.messages, provider_name=self.provider_name, model_name=request.model
+        )
+        transport.body = {"model": request.model, "messages": messages, **transport.body}
+        stream = None
+        if transport.body.get("stream"):
+            options = transport.body.pop("stream_options", {})
+            if options is not None:
+                transport.body["stream_options"] = {"include_usage": True, **options}
+            stream = OpenAIChatStream(self.provider_name, request.model, transport.body.get("n") or 1)
+        return transport, stream
 
     # -------------------------------------------------------------------
     # Embeddings

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/streaming.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/streaming.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Assemble SSE chat responses before exposing them to parsers or tool execution."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Any, NoReturn
+
+from data_designer.engine.models.clients.errors import (
+    ProviderError,
+    ProviderErrorKind,
+    map_http_status_to_provider_error_kind,
+)
+
+
+class ChatStream(ABC):
+    """Decode SSE frames and enforce an explicit provider end-of-stream marker."""
+
+    def __init__(self, provider_name: str, model_name: str) -> None:
+        """Initialize an empty response and error context for the named provider/model."""
+        self.provider_name: str = provider_name
+        self.model_name: str = model_name
+        self.complete: bool = False
+        self._data: list[str] = []
+        self._event: str = ""
+
+    def feed_line(self, line: str) -> bool:
+        """Consume one decoded SSE line; return whether the response has ended.
+
+        Args:
+            line: UTF-8 line without its newline, including blank frame separators.
+
+        Raises:
+            ProviderError: For malformed payloads or provider errors inside a stream.
+        """
+        line = line.removeprefix("\ufeff")
+        if line:
+            field, _, value = line.partition(":")
+            value = value.removeprefix(" ")
+            if field == "data":
+                self._data.append(value)
+            elif field == "event":
+                self._event = value
+            return self.complete
+
+        data, event = "\n".join(self._data), self._event
+        self._data, self._event = [], ""
+        if not data:
+            return self.complete
+        try:
+            payload = {"type": "done"} if data == "[DONE]" else json.loads(data)
+            if not isinstance(payload, dict):
+                self.fail("Expected a JSON object in the stream")
+            if event == "error" or payload.get("error") or payload.get("type") == "error":
+                self._raise_provider_error(payload)
+            self._consume(payload)
+        except (ValueError, TypeError, KeyError, IndexError) as exc:
+            self.fail("Malformed chat stream event", cause=exc)
+        return self.complete
+
+    def finish(self) -> dict[str, Any]:
+        """Return the assembled response, or fail if the connection ended prematurely.
+
+        Incomplete responses are connection failures so the request executor can retry
+        the entire request with a new accumulator; no partial result is returned.
+        """
+        if not self.complete:
+            self.fail("Chat stream ended before its completion marker", kind=ProviderErrorKind.API_CONNECTION)
+        return self._build_response()
+
+    def fail(
+        self,
+        message: str,
+        *,
+        kind: ProviderErrorKind = ProviderErrorKind.API_ERROR,
+        cause: Exception | None = None,
+    ) -> NoReturn:
+        """Raise a canonical error using message, failure kind, and optional original cause."""
+        raise ProviderError(kind, message, provider_name=self.provider_name, model_name=self.model_name, cause=cause)
+
+    def _raise_provider_error(self, payload: dict[str, Any]) -> NoReturn:
+        """Raise the error carried by an SSE payload, preserving rate-limit classification."""
+        error = payload.get("error") or payload
+        if not isinstance(error, dict):
+            self.fail(str(error))
+        status = {
+            "rate_limit_error": 429,
+            "overloaded_error": 529,
+            "authentication_error": 401,
+            "permission_error": 403,
+            "invalid_request_error": 400,
+            "api_error": 500,
+        }.get(error.get("type"))
+        code = error.get("code")
+        if status is None and str(code).isdigit():
+            status = int(code)
+        message = str(error.get("message") or "Provider reported an error in the chat stream")
+        kind = map_http_status_to_provider_error_kind(status, message) if status else ProviderErrorKind.API_ERROR
+        raise ProviderError(
+            kind, message, status_code=status, provider_name=self.provider_name, model_name=self.model_name
+        )
+
+    @abstractmethod
+    def _consume(self, payload: dict[str, Any]) -> None:
+        """Merge one provider event into this response, setting complete at its terminal event."""
+
+    @abstractmethod
+    def _build_response(self) -> dict[str, Any]:
+        """Validate accumulated state and return a non-streaming provider response object."""
+
+
+class OpenAIChatStream(ChatStream):
+    """Collect interleaved choices, reasoning, tool arguments, and final token usage."""
+
+    def __init__(self, provider_name: str, model_name: str, num_choices: int = 1) -> None:
+        """Initialize named provider/model context and the expected number of choices."""
+        super().__init__(provider_name, model_name)
+        self._num_choices: int = num_choices
+        self._response: dict[str, Any] = {}
+        self._choices: dict[int, dict[str, Any]] = {}
+
+    def _consume(self, payload: dict[str, Any]) -> None:
+        """Merge one chat chunk into indexed choices, or record the [DONE] marker."""
+        if payload.get("type") == "done":
+            self.complete = True
+            return
+        for key, value in payload.items():
+            if key != "choices" and value is not None:
+                self._response[key] = value
+        for chunk in payload.get("choices") or []:
+            index = chunk["index"]
+            if type(index) is not int or index < 0:
+                self.fail("Invalid choice index in chat stream")
+            choice = self._choices.setdefault(index, {"index": index, "message": {}})
+            merge_stream_delta(choice["message"], chunk.get("delta") or {})
+            if chunk.get("finish_reason") is not None:
+                choice["finish_reason"] = chunk["finish_reason"]
+            if chunk.get("logprobs") is not None:
+                merge_stream_delta(choice.setdefault("logprobs", {}), chunk["logprobs"])
+
+    def _build_response(self) -> dict[str, Any]:
+        """Return all choices in index order, rejecting missing or unfinished choices."""
+        if set(self._choices) != set(range(self._num_choices)) or any(
+            not choice.get("finish_reason") for choice in self._choices.values()
+        ):
+            self.fail("Chat stream ended with missing or unfinished choices", kind=ProviderErrorKind.API_CONNECTION)
+        for choice in self._choices.values():
+            calls = choice["message"].get("tool_calls")
+            if calls:
+                calls.sort(key=lambda call: call["index"])
+        return {
+            **self._response,
+            "object": "chat.completion",
+            "choices": [self._choices[i] for i in sorted(self._choices)],
+        }
+
+
+def merge_stream_delta(target: dict[str, Any], delta: dict[str, Any]) -> None:
+    """Merge a JSON delta into target in place, concatenating text and indexed list items.
+
+    Args:
+        target: Accumulated message or nested object, mutated by this function.
+        delta: New fragments; null fields are ignored. Lists with index fields are
+            merged by index, allowing tool calls and content blocks to interleave.
+
+    Raises:
+        TypeError: If a provider changes the type of a field between chunks.
+    """
+    for key, value in delta.items():
+        if value is None:
+            continue
+        if key not in target or target[key] is None:
+            target[key] = deepcopy(value)
+        elif isinstance(value, str):
+            target[key] += value
+        elif isinstance(value, dict):
+            merge_stream_delta(target[key], value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict) and "index" in item:
+                    prior = next(
+                        (old for old in target[key] if isinstance(old, dict) and old.get("index") == item["index"]),
+                        None,
+                    )
+                    if prior is not None:
+                        merge_stream_delta(prior, item)
+                        continue
+                target[key].append(deepcopy(item))
+        else:
+            target[key] = value
+
+
+class AnthropicMessageStream(ChatStream):
+    """Collect Messages API content blocks and cumulative usage through message_stop."""
+
+    def __init__(self, provider_name: str, model_name: str) -> None:
+        """Initialize named provider/model context and empty message/block state."""
+        super().__init__(provider_name, model_name)
+        self._message: dict[str, Any] | None = None
+        self._blocks: dict[int, dict[str, Any]] = {}
+        self._partial_json: dict[int, list[str]] = {}
+        self._open_blocks: set[int] = set()
+
+    def _consume(self, payload: dict[str, Any]) -> None:
+        """Apply one Messages event, preserving thinking signatures and tool JSON."""
+        event = payload.get("type")
+        if event == "message_start":
+            if self._message is not None:
+                self.fail("Duplicate message_start in chat stream")
+            self._message = deepcopy(payload["message"])
+        elif event == "content_block_start":
+            index = payload["index"]
+            if type(index) is not int or index < 0 or index in self._blocks:
+                self.fail("Invalid or duplicate content block index in chat stream")
+            self._blocks[index] = deepcopy(payload["content_block"])
+            self._open_blocks.add(index)
+        elif event == "content_block_delta":
+            index, delta = payload["index"], payload["delta"]
+            if index not in self._open_blocks:
+                self.fail("Delta for an unopened content block")
+            if delta.get("type") == "input_json_delta":
+                self._partial_json.setdefault(index, []).append(delta["partial_json"])
+            elif delta.get("type") == "citations_delta":
+                self._blocks[index].setdefault("citations", []).append(delta["citation"])
+            else:
+                merge_stream_delta(self._blocks[index], {key: value for key, value in delta.items() if key != "type"})
+        elif event == "content_block_stop":
+            index = payload["index"]
+            self._open_blocks.remove(index)
+            if index in self._partial_json:
+                self._blocks[index]["input"] = json.loads("".join(self._partial_json.pop(index)))
+        elif event == "message_delta":
+            if self._message is None:
+                self.fail("message_delta arrived before message_start")
+            self._message.update(payload.get("delta") or {})
+            self._message.setdefault("usage", {}).update(
+                {key: value for key, value in (payload.get("usage") or {}).items() if value is not None}
+            )
+        elif event == "message_stop":
+            self.complete = True
+        # Ping and future event types do not change the accumulated message.
+
+    def _build_response(self) -> dict[str, Any]:
+        """Return the final message with ordered blocks and non-duplicated token counts."""
+        if (
+            self._message is None
+            or self._open_blocks
+            or not self._message.get("stop_reason")
+            or set(self._blocks) != set(range(len(self._blocks)))
+        ):
+            self.fail("Chat stream ended with an unfinished message", kind=ProviderErrorKind.API_CONNECTION)
+        return {**self._message, "content": [self._blocks[i] for i in sorted(self._blocks)]}

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/types.py
@@ -74,6 +74,9 @@ class ChatCompletionRequest:
     extra_body: dict[str, Any] | None = None
     extra_headers: dict[str, str] | None = None
 
+    # None preserves the provider's default and the existing non-streaming wire format.
+    stream: bool | None = None
+
 
 @dataclass
 class ChatCompletionChoice:

--- a/packages/data-designer-engine/src/data_designer/engine/models/facade.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/facade.py
@@ -106,6 +106,7 @@ _COMPLETION_REQUEST_FIELDS = frozenset(
         "response_format",
         "frequency_penalty",
         "presence_penalty",
+        "stream",
         "timeout",
         "tools",
         "extra_body",
@@ -185,6 +186,22 @@ class ModelFacade:
     @property
     def usage_stats(self) -> ModelUsageStats:
         return self._usage_stats
+
+    def is_streaming_enabled(self, **kwargs: Any) -> bool:
+        """Resolve the effective chat streaming flag without sampling inference parameters.
+
+        Args:
+            **kwargs: Per-call model parameters. The stream field overrides model config;
+                extra_body overrides that field, and provider extra_body takes precedence.
+
+        Returns:
+            Whether the final chat request body requests streaming.
+        """
+        params = self._model_config.inference_parameters
+        stream = kwargs.get("stream", getattr(params, "stream", False))
+        extra_body = kwargs.get("extra_body", params.extra_body) or {}
+        provider_body = self.model_provider.extra_body or {}
+        return bool(provider_body.get("stream", extra_body.get("stream", stream)))
 
     def consolidate_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         # Remove purpose from kwargs to avoid passing it to the model

--- a/packages/data-designer-engine/tests/engine/column_generators/generators/test_custom.py
+++ b/packages/data-designer-engine/tests/engine/column_generators/generators/test_custom.py
@@ -545,8 +545,11 @@ def test_async_bridge_obeys_run_cancellation_before_scheduling() -> None:
     facade.agenerate.assert_not_called()
 
 
-def test_async_bridge_cancels_in_flight_request() -> None:
+@pytest.mark.parametrize("streaming", [False, True])
+def test_async_bridge_cancels_in_flight_request(streaming: bool) -> None:
+    """Run cancellation stops an in-flight model call with or without a streaming deadline."""
     facade = Mock()
+    facade.is_streaming_enabled.return_value = streaming
     facade.generate.side_effect = SyncClientUnavailableError(
         "Sync methods are not available on an async-mode HttpModelClient."
     )

--- a/packages/data-designer-engine/tests/engine/models/clients/test_streaming.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_streaming.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
@@ -497,8 +498,28 @@ def generate_streamed_custom_row(row: dict, generator_params: Any, models: dict[
 
 
 @pytest.mark.asyncio
-async def test_sync_custom_column_waits_for_active_stream(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A public synchronous custom column consumes its async model stream past the bridge deadline."""
+@pytest.mark.parametrize("completion_races_with_timeout", [False, True])
+async def test_sync_custom_column_waits_for_active_stream(
+    monkeypatch: pytest.MonkeyPatch, completion_races_with_timeout: bool
+) -> None:
+    """A synchronous custom column returns a complete async response despite bridge polling deadlines.
+
+    Args:
+        monkeypatch: Shortens the bridge deadline and optionally injects a polling race.
+        completion_races_with_timeout: Completes generation just before reporting a polling timeout.
+    """
+    if completion_races_with_timeout:
+        future_result = concurrent.futures.Future.result
+
+        def finish_before_timeout_check(future: concurrent.futures.Future, timeout: float | None = None) -> Any:
+            """Read future using timeout, then simulate a polling timeout racing with its completed result."""
+            result = future_result(future, timeout)
+            if timeout is not None:
+                raise concurrent.futures.TimeoutError
+            return result
+
+        monkeypatch.setattr(concurrent.futures.Future, "result", finish_before_timeout_check)
+
     stream = DelayedStream(encode_events([make_chunk({"content": "ok"}, "stop"), "[DONE]"]))
     client = make_client(
         httpx.MockTransport(

--- a/packages/data-designer-engine/tests/engine/models/clients/test_streaming.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_streaming.py
@@ -1,0 +1,659 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from data_designer.config import (
+    ChatCompletionInferenceParams,
+    CustomColumnConfig,
+    ModelConfig,
+    ModelProvider,
+    custom_column_generator,
+)
+from data_designer.engine.column_generators.generators.custom import CustomColumnGenerator
+from data_designer.engine.column_generators.utils.errors import CustomColumnGenerationError
+from data_designer.engine.model_provider import ModelProviderRegistry
+from data_designer.engine.models.clients.adapters.anthropic import AnthropicClient
+from data_designer.engine.models.clients.adapters.http_model_client import ClientConcurrencyMode
+from data_designer.engine.models.clients.adapters.openai_compatible import OpenAICompatibleClient
+from data_designer.engine.models.clients.errors import ProviderError, ProviderErrorKind
+from data_designer.engine.models.clients.model_request_executor import ModelRequestExecutor
+from data_designer.engine.models.clients.retry import RetryConfig
+from data_designer.engine.models.clients.types import ChatCompletionRequest
+from data_designer.engine.models.facade import ModelFacade
+from data_designer.engine.models.request_admission.controller import AdaptiveRequestAdmissionController
+from data_designer.engine.models.utils import ChatMessage
+from data_designer.engine.resources.resource_provider import ResourceProvider
+from data_designer.engine.testing import InMemoryAdmissionEventSink
+
+
+class FragmentedStream(httpx.SyncByteStream, httpx.AsyncByteStream):
+    """Expose real HTTPX incremental decoding and observable cleanup to adapter tests."""
+
+    def __init__(self, body: bytes, error: Exception | None = None, gate: asyncio.Event | None = None) -> None:
+        """Store body bytes, optional terminal error, and optional async read gate."""
+        self.body: bytes = body
+        self.error: Exception | None = error
+        self.gate: asyncio.Event | None = gate
+        self.waiting: asyncio.Event = asyncio.Event()
+        self.closed: bool = False
+
+    def __iter__(self) -> Iterator[bytes]:
+        """Yield small byte fragments, then raise the configured transport failure."""
+        for start in range(0, len(self.body), 7):
+            yield self.body[start : start + 7]
+        if self.error:
+            raise self.error
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        """Yield fragments cooperatively and optionally wait for cancellation at the end."""
+        for part in self:
+            await asyncio.sleep(0)
+            yield part
+        if self.gate is not None:
+            self.waiting.set()
+            await self.gate.wait()
+
+    def close(self) -> None:
+        """Record that HTTPX released the synchronous response."""
+        self.closed = True
+
+    async def aclose(self) -> None:
+        """Record that HTTPX released the asynchronous response."""
+        self.closed = True
+
+
+def encode_events(events: list[dict[str, Any] | str]) -> bytes:
+    """Encode JSON events or literal strings as UTF-8 SSE, including CRLF and comments."""
+    frames = ["\ufeff: keepalive\r\n\r\n"]
+    for event in events:
+        data = json.dumps(event, ensure_ascii=False) if isinstance(event, dict) else event
+        frames.append(f"data: {data}\r\n\r\n")
+    return "".join(frames).encode()
+
+
+def make_chunk(delta: dict[str, Any], finish: str | None = None, index: int = 0) -> dict[str, Any]:
+    """Return an indexed OpenAI chunk carrying delta fields and an optional finish reason."""
+    return {"id": "chat-test", "choices": [{"index": index, "delta": delta, "finish_reason": finish}]}
+
+
+def make_client(
+    transport: httpx.MockTransport, is_async: bool, anthropic: bool = False
+) -> OpenAICompatibleClient | AnthropicClient:
+    """Return a native adapter using the supplied HTTP transport, mode, and API dialect."""
+    cls = AnthropicClient if anthropic else OpenAICompatibleClient
+    kwargs = (
+        {"async_client": httpx.AsyncClient(transport=transport)}
+        if is_async
+        else {"sync_client": httpx.Client(transport=transport)}
+    )
+    return cls(
+        provider_name="test",
+        endpoint="https://example.test/v1",
+        api_key="test-key",
+        concurrency_mode=ClientConcurrencyMode.ASYNC if is_async else ClientConcurrencyMode.SYNC,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+async def test_stream_assembles_interleaved_choices_tools_and_usage(is_async: bool) -> None:
+    """Both execution modes preserve fragmented text/tools, choice order, and final usage."""
+    events = [
+        make_chunk({"role": "assistant", "content": "second"}, "length", index=1),
+        make_chunk({"role": "assistant", "reasoning_content": "思"}),
+        make_chunk({"reasoning_content": "考", "content": "你"}),
+        make_chunk(
+            {
+                "content": "好",
+                "tool_calls": [
+                    {"index": 1, "id": "call_b", "type": "function", "function": {"name": "second", "arguments": "{"}},
+                    {
+                        "index": 0,
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "first", "arguments": '{"x":'},
+                    },
+                ],
+            }
+        ),
+        make_chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": "1}"}},
+                    {"index": 1, "function": {"arguments": "}"}},
+                ]
+            },
+            "tool_calls",
+        ),
+        {
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 7,
+                "total_tokens": 16,
+                "completion_tokens_details": {"reasoning_tokens": 2},
+            },
+        },
+        "[DONE]",
+    ]
+    stream = FragmentedStream(encode_events(events))
+    requests: list[dict[str, Any]] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        """Capture the outgoing request body and return the fragmented SSE response."""
+        requests.append(json.loads(request.content))
+        assert request.headers["authorization"] == "Bearer test-key"
+        assert request.extensions["timeout"]["read"] == 19
+        return httpx.Response(200, headers={"content-type": "text/event-stream; charset=utf-8"}, stream=stream)
+
+    client = make_client(httpx.MockTransport(handle), is_async)
+    request = ChatCompletionRequest("model", [{"role": "user", "content": "hello"}], stream=True, n=2, timeout=19)
+    try:
+        result = await client.acompletion(request) if is_async else client.completion(request)
+        assert [c.message.content for c in result.choices] == ["你好", "second"]
+        assert [c.finish_reason for c in result.choices] == ["tool_calls", "length"]
+        assert result.message.reasoning_content == "思考"
+        assert [(t.id, t.name, t.arguments_json) for t in result.message.tool_calls] == [
+            ("call_a", "first", '{"x":1}'),
+            ("call_b", "second", "{}"),
+        ]
+        assert result.usage.total_tokens == 16
+        assert result.usage.reasoning_tokens == 2
+        assert requests[0]["stream"] is True
+        assert requests[0]["stream_options"] == {"include_usage": True}
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_anthropic_stream_preserves_blocks_signatures_and_cumulative_usage(is_async: bool) -> None:
+    """Messages streaming preserves ordered content/tool blocks without summing cumulative usage."""
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg",
+                "role": "assistant",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 1},
+            },
+        },
+        {"type": "ping"},
+        {"type": "future_event"},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "Think"}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "sig"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "你好"}},
+        {"type": "content_block_delta", "index": 1, "delta": {"type": "citations_delta", "citation": {"url": "url"}}},
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {"type": "tool_use", "id": "call", "name": "add", "input": {}},
+        },
+        {"type": "content_block_delta", "index": 2, "delta": {"type": "input_json_delta", "partial_json": '{"a":'}},
+        {"type": "content_block_delta", "index": 2, "delta": {"type": "input_json_delta", "partial_json": "2}"}},
+        {"type": "content_block_stop", "index": 2},
+        {"type": "message_delta", "delta": {"stop_reason": None}, "usage": {"output_tokens": 4}},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 8}},
+        {"type": "message_stop"},
+    ]
+    stream = FragmentedStream(encode_events(events))
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=stream)
+        ),
+        is_async,
+        anthropic=True,
+    )
+    try:
+        request = ChatCompletionRequest("model", [{"role": "user", "content": "hello"}], stream=True)
+        result = await client.acompletion(request) if is_async else client.completion(request)
+        assert result.message.content == "你好"
+        assert result.message.reasoning_content == "Think"
+        assert json.loads(result.message.tool_calls[0].arguments_json) == {"a": 2}
+        assert result.choices[0].finish_reason == "tool_use"
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 8
+        assert result.raw["content"][0]["signature"] == "sig"
+        assert result.raw["content"][1]["citations"] == [{"url": "url"}]
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize(
+    ("events", "error", "kind"),
+    [
+        ([make_chunk({"content": "partial"})], None, ProviderErrorKind.API_CONNECTION),
+        ([make_chunk({"content": "partial"}), "[DONE]"], None, ProviderErrorKind.API_CONNECTION),
+        (["[DONE]"], None, ProviderErrorKind.API_CONNECTION),
+        (["{malformed"], None, ProviderErrorKind.API_ERROR),
+        (["[]"], None, ProviderErrorKind.API_ERROR),
+        ([{"error": {"code": 429, "message": "rate limited"}}], None, ProviderErrorKind.RATE_LIMIT),
+        ([make_chunk({"content": "partial"})], httpx.ReadError("disconnected"), ProviderErrorKind.API_CONNECTION),
+        ([make_chunk({"content": "partial"})], httpx.ReadTimeout("idle"), ProviderErrorKind.TIMEOUT),
+    ],
+)
+async def test_stream_failure_never_returns_partial_output(
+    is_async: bool, events: list[dict[str, Any] | str], error: Exception | None, kind: ProviderErrorKind
+) -> None:
+    """Given malformed/error/truncated events, both modes raise the expected kind and close HTTP."""
+    stream = FragmentedStream(encode_events(events), error=error)
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=stream)
+        ),
+        is_async,
+    )
+    try:
+        request = ChatCompletionRequest("model", [], stream=True)
+        with pytest.raises(ProviderError) as caught:
+            await client.acompletion(request) if is_async else client.completion(request)
+        assert caught.value.kind == kind
+        assert caught.value.provider_name == "test"
+        assert caught.value.model_name == "model"
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("anthropic", [False, True], ids=["openai", "anthropic"])
+@pytest.mark.parametrize("streaming", [False, True], ids=["json", "sse"])
+@pytest.mark.parametrize("status", [200, 401, 429, 503])
+async def test_http_errors_and_invalid_response_bodies(
+    is_async: bool, anthropic: bool, streaming: bool, status: int
+) -> None:
+    """Both response paths preserve error details and release the HTTP response on failure.
+
+    Args:
+        is_async: Selects the synchronous or asynchronous HTTP client.
+        anthropic: Selects the Messages protocol instead of OpenAI chat completions.
+        streaming: Requests SSE instead of a buffered JSON response.
+        status: HTTP error status, or 200 with a body invalid for the requested format.
+    """
+    stream = FragmentedStream(b"not JSON" if status == 200 else b'{"error":{"message":"failed"}}')
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(
+                status, headers={"content-type": "application/json", "retry-after": "3"}, stream=stream
+            )
+        ),
+        is_async,
+        anthropic=anthropic,
+    )
+    try:
+        with pytest.raises(ProviderError) as caught:
+            request = ChatCompletionRequest("model", [{"role": "user", "content": "hello"}], stream=streaming)
+            await client.acompletion(request) if is_async else client.completion(request)
+        assert caught.value.status_code == (None if status == 200 and streaming else status)
+        assert (
+            caught.value.kind
+            == {
+                200: ProviderErrorKind.API_ERROR,
+                401: ProviderErrorKind.AUTHENTICATION,
+                429: ProviderErrorKind.RATE_LIMIT,
+                503: ProviderErrorKind.INTERNAL_SERVER,
+            }[status]
+        )
+        if status != 200:
+            assert "failed" in str(caught.value)
+        if status == 429:
+            assert caught.value.retry_after == 3
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_disconnected_stream_retries_whole_request_with_fresh_state(is_async: bool) -> None:
+    """A disconnect discards partial text; the request executor reacquires admission for retry."""
+    streams = [
+        FragmentedStream(encode_events([make_chunk({"content": "discard"})])),
+        FragmentedStream(encode_events([make_chunk({"content": "complete"}, "stop"), "[DONE]"])),
+    ]
+    pending = iter(streams)
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=next(pending))
+        ),
+        is_async,
+    )
+    sink = InMemoryAdmissionEventSink()
+    controller = AdaptiveRequestAdmissionController(event_sink=sink)
+    controller.register(provider_name="test", model_id="model", alias="test", max_parallel_requests=1)
+    executor = ModelRequestExecutor(
+        client,
+        controller,
+        "test",
+        "model",
+        event_sink=sink,
+        retry_config=RetryConfig(max_retries=1, backoff_factor=0),
+    )
+    try:
+        request = ChatCompletionRequest("model", [], stream=True)
+        result = (
+            await executor.acompletion(request) if is_async else await asyncio.to_thread(executor.completion, request)
+        )
+        assert result.message.content == "complete"
+        assert all(stream.closed for stream in streams)
+        completed = [event for event in sink.request_events if event.event_kind == "model_request_completed"]
+        assert [event.diagnostics["outcome"] for event in completed] == ["api_connection", "success"]
+    finally:
+        await executor.aclose() if is_async else executor.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stream_closes_connection_and_releases_admission() -> None:
+    """Cancelling a waiting SSE read closes it and records a released, cancelled request."""
+    stream = FragmentedStream(encode_events([make_chunk({"content": "partial"})]), gate=asyncio.Event())
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=stream)
+        ),
+        True,
+    )
+    sink = InMemoryAdmissionEventSink()
+    controller = AdaptiveRequestAdmissionController(event_sink=sink)
+    controller.register(provider_name="test", model_id="model", alias="test", max_parallel_requests=1)
+    executor = ModelRequestExecutor(
+        client,
+        controller,
+        "test",
+        "model",
+        event_sink=sink,
+    )
+    task = asyncio.create_task(executor.acompletion(ChatCompletionRequest("model", [], stream=True)))
+    try:
+        await asyncio.wait_for(stream.waiting.wait(), 2)
+        assert not stream.closed
+        assert any(s.active_lease_count == 1 for s in controller.pressure.snapshots().values())
+        assert not any(event.event_kind == "model_request_completed" for event in sink.request_events)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert stream.closed
+        completed = [event for event in sink.request_events if event.event_kind == "model_request_completed"]
+        assert completed[0].diagnostics["outcome"] == "local_cancelled"
+        assert all(s.active_lease_count == 0 for s in controller.pressure.snapshots().values())
+    finally:
+        task.cancel()
+        await executor.aclose()
+
+
+@pytest.mark.parametrize("options", [None, {"include_usage": False}, {"include_usage": True}])
+def test_stream_options_respect_endpoint_overrides(options: dict[str, Any] | None) -> None:
+    """Explicit stream_options can disable requesting usage or omit unsupported options entirely."""
+    stream = FragmentedStream(encode_events([make_chunk({"content": "ok"}, "stop"), "[DONE]"]))
+    payloads: list[dict[str, Any]] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        """Record the supplied request and return a valid SSE response without usage."""
+        payloads.append(json.loads(request.content))
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=stream)
+
+    client = make_client(httpx.MockTransport(handle), False)
+    try:
+        result = client.completion(
+            ChatCompletionRequest("model", [], stream=True, extra_body={"stream_options": options})
+        )
+        assert result.message.content == "ok"
+        assert result.usage is None
+        if options is None:
+            assert "stream_options" not in payloads[0]
+        else:
+            assert payloads[0]["stream_options"] == options
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("configured", "config_extra", "provider_extra", "kwargs", "expected"),
+    [
+        (True, None, None, {}, True),
+        (True, None, None, {"stream": False}, False),
+        (False, {"stream": True}, None, {}, True),
+        (False, {"stream": True}, None, {"extra_body": None}, False),
+        (True, None, {"stream": False}, {"stream": True}, False),
+        (False, None, {"stream": True}, {"stream": False}, True),
+        (True, None, None, {"extra_body": {"stream": False}}, False),
+    ],
+)
+def test_facade_stream_flag_matches_effective_wire_request(
+    configured: bool, config_extra: dict | None, provider_extra: dict | None, kwargs: dict, expected: bool
+) -> None:
+    """Model, call, extra-body, and provider overrides resolve identically for bridges and HTTP."""
+    provider = ModelProvider(
+        name="test", endpoint="https://example.test/v1", provider_type="openai", extra_body=provider_extra
+    )
+    config = ModelConfig(
+        alias="test",
+        model="model",
+        provider="test",
+        inference_parameters=ChatCompletionInferenceParams(
+            stream=configured,
+            extra_body=config_extra,
+        ),
+    )
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        """Assert the outgoing request's mode and return the corresponding wire response format."""
+        payload = json.loads(request.content)
+        assert bool(payload.get("stream")) is expected
+        if expected:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=FragmentedStream(encode_events([make_chunk({"content": "ok"}, "stop"), "[DONE]"])),
+            )
+        return httpx.Response(
+            200, json={"choices": [{"index": 0, "message": {"content": "ok"}, "finish_reason": "stop"}]}
+        )
+
+    client = make_client(httpx.MockTransport(handle), False)
+    model = ModelFacade(config, ModelProviderRegistry(providers=[provider]), client=client)
+    try:
+        assert model.is_streaming_enabled(**kwargs) is expected
+        assert model.completion([ChatMessage.as_user("hello")], **kwargs).message.content == "ok"
+    finally:
+        model.close()
+
+
+class DelayedStream(FragmentedStream):
+    """A stream whose total duration exceeds the test's synthetic bridge deadline."""
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        """Yield a heartbeat, await a slow response, then yield complete SSE data."""
+        yield b": keepalive\n\n"
+        await asyncio.sleep(0.05)
+        yield self.body
+
+
+@custom_column_generator(model_aliases=["test"])
+def generate_streamed_custom_row(row: dict, generator_params: Any, models: dict[str, Any]) -> dict:
+    """Generate result into row using model 'test'; generator_params is unused."""
+    row["result"], _ = models["test"].generate("Say ok")
+    return row
+
+
+@pytest.mark.asyncio
+async def test_sync_custom_column_waits_for_active_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A public synchronous custom column consumes its async model stream past the bridge deadline."""
+    stream = DelayedStream(encode_events([make_chunk({"content": "ok"}, "stop"), "[DONE]"]))
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=stream,
+            )
+        ),
+        True,
+    )
+    config = ModelConfig(
+        alias="test", model="model", provider="test", inference_parameters=ChatCompletionInferenceParams(stream=True)
+    )
+    provider = ModelProvider(name="test", endpoint="https://example.test/v1", provider_type="openai")
+    model = ModelFacade(config, ModelProviderRegistry(providers=[provider]), client=client)
+    resources = MagicMock(spec=ResourceProvider)
+    resources.model_registry = MagicMock()
+    resources.model_registry.get_model.return_value = model
+    generator = CustomColumnGenerator(
+        config=CustomColumnConfig(name="result", generator_function=generate_streamed_custom_row),
+        resource_provider=resources,
+    )
+    monkeypatch.setattr(
+        "data_designer.engine.column_generators.generators.custom._compute_bridge_timeout", lambda *args: 0.01
+    )
+    try:
+        assert await asyncio.wait_for(asyncio.to_thread(generator.generate, {}), 2) == {"result": "ok"}
+        assert stream.closed
+    finally:
+        await model.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize(
+    ("events", "kind"),
+    [
+        ([{"type": "message_stop"}], ProviderErrorKind.API_CONNECTION),
+        ([{"type": "message_start", "message": {"content": [], "usage": {}}}], ProviderErrorKind.API_CONNECTION),
+        (
+            [{"type": "error", "error": {"type": "rate_limit_error", "message": "limited"}}],
+            ProviderErrorKind.RATE_LIMIT,
+        ),
+        (
+            [{"type": "error", "error": {"type": "overloaded_error", "message": "overloaded"}}],
+            ProviderErrorKind.INTERNAL_SERVER,
+        ),
+        (
+            [{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "lost"}}],
+            ProviderErrorKind.API_ERROR,
+        ),
+        (
+            [
+                {"type": "message_start", "message": {"content": [], "usage": {}}},
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "partial"}},
+                {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+                {"type": "message_stop"},
+            ],
+            ProviderErrorKind.API_CONNECTION,
+        ),
+        (
+            [
+                {"type": "message_start", "message": {"content": [], "usage": {}}},
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "input": {}}},
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{"}},
+                {"type": "content_block_stop", "index": 0},
+            ],
+            ProviderErrorKind.API_ERROR,
+        ),
+    ],
+)
+async def test_anthropic_stream_rejects_errors_and_incomplete_blocks(
+    is_async: bool, events: list[dict[str, Any]], kind: ProviderErrorKind
+) -> None:
+    """Given SSE events and expected error kind, each execution mode rejects incomplete Messages."""
+    stream = FragmentedStream(encode_events(events))
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=stream,
+            )
+        ),
+        is_async,
+        anthropic=True,
+    )
+    try:
+        request = ChatCompletionRequest("model", [{"role": "user", "content": "hello"}], stream=True)
+        with pytest.raises(ProviderError) as caught:
+            await client.acompletion(request) if is_async else client.completion(request)
+        assert caught.value.kind == kind
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_sse_multiline_data_and_final_chunk_usage(is_async: bool) -> None:
+    """Each mode handles multiline SSE data and usage attached to the last choice chunk."""
+    stream = FragmentedStream(
+        b'event: message\n: comment\ndata: {"choices":\ndata: [{"index":0,"delta":{"content":"ok"},'
+        b'"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    client = make_client(
+        httpx.MockTransport(
+            lambda _: httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=stream,
+            )
+        ),
+        is_async,
+    )
+    try:
+        request = ChatCompletionRequest("model", [], stream=True)
+        result = await client.acompletion(request) if is_async else client.completion(request)
+        assert result.message.content == "ok"
+        assert result.usage.total_tokens == 5
+        assert stream.closed
+    finally:
+        await client.aclose() if is_async else client.close()
+
+
+@pytest.mark.asyncio
+async def test_streaming_custom_column_propagates_coroutine_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A completed coroutine's TimeoutError must not be mistaken for an endless polling timeout.
+
+    Args:
+        monkeypatch: Substitutes an async model boundary raising TimeoutError immediately.
+    """
+    client = make_client(httpx.MockTransport(lambda _: httpx.Response(500)), True)
+    config = ModelConfig(
+        alias="test", model="model", provider="test", inference_parameters=ChatCompletionInferenceParams(stream=True)
+    )
+    provider = ModelProvider(name="test", endpoint="https://example.test/v1", provider_type="openai")
+    model = ModelFacade(config, ModelProviderRegistry(providers=[provider]), client=client)
+    resources = MagicMock(spec=ResourceProvider)
+    resources.model_registry = MagicMock()
+    resources.model_registry.get_model.return_value = model
+    generator = CustomColumnGenerator(
+        config=CustomColumnConfig(name="result", generator_function=generate_streamed_custom_row),
+        resource_provider=resources,
+    )
+
+    async def fail_generation(*args: Any, **kwargs: Any) -> tuple[Any, list]:
+        """Reject forwarded generation args/kwargs with a coroutine-level timeout, returning no result."""
+        raise TimeoutError("coroutine timed out")
+
+    monkeypatch.setattr(model, "agenerate", fail_generation)
+    try:
+        with pytest.raises(CustomColumnGenerationError, match="coroutine timed out"):
+            await asyncio.wait_for(asyncio.to_thread(generator.generate, {}), 2)
+    finally:
+        await model.aclose()

--- a/tests_e2e/tests/test_streaming_live.py
+++ b/tests_e2e/tests/test_streaming_live.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in real DeepSeek streaming checks for both native HTTP adapter protocols."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from dotenv import dotenv_values
+
+import data_designer.config as dd
+from data_designer.config import ChatCompletionInferenceParams, ModelConfig, ModelProvider
+from data_designer.engine.model_provider import ModelProviderRegistry
+from data_designer.engine.models.clients.adapters.http_model_client import ClientConcurrencyMode
+from data_designer.engine.models.clients.streaming import ChatStream
+from data_designer.engine.models.clients.types import ChatCompletionResponse
+from data_designer.engine.models.factory import create_model_registry
+from data_designer.engine.models.utils import ChatMessage
+from data_designer.engine.secret_resolver import EnvironmentResolver
+from data_designer.engine.testing import StubMCPFacade, StubMCPRegistry
+from data_designer.interface import DataDesigner
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DATA_DESIGNER_LIVE_STREAMING") != "1",
+    reason="Set DATA_DESIGNER_LIVE_STREAMING=1 to call the real DeepSeek API using API_KEY from .env",
+)
+
+_PROVIDERS = {
+    "openai": "https://api.deepseek.com",
+    "anthropic": "https://api.deepseek.com/anthropic",
+}
+
+
+@pytest.fixture(params=list(_PROVIDERS))
+def live_model(request: pytest.FixtureRequest) -> tuple[ModelProvider, ModelConfig]:
+    """Build shared DeepSeek configuration for each supported API protocol.
+
+    Args:
+        request: Supplies the parametrized provider type (openai or anthropic).
+
+    Returns:
+        Provider and per-test model configuration with streaming enabled and thinking
+        disabled; tests can override inference parameters or enable the health check.
+    """
+    provider = ModelProvider(
+        name=f"deepseek-{request.param}",
+        endpoint=_PROVIDERS[request.param],
+        provider_type=request.param,
+        api_key="API_KEY",
+    )
+    config = ModelConfig(
+        alias="stream-test",
+        model="deepseek-v4-flash",
+        provider=provider.name,
+        skip_health_check=True,
+        inference_parameters=ChatCompletionInferenceParams(
+            stream=True,
+            temperature=0,
+            max_tokens=512,
+            timeout=120,
+            max_parallel_requests=2,
+            extra_body={"thinking": {"type": "disabled"}},
+        ),
+    )
+    return provider, config
+
+
+@pytest.fixture
+def live_streams(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Load only API_KEY and observe actual SSE decoding without replacing network responses.
+
+    Args:
+        monkeypatch: Restores the environment and decoder observer after each test.
+
+    Returns:
+        Per-request event counts and terminal-marker status, excluding credentials/content.
+    """
+    key = dotenv_values(Path(__file__).resolve().parents[2] / ".env").get("API_KEY") or os.environ.get("API_KEY")
+    assert key, "API_KEY must be available in .env or the environment"
+    monkeypatch.setenv("API_KEY", key)
+    observed: dict[ChatStream, dict[str, Any]] = {}
+    records: list[dict[str, Any]] = []
+    original = ChatStream.feed_line
+
+    def observe(stream: ChatStream, line: str) -> bool:
+        """Count actual SSE data lines for stream and return the original decoder result."""
+        if stream not in observed:
+            observed[stream] = {"provider": stream.provider_name, "data_events": 0, "complete": False}
+            records.append(observed[stream])
+        if line.startswith("data:"):
+            observed[stream]["data_events"] += 1
+        complete = original(stream, line)
+        observed[stream]["complete"] = complete
+        return complete
+
+    monkeypatch.setattr(ChatStream, "feed_line", observe)
+    return records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("scenario", ["json", "thinking", "tools"])
+async def test_live_streaming(
+    live_model: tuple[ModelProvider, ModelConfig], is_async: bool, scenario: str, live_streams: list[dict[str, Any]]
+) -> None:
+    """Exercise real model generation through config, admission, SSE, parsing, and usage.
+
+    Args:
+        live_model: DeepSeek provider and model configuration for the API protocol under test.
+        is_async: Selects native synchronous or asynchronous model execution.
+        scenario: JSON parsing, reasoning capture, or a complete model/tool/model exchange.
+        live_streams: Observer of real streamed responses; no model outputs are mocked.
+    """
+    provider, config = live_model
+    if scenario == "thinking":
+        config.inference_parameters.max_tokens = 2048
+        config.inference_parameters.extra_body = {"thinking": {"type": "enabled"}}
+    calls: list[dict[str, Any]] = []
+
+    def execute_sum(response: ChatCompletionResponse) -> list[ChatMessage]:
+        """Execute the fully assembled sum tool request and return assistant/tool trace messages."""
+        assert len(response.message.tool_calls) == 1
+        call = response.message.tool_calls[0]
+        assert call.name == "sum_numbers"
+        args = json.loads(call.arguments_json)
+        assert args == {"a": 17, "b": 25}
+        calls.append(args)
+        return [
+            ChatMessage.as_assistant(
+                content=response.message.content or "",
+                tool_calls=[
+                    {
+                        "id": call.id,
+                        "type": "function",
+                        "function": {"name": call.name, "arguments": call.arguments_json},
+                    }
+                ],
+            ),
+            ChatMessage.as_tool(content=str(args["a"] + args["b"]), tool_call_id=call.id),
+        ]
+
+    tools = StubMCPRegistry(
+        StubMCPFacade(
+            process_fn=execute_sum,
+            tool_schemas=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "sum_numbers",
+                        "description": "Add two integers.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                            "required": ["a", "b"],
+                            "additionalProperties": False,
+                        },
+                    },
+                }
+            ],
+        )
+    )
+    registry = create_model_registry(
+        model_configs=[config],
+        secret_resolver=EnvironmentResolver(),
+        model_provider_registry=ModelProviderRegistry(providers=[provider]),
+        client_concurrency_mode=ClientConcurrencyMode.ASYNC if is_async else ClientConcurrencyMode.SYNC,
+        mcp_registry=tools if scenario == "tools" else None,
+    )
+    model = registry.get_model(model_alias=config.alias)
+    kwargs: dict[str, Any] = {}
+    if scenario == "tools":
+        prompt = "You must call sum_numbers with a=17 and b=25 before answering. Then return only its numeric result."
+        kwargs["tool_alias"] = "tools"
+    elif scenario == "json":
+        prompt = 'Return exactly the JSON object {"answer":42,"label":"你好"}, without Markdown or explanation.'
+        kwargs["parser"] = json.loads
+    else:
+        prompt = "Calculate 17+25. Think briefly, then return only the numeric answer."
+    try:
+        if is_async:
+            output, trace = await model.agenerate(prompt, **kwargs)
+        else:
+            output, trace = await asyncio.to_thread(model.generate, prompt, **kwargs)
+        assert output == {"answer": 42, "label": "你好"} if scenario == "json" else output.strip() == "42"
+        if scenario == "thinking":
+            assert any(message.reasoning_content for message in trace if message.role == "assistant")
+        if scenario == "tools":
+            assert calls == [{"a": 17, "b": 25}]
+            assert any(message.role == "tool" for message in trace)
+        expected_requests = 2 if scenario == "tools" else 1
+        assert len(live_streams) == expected_requests
+        assert all(record["complete"] and record["data_events"] > 2 for record in live_streams)
+        stats = model.usage_stats.model_dump(mode="json")
+        assert stats["request_usage"] == {
+            "successful_requests": expected_requests,
+            "failed_requests": 0,
+            "total_requests": expected_requests,
+        }
+        assert stats["token_usage"]["input_tokens"] > 0
+        assert stats["token_usage"]["output_tokens"] > 0
+        print(
+            json.dumps(
+                {
+                    "protocol": provider.provider_type,
+                    "async": is_async,
+                    "scenario": scenario,
+                    "streams": live_streams,
+                    "usage": stats,
+                },
+                ensure_ascii=False,
+            )
+        )
+    finally:
+        if is_async:
+            await registry.aclose()
+        else:
+            registry.close()
+
+
+def test_live_streaming_dataset(
+    live_model: tuple[ModelProvider, ModelConfig], live_streams: list[dict[str, Any]], tmp_path: Path
+) -> None:
+    """Create and reload a real dataset with streamed text, code, structured, and judge columns.
+
+    Args:
+        live_model: DeepSeek provider and model configuration used for every generated column.
+        live_streams: Observer proving all generated responses were complete SSE streams.
+        tmp_path: Isolated directory for generated dataset artifacts.
+    """
+    provider, config = live_model
+    config.skip_health_check = False
+    builder = dd.DataDesignerConfigBuilder(model_configs=[config])
+    builder.add_column(
+        dd.LLMTextColumnConfig(
+            name="answer",
+            model_alias=config.alias,
+            prompt="Return only the number 42.",
+            with_trace=dd.TraceType.ALL_MESSAGES,
+        )
+    )
+    builder.add_column(
+        dd.LLMCodeColumnConfig(
+            name="code",
+            model_alias=config.alias,
+            prompt="Write the single Python statement answer = 42.",
+            code_lang=dd.CodeLang.PYTHON,
+        )
+    )
+    builder.add_column(
+        dd.LLMStructuredColumnConfig(
+            name="structured",
+            model_alias=config.alias,
+            prompt="Return answer as the integer {{ answer }}.",
+            output_format={"type": "object", "properties": {"answer": {"type": "integer"}}, "required": ["answer"]},
+        )
+    )
+    builder.add_column(
+        dd.LLMJudgeColumnConfig(
+            name="judgment",
+            model_alias=config.alias,
+            prompt="The expected answer is 42. Evaluate this answer: {{ answer }}.",
+            scores=[
+                dd.Score(
+                    name="correctness", description="Whether the answer is 42.", options={0: "Incorrect", 1: "Correct"}
+                )
+            ],
+        )
+    )
+    designer = DataDesigner(model_providers=[provider], secret_resolver=EnvironmentResolver(), artifact_path=tmp_path)
+    results = designer.create(builder, num_records=1, dataset_name=f"stream-{provider.provider_type}")
+    frame = results.load_dataset()
+    assert len(frame) == 1
+    assert frame.iloc[0]["answer"].strip() == "42"
+    assert "42" in frame.iloc[0]["code"]
+    assert frame.iloc[0]["structured"] == {"answer": 42}
+    assert frame.iloc[0]["answer__trace"][-1]["content"][0]["text"].strip() == "42"
+    assert frame.iloc[0]["judgment"]["correctness"]["score"] == 1
+    assert len(live_streams) == 5  # One model health check and four generated columns.
+    assert all(record["complete"] and record["data_events"] > 2 for record in live_streams)
+    print(json.dumps({"protocol": provider.provider_type, "dataset_rows": len(frame), "streams": live_streams}))


### PR DESCRIPTION
## 📋 Summary

Add opt-in `stream=True` transport for chat generation so supported endpoints can send incremental responses during long generations. Data Designer assembles the response before structured parsing, tool execution, or row output, preserving the existing complete-result API and keeping streaming disabled by default.

## 🔗 Related Issue

Closes #921. The feature proposal is awaiting maintainer triage.

## 🔄 Changes

- Add the chat inference parameter and forward it through canonical requests with the existing override precedence.
- Assemble OpenAI-compatible and Anthropic Messages SSE in both synchronous and asynchronous adapters, including fragmented text, reasoning, tool arguments, choices, and token usage.
- Share HTTP status/error handling; discard incomplete responses before retry and release connections and admission leases on cancellation.
- Let synchronous custom columns wait for active async streams while retaining cancellation, and preserve the actual result when completion races with bridge timeout polling.
- Document configuration, supported endpoints, complete-result semantics, and streaming read timeouts.

## 🧪 Testing

- [x] All three package suites: `.venv/bin/pytest packages/data-designer-config/tests packages/data-designer-engine/tests packages/data-designer/tests -q` — **4,108 passed, 1 skipped**. The skipped test is the separately enabled production plugin-catalog smoke test.
- [x] Unit tests cover fragmented UTF-8/SSE, interleaved choices/tools, cumulative usage, HTTP/provider errors, disconnect/retry, cancellation, parameter overrides, and sync-to-async bridge races.
- [x] Opt-in live E2E tests: `DATA_DESIGNER_LIVE_STREAMING=1 .venv/bin/pytest -c pyproject.toml tests_e2e/tests/test_streaming_live.py -q -s` — **14 passed, 26 complete SSE responses**, using `deepseek-v4-flash` through DeepSeek's OpenAI-compatible and Anthropic-compatible APIs. Includes sync/async JSON, reasoning, tool round trips, health checks, and dataset generation. The tool callback is local and deterministic; model responses are real.
- [x] Ruff lint/format, `git diff --check`, internal links across 86 Fern pages, and the documentation configuration example pass. Fern reports 0 errors; authenticated redirect checking was skipped because no Fern login/token was available.

Live protocol coverage uses DeepSeek, not Anthropic-hosted Claude. No comparative reliability or throughput benchmark was run.

## ✅ Checklist

- [x] Follows commit message conventions.
- [x] Both commits are signed off (DCO).
- [x] User documentation updated. Architecture documentation reviewed; existing subsystem boundaries remain accurate.
- [x] Local self-review completed; the bridge completion/timeout race found during review was fixed and regression-tested.
