### PR TITLE
feat(slurm): wire M2 services and CLI

### DIFF
--- a/packages/data-designer-slurm/pyproject.toml
+++ b/packages/data-designer-slurm/pyproject.toml
@@ -38,6 +38,7 @@ bump = true
 dependencies = [
     "data-designer=={{ version }}",
     "packaging>=25,<27",
+    "pip>=25,<27",
     "pydantic>=2.9.2,<3",
     "pyyaml>=6.0.1,<7",
 ]

--- a/packages/data-designer-slurm/src/data_designer/slurm/cli.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/cli.py
@@ -107,6 +107,12 @@ def image_add_command(
     operation = SlurmServiceOperation.ADD_IMAGE
 
     def add() -> BaseModel:
+        if not source.endswith(".sqsh") and re.fullmatch(r"[^\s]+@sha256:[0-9a-f]{64}", source) is None:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.INVALID_REQUEST,
+                operation,
+                "OCI image source must be digest-qualified as name@sha256:<digest>",
+            )
         request = ImageBuildRequest(name=name or _derive_image_name(source), kind=kind, source=source)
         return create_slurm_image_service(profile_file=profile_file, cluster=cluster).add(request, replace=replace)
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/cli.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/cli.py
@@ -85,7 +85,7 @@ def cancel_command(
     profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
     cluster: str | None = typer.Option(None, "--cluster"),
 ) -> None:
-    """Cancel active jobs recorded for one managed run."""
+    """Request job cancellation; status changes after reconciliation."""
     operation = SlurmServiceOperation.CANCEL_RUN
     result = _invoke(
         operation,

--- a/packages/data-designer-slurm/src/data_designer/slurm/cli.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/cli.py
@@ -3,19 +3,215 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import NoReturn, TypeVar
+
 import click
 import typer
+from pydantic import BaseModel, ValidationError
+
+from data_designer.slurm.config import ImageBuildRequest, SlurmConfigLoadError, load_run_config
+from data_designer.slurm.contracts import canonical_json
+from data_designer.slurm.services import (
+    SlurmServiceError,
+    SlurmServiceErrorCode,
+    SlurmServiceOperation,
+    create_slurm_image_service,
+    create_slurm_run_service,
+)
+
+_ResultT = TypeVar("_ResultT")
+_EXIT_CODES = {
+    SlurmServiceErrorCode.INVALID_REQUEST: 2,
+    SlurmServiceErrorCode.NOT_FOUND: 3,
+    SlurmServiceErrorCode.CONFLICT: 4,
+    SlurmServiceErrorCode.UNAVAILABLE: 5,
+    SlurmServiceErrorCode.INTERNAL: 1,
+}
 
 app = typer.Typer(
     name="slurm",
     help="Run Data Designer workloads on Slurm",
     no_args_is_help=True,
 )
+image_app = typer.Typer(help="Manage verified Slurm images", no_args_is_help=True)
+app.add_typer(image_app, name="image")
 
 
 @app.callback()
 def slurm_callback() -> None:
     pass
+
+
+@app.command("execute")
+def execute_command(
+    run_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+    force: bool = typer.Option(False, "--force"),
+) -> None:
+    """Prepare and submit one authored run."""
+    operation = SlurmServiceOperation.EXECUTE_RUN
+
+    def execute() -> BaseModel:
+        config = load_run_config(run_file)
+        service = create_slurm_run_service(profile_file=profile_file, cluster=cluster)
+        return service.execute(config, source_root=run_file.resolve().parent, dry_run=dry_run, force=force)
+
+    _emit_result(_invoke(operation, execute))
+
+
+@app.command("status")
+def status_command(
+    run_id: str = typer.Argument(..., help="Managed Data Designer run ID"),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """Show persisted M2 run status without scheduler reconciliation."""
+    operation = SlurmServiceOperation.STATUS_RUN
+    result = _invoke(
+        operation,
+        lambda: create_slurm_run_service(profile_file=profile_file, cluster=cluster).status(run_id),
+    )
+    _emit_result(result)
+
+
+@app.command("cancel")
+def cancel_command(
+    run_id: str = typer.Argument(..., help="Managed Data Designer run ID"),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """Cancel active jobs recorded for one managed run."""
+    operation = SlurmServiceOperation.CANCEL_RUN
+    result = _invoke(
+        operation,
+        lambda: create_slurm_run_service(profile_file=profile_file, cluster=cluster).cancel(run_id),
+    )
+    _emit_result(result)
+
+
+@image_app.command("add")
+def image_add_command(
+    source: str = typer.Argument(...),
+    kind: str = typer.Option(..., "--kind", help="Image role: client or serving"),
+    name: str | None = typer.Option(None, "--name"),
+    replace: bool = typer.Option(False, "--replace"),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """Request image import or inspection; requires IMG lifecycle support."""
+    operation = SlurmServiceOperation.ADD_IMAGE
+
+    def add() -> BaseModel:
+        request = ImageBuildRequest(name=name or _derive_image_name(source), kind=kind, source=source)
+        return create_slurm_image_service(profile_file=profile_file, cluster=cluster).add(request, replace=replace)
+
+    _emit_result(_invoke(operation, add))
+
+
+@image_app.command("ls")
+def image_list_command(
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """List registered image aliases."""
+    operation = SlurmServiceOperation.LIST_IMAGES
+    images = _invoke(
+        operation,
+        lambda: create_slurm_image_service(profile_file=profile_file, cluster=cluster).list(),
+    )
+    _emit_json([image.model_dump(mode="json") for image in images])
+
+
+@image_app.command("info")
+def image_info_command(
+    name: str = typer.Argument(...),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """Show one registered image alias."""
+    operation = SlurmServiceOperation.GET_IMAGE
+    result = _invoke(
+        operation,
+        lambda: create_slurm_image_service(profile_file=profile_file, cluster=cluster).get(name),
+    )
+    _emit_result(result)
+
+
+@image_app.command("rm")
+def image_remove_command(
+    name: str = typer.Argument(...),
+    profile_file: Path | None = typer.Option(None, "--profile-file", dir_okay=False),
+    cluster: str | None = typer.Option(None, "--cluster"),
+) -> None:
+    """Unregister one alias without deleting its SQSH artifact."""
+    operation = SlurmServiceOperation.REMOVE_IMAGE
+    result = _invoke(
+        operation,
+        lambda: create_slurm_image_service(profile_file=profile_file, cluster=cluster).remove(name),
+    )
+    _emit_result(result)
+
+
+def _invoke(operation: SlurmServiceOperation, call: Callable[[], _ResultT]) -> _ResultT:
+    try:
+        return call()
+    except SlurmServiceError as error:
+        _fail(error)
+    except SlurmConfigLoadError as error:
+        message = _bounded_error_message(str(error), fallback="invalid command input")
+        _fail(SlurmServiceError(SlurmServiceErrorCode.INVALID_REQUEST, operation, message))
+    except ValidationError:
+        _fail(SlurmServiceError(SlurmServiceErrorCode.INVALID_REQUEST, operation, "invalid command input"))
+    except Exception:
+        _fail(
+            SlurmServiceError(
+                SlurmServiceErrorCode.INTERNAL,
+                operation,
+                f"{operation.value.replace('_', ' ')} failed",
+            )
+        )
+
+
+def _fail(error: SlurmServiceError) -> NoReturn:
+    _emit_json(
+        {
+            "error": {
+                "code": error.code.value,
+                "message": str(error),
+                "operation": error.operation.value,
+            }
+        },
+        err=True,
+    )
+    raise typer.Exit(_EXIT_CODES[error.code])
+
+
+def _emit_result(result: BaseModel) -> None:
+    _emit_json(result.model_dump(mode="json"))
+
+
+def _emit_json(value: object, *, err: bool = False) -> None:
+    typer.echo(canonical_json(value).decode("utf-8"), err=err)
+
+
+def _derive_image_name(source: str) -> str:
+    if source.endswith(".sqsh"):
+        candidate = Path(source).stem
+    else:
+        candidate = source.rpartition("@sha256:")[0].rsplit("/", maxsplit=1)[-1].split(":", maxsplit=1)[0]
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", candidate).strip("-._") or "image"
+
+
+def _bounded_error_message(message: str, *, fallback: str) -> str:
+    sanitized = "".join(" " if ord(character) < 32 or ord(character) == 127 else character for character in message)
+    if not sanitized:
+        return fallback
+    return sanitized if len(sanitized) <= 512 else f"{sanitized[:509]}..."
 
 
 def create_cli() -> click.Command:

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/dependencies.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/dependencies.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve immutable client dependency locks before Slurm submission."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.utils import canonicalize_name, parse_wheel_filename
+
+from data_designer.slurm.client.filesystem import compute_file_sha256, read_regular_bytes
+from data_designer.slurm.client.records import ClientErrorCode
+from data_designer.slurm.config import ClientDependencies, ClientImageInspection
+from data_designer.slurm.contracts import ArtifactReference, InstalledDistribution, validate_absolute_path
+from data_designer.slurm.planning import LockedPackage, ResolvedDependencyLock, ResolvedImage
+
+_RESOLVER_VERSION = "pip-pure-wheel-1"
+_LOCK_SOURCE_DIRECTORY = "inputs"
+_DEPENDENCY_DIRECTORY = "dependencies"
+
+DependencyCommandRunner = Callable[[tuple[str, ...], Path, Mapping[str, str]], None]
+
+
+class ClientDependencyResolutionError(RuntimeError):
+    """Raised when authored client dependencies cannot produce a safe lock."""
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedClientDependencies:
+    """Resolved lock plus source artifacts for atomic run initialization."""
+
+    lock: ResolvedDependencyLock
+    wheel_sources: tuple[Path, ...]
+    lock_source: Path | None = None
+
+
+class ClientDependencyResolver:
+    """Resolve pure wheels against the immutable client-image inventory."""
+
+    def __init__(
+        self,
+        *,
+        command_runner: DependencyCommandRunner | None = None,
+        environ: Mapping[str, str] | None = None,
+        python_executable: str | None = None,
+    ) -> None:
+        self._command_runner = command_runner or _run_pip_download
+        self._environ = os.environ if environ is None else environ
+        self._python_executable = sys.executable if python_executable is None else python_executable
+
+    @contextmanager
+    def resolve(
+        self,
+        dependencies: ClientDependencies,
+        client_image: ResolvedImage,
+        *,
+        run_root: str | Path,
+        source_root: str | Path,
+    ) -> Iterator[ResolvedClientDependencies]:
+        """Yield one verified resolution while temporary wheel sources remain live."""
+        if not isinstance(dependencies, ClientDependencies):
+            raise ClientDependencyResolutionError("client dependencies are invalid")
+        inspection = client_image.inspection_facts
+        if not isinstance(inspection, ClientImageInspection):
+            raise ClientDependencyResolutionError("client image lacks dependency inspection facts")
+        try:
+            normalized_run_root = Path(validate_absolute_path(Path(run_root).as_posix()))
+            normalized_source_root = Path(validate_absolute_path(Path(source_root).as_posix()))
+        except ValueError as error:
+            raise ClientDependencyResolutionError("dependency resolution paths are invalid") from error
+
+        with tempfile.TemporaryDirectory(prefix="data-designer-slurm-dependencies-") as temporary:
+            temporary_root = Path(temporary).resolve()
+            try:
+                if dependencies.requirements is None:
+                    result = self._load_lock(
+                        dependencies,
+                        client_image,
+                        normalized_run_root,
+                        normalized_source_root,
+                    )
+                else:
+                    result = self._resolve_requirements(
+                        dependencies,
+                        client_image,
+                        normalized_run_root,
+                        temporary_root,
+                    )
+            except ClientDependencyResolutionError:
+                raise
+            except OSError as error:
+                raise ClientDependencyResolutionError("client dependency artifacts are unavailable") from error
+            yield result
+
+    def _resolve_requirements(
+        self,
+        dependencies: ClientDependencies,
+        client_image: ResolvedImage,
+        run_root: Path,
+        temporary_root: Path,
+    ) -> ResolvedClientDependencies:
+        requirements = dependencies.requirements
+        assert requirements is not None
+        inspection = client_image.inspection_facts
+        assert isinstance(inspection, ClientImageInspection)
+        image_distributions = tuple(sorted(inspection.distributions, key=lambda item: item.name))
+        if not requirements:
+            return ResolvedClientDependencies(
+                lock=_build_lock(client_image, image_distributions=image_distributions, authored_requirements=()),
+                wheel_sources=(),
+            )
+
+        requirements_path = temporary_root / "requirements.in"
+        constraints_path = temporary_root / "constraints.txt"
+        wheelhouse = temporary_root / "wheels"
+        wheelhouse.mkdir(mode=0o700)
+        requirements_path.write_text("".join(f"{item}\n" for item in requirements), encoding="utf-8")
+        constraints_path.write_text(
+            "".join(f"{item.name}=={item.version}\n" for item in image_distributions),
+            encoding="utf-8",
+        )
+        command = (
+            self._python_executable,
+            "-m",
+            "pip",
+            "download",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--only-binary=:all:",
+            "--platform=any",
+            "--implementation=py",
+            "--abi=none",
+            f"--python-version={inspection.python_version.rsplit('.', maxsplit=1)[0]}",
+            f"--dest={wheelhouse.as_posix()}",
+            f"--requirement={requirements_path.as_posix()}",
+            f"--constraint={constraints_path.as_posix()}",
+        )
+        environment = self._resolution_environment(dependencies)
+        try:
+            self._command_runner(command, temporary_root, environment)
+        except ClientDependencyResolutionError:
+            raise
+        except Exception as error:
+            raise ClientDependencyResolutionError("client dependency resolution failed") from error
+
+        packages, sources = _load_downloaded_wheels(wheelhouse, run_root, image_distributions)
+        try:
+            lock = _build_lock(
+                client_image,
+                image_distributions=image_distributions,
+                authored_requirements=tuple(requirements),
+                overlay_packages=packages,
+            )
+        except ValueError as error:
+            raise ClientDependencyResolutionError("resolved client dependencies are incompatible") from error
+        return ResolvedClientDependencies(lock=lock, wheel_sources=sources)
+
+    def _load_lock(
+        self,
+        dependencies: ClientDependencies,
+        client_image: ResolvedImage,
+        run_root: Path,
+        source_root: Path,
+    ) -> ResolvedClientDependencies:
+        lock_file = dependencies.lock_file
+        assert lock_file is not None
+        source = source_root / lock_file
+        try:
+            content = read_regular_bytes(source, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING)
+            supplied = ResolvedDependencyLock.model_validate_json(content, strict=True)
+        except Exception as error:
+            raise ClientDependencyResolutionError("client dependency lock is invalid") from error
+        inspection = client_image.inspection_facts
+        assert isinstance(inspection, ClientImageInspection)
+        if (
+            supplied.client_image_sha256 != client_image.sha256
+            or supplied.python_abi != inspection.python_abi
+            or supplied.image_distributions != tuple(sorted(inspection.distributions, key=lambda item: item.name))
+        ):
+            raise ClientDependencyResolutionError("client dependency lock targets another image")
+
+        packages: list[LockedPackage] = []
+        sources: list[Path] = []
+        for package in supplied.overlay_packages:
+            wheel = Path(package.artifact.path)
+            _verify_locked_wheel(wheel, package)
+            packages.append(
+                LockedPackage(
+                    name=package.name,
+                    version=package.version,
+                    artifact=ArtifactReference(
+                        path=(run_root / _DEPENDENCY_DIRECTORY / wheel.name).as_posix(),
+                        sha256=package.artifact.sha256,
+                    ),
+                )
+            )
+            sources.append(wheel)
+        source_reference = ArtifactReference(
+            path=(run_root / _LOCK_SOURCE_DIRECTORY / source.name).as_posix(),
+            sha256=hashlib.sha256(content).hexdigest(),
+        )
+        try:
+            lock = ResolvedDependencyLock(
+                schema_version=1,
+                resolver_version=supplied.resolver_version,
+                python_abi=supplied.python_abi,
+                client_image_sha256=supplied.client_image_sha256,
+                authored_requirements=supplied.authored_requirements,
+                authored_source=lock_file,
+                source=source_reference,
+                image_distributions=supplied.image_distributions,
+                overlay_packages=tuple(packages),
+            )
+        except ValueError as error:
+            raise ClientDependencyResolutionError("client dependency lock is incompatible") from error
+        return ResolvedClientDependencies(lock=lock, wheel_sources=tuple(sources), lock_source=source)
+
+    def _resolution_environment(self, dependencies: ClientDependencies) -> dict[str, str]:
+        environment = dict(self._environ)
+        for reference in dependencies.index_credentials.values():
+            value = environment.get(reference.environment)
+            if value is None or not value:
+                raise ClientDependencyResolutionError("client dependency index credential is unavailable")
+        return environment
+
+
+def _build_lock(
+    client_image: ResolvedImage,
+    *,
+    image_distributions: tuple[InstalledDistribution, ...],
+    authored_requirements: tuple[str, ...],
+    overlay_packages: tuple[LockedPackage, ...] = (),
+) -> ResolvedDependencyLock:
+    inspection = client_image.inspection_facts
+    assert isinstance(inspection, ClientImageInspection)
+    return ResolvedDependencyLock(
+        schema_version=1,
+        resolver_version=_RESOLVER_VERSION,
+        python_abi=inspection.python_abi,
+        client_image_sha256=client_image.sha256,
+        authored_requirements=authored_requirements,
+        image_distributions=image_distributions,
+        overlay_packages=overlay_packages,
+    )
+
+
+def _load_downloaded_wheels(
+    wheelhouse: Path,
+    run_root: Path,
+    image_distributions: tuple[InstalledDistribution, ...],
+) -> tuple[tuple[LockedPackage, ...], tuple[Path, ...]]:
+    image = {item.name: item.version for item in image_distributions}
+    packages: list[tuple[LockedPackage, Path]] = []
+    names: set[str] = set()
+    for wheel in sorted(wheelhouse.iterdir(), key=lambda path: path.name):
+        status = wheel.lstat()
+        if not stat.S_ISREG(status.st_mode) or wheel.suffix != ".whl":
+            raise ClientDependencyResolutionError("dependency resolver produced an invalid artifact")
+        try:
+            name, version, _, tags = parse_wheel_filename(wheel.name)
+        except ValueError as error:
+            raise ClientDependencyResolutionError("dependency resolver produced an invalid wheel") from error
+        normalized_name = canonicalize_name(name)
+        normalized_version = str(version)
+        if not tags or any(tag.abi != "none" or tag.platform != "any" for tag in tags):
+            raise ClientDependencyResolutionError("client dependencies must resolve to platform-independent wheels")
+        if normalized_name in image:
+            if image[normalized_name] != normalized_version:
+                raise ClientDependencyResolutionError("client dependency conflicts with the selected image")
+            continue
+        if normalized_name in names:
+            raise ClientDependencyResolutionError("dependency resolver produced duplicate packages")
+        names.add(normalized_name)
+        digest = compute_file_sha256(wheel, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING)
+        packages.append(
+            (
+                LockedPackage(
+                    name=normalized_name,
+                    version=normalized_version,
+                    artifact=ArtifactReference(
+                        path=(run_root / _DEPENDENCY_DIRECTORY / wheel.name).as_posix(),
+                        sha256=digest,
+                    ),
+                ),
+                wheel,
+            )
+        )
+    packages.sort(key=lambda item: item[0].name)
+    return tuple(item[0] for item in packages), tuple(item[1] for item in packages)
+
+
+def _verify_locked_wheel(wheel: Path, package: LockedPackage) -> None:
+    try:
+        name, version, _, tags = parse_wheel_filename(wheel.name)
+        digest = compute_file_sha256(wheel, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING)
+    except Exception as error:
+        raise ClientDependencyResolutionError("client dependency artifact is invalid") from error
+    if (
+        not tags
+        or any(tag.abi != "none" or tag.platform != "any" for tag in tags)
+        or canonicalize_name(name) != package.name
+        or str(version) != package.version
+        or digest != package.artifact.sha256
+    ):
+        raise ClientDependencyResolutionError("client dependency artifact differs from its lock")
+
+
+def _run_pip_download(command: tuple[str, ...], cwd: Path, environment: Mapping[str, str]) -> None:
+    try:
+        subprocess.run(
+            command,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ClientDependencyResolutionError("client dependency resolution failed") from error
+
+
+__all__ = [
+    "ClientDependencyResolutionError",
+    "ClientDependencyResolver",
+    "ResolvedClientDependencies",
+]

--- a/packages/data-designer-slurm/src/data_designer/slurm/client/dependencies.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/client/dependencies.py
@@ -25,6 +25,7 @@ from data_designer.slurm.contracts import ArtifactReference, InstalledDistributi
 from data_designer.slurm.planning import LockedPackage, ResolvedDependencyLock, ResolvedImage
 
 _RESOLVER_VERSION = "pip-pure-wheel-1"
+_DEFAULT_INDEX_URL = "https://pypi.org/simple"
 _LOCK_SOURCE_DIRECTORY = "inputs"
 _DEPENDENCY_DIRECTORY = "dependencies"
 
@@ -110,9 +111,11 @@ class ClientDependencyResolver:
         temporary_root: Path,
     ) -> ResolvedClientDependencies:
         requirements = dependencies.requirements
-        assert requirements is not None
+        if requirements is None:
+            raise ClientDependencyResolutionError("client dependency requirements are unavailable")
         inspection = client_image.inspection_facts
-        assert isinstance(inspection, ClientImageInspection)
+        if not isinstance(inspection, ClientImageInspection):
+            raise ClientDependencyResolutionError("client image lacks dependency inspection facts")
         image_distributions = tuple(sorted(inspection.distributions, key=lambda item: item.name))
         if not requirements:
             return ResolvedClientDependencies(
@@ -136,6 +139,7 @@ class ClientDependencyResolver:
             "download",
             "--disable-pip-version-check",
             "--no-input",
+            f"--index-url={_DEFAULT_INDEX_URL}",
             "--only-binary=:all:",
             "--platform=any",
             "--implementation=py",
@@ -173,7 +177,8 @@ class ClientDependencyResolver:
         source_root: Path,
     ) -> ResolvedClientDependencies:
         lock_file = dependencies.lock_file
-        assert lock_file is not None
+        if lock_file is None:
+            raise ClientDependencyResolutionError("client dependency lock is unavailable")
         source = source_root / lock_file
         try:
             content = read_regular_bytes(source, missing_code=ClientErrorCode.DEPENDENCY_ARTIFACT_MISSING)
@@ -181,7 +186,8 @@ class ClientDependencyResolver:
         except Exception as error:
             raise ClientDependencyResolutionError("client dependency lock is invalid") from error
         inspection = client_image.inspection_facts
-        assert isinstance(inspection, ClientImageInspection)
+        if not isinstance(inspection, ClientImageInspection):
+            raise ClientDependencyResolutionError("client image lacks dependency inspection facts")
         if (
             supplied.client_image_sha256 != client_image.sha256
             or supplied.python_abi != inspection.python_abi
@@ -226,11 +232,18 @@ class ClientDependencyResolver:
         return ResolvedClientDependencies(lock=lock, wheel_sources=tuple(sources), lock_source=source)
 
     def _resolution_environment(self, dependencies: ClientDependencies) -> dict[str, str]:
-        environment = dict(self._environ)
+        credential_names = {reference.environment for reference in dependencies.index_credentials.values()}
         for reference in dependencies.index_credentials.values():
-            value = environment.get(reference.environment)
+            value = self._environ.get(reference.environment)
             if value is None or not value:
                 raise ClientDependencyResolutionError("client dependency index credential is unavailable")
+        # These credentials belong to the allocation runtime, not submit-side pip.
+        environment = {
+            name: value
+            for name, value in self._environ.items()
+            if not name.startswith("PIP_") and name not in credential_names
+        }
+        environment["PIP_CONFIG_FILE"] = os.devnull
         return environment
 
 
@@ -242,7 +255,8 @@ def _build_lock(
     overlay_packages: tuple[LockedPackage, ...] = (),
 ) -> ResolvedDependencyLock:
     inspection = client_image.inspection_facts
-    assert isinstance(inspection, ClientImageInspection)
+    if not isinstance(inspection, ClientImageInspection):
+        raise ClientDependencyResolutionError("client image lacks dependency inspection facts")
     return ResolvedDependencyLock(
         schema_version=1,
         resolver_version=_RESOLVER_VERSION,

--- a/packages/data-designer-slurm/src/data_designer/slurm/config/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/config/__init__.py
@@ -29,6 +29,7 @@ from data_designer.slurm.config.images import (
 from data_designer.slurm.config.loading import (
     DEFAULT_PROFILE_FILE_NAME,
     PROFILE_FILE_ENVIRONMENT,
+    load_builder_payload,
     load_profile_catalog,
     load_run_config,
     resolve_profile,
@@ -113,6 +114,7 @@ __all__ = [
     "SubmissionConfig",
     "VllmServerConfig",
     "injected_profile",
+    "load_builder_payload",
     "load_profile_catalog",
     "load_run_config",
     "resolve_profile",

--- a/packages/data-designer-slurm/src/data_designer/slurm/config/loading.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/config/loading.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TypeVar, cast
 
 import yaml
-from pydantic import ValidationError
+from pydantic import JsonValue, ValidationError
 from yaml.nodes import MappingNode
 
 from data_designer.slurm._errors import format_parse_error, format_validation_error
@@ -25,7 +25,7 @@ from data_designer.slurm.config.profiles import (
     injected_profile,
     select_profile,
 )
-from data_designer.slurm.config.run import DataDesignerSlurmConfig
+from data_designer.slurm.config.run import BuilderInput, DataDesignerSlurmConfig
 
 PROFILE_FILE_ENVIRONMENT = "DATA_DESIGNER_SLURM_PROFILE_FILE"
 DEFAULT_PROFILE_FILE_NAME = ".data-designer-slurm-profile.yml"
@@ -72,6 +72,31 @@ def load_run_config(path: str | Path) -> DataDesignerSlurmConfig:
 def load_profile_catalog(path: str | Path) -> SlurmProfileCatalog:
     """Load one strict local YAML or JSON cluster-profile catalog."""
     return _load_config(path, SlurmProfileCatalog)
+
+
+def load_builder_payload(path: str | Path) -> dict[str, JsonValue]:
+    """Load one complete serialized Data Designer builder config."""
+    resolved_path = _normalize_file_path(path)
+    try:
+        contents = resolved_path.read_text(encoding="utf-8")
+    except OSError:
+        raise SlurmConfigLoadError(f"cannot read configuration file {resolved_path}") from None
+    try:
+        payload = _parse_mapping(contents, suffix=resolved_path.suffix)
+        validated = BuilderInput(inline=payload).inline
+        assert validated is not None
+        return validated
+    except SlurmConfigLoadError:
+        raise
+    except ValidationError as error:
+        message = format_validation_error(
+            error,
+            subject=f"builder configuration file {resolved_path}",
+            models=BuilderInput,
+        )
+        raise SlurmConfigLoadError(message) from None
+    except (json.JSONDecodeError, yaml.YAMLError) as error:
+        raise SlurmConfigLoadError(f"invalid configuration file {resolved_path}: {format_parse_error(error)}") from None
 
 
 def resolve_profile(

--- a/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/images/service.py
@@ -308,7 +308,10 @@ def _open_verified_sqsh(
             dir_fd=directory_descriptor,
         )
         after_open = os.fstat(descriptor)
-        if (before_open.st_dev, before_open.st_ino) != (after_open.st_dev, after_open.st_ino):
+        if not stat.S_ISREG(after_open.st_mode) or (before_open.st_dev, before_open.st_ino) != (
+            after_open.st_dev,
+            after_open.st_ino,
+        ):
             raise ImageVerificationError(f"image path {path} changed while it was being opened")
         facts = _get_file_facts(after_open)
         sha256 = _hash_descriptor(descriptor)

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/__init__.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/__init__.py
@@ -5,24 +5,72 @@
 
 from __future__ import annotations
 
+import importlib
+from typing import TYPE_CHECKING
+
 from data_designer.slurm.services.benchmark import SlurmBenchmarkBackend, SlurmBenchmarkService
 from data_designer.slurm.services.errors import (
     SlurmServiceError,
     SlurmServiceErrorCode,
     SlurmServiceOperation,
 )
-from data_designer.slurm.services.images import SlurmImageResolver, SlurmImageService
-from data_designer.slurm.services.run import SlurmBatchScriptRenderer, SlurmRunPlanner, SlurmRunService
+from data_designer.slurm.services.images import SlurmImageManager, SlurmImageResolver, SlurmImageService
+from data_designer.slurm.services.results import (
+    SlurmPersistedAttemptStatus,
+    SlurmPersistedRunStatus,
+    SlurmPersistedShardStatus,
+    SlurmRunCancellation,
+    SlurmRunExecution,
+)
+from data_designer.slurm.services.run import SlurmBatchScriptRenderer, SlurmRunBackend, SlurmRunPlanner, SlurmRunService
+
+if TYPE_CHECKING:
+    from data_designer.slurm.services.wiring import (  # noqa: F401
+        SlurmRunArtifactPublisher,
+        create_slurm_image_service,
+        create_slurm_run_service,
+    )
+
+_LAZY_IMPORTS = {
+    "SlurmRunArtifactPublisher": ("data_designer.slurm.services.wiring", "SlurmRunArtifactPublisher"),
+    "create_slurm_image_service": ("data_designer.slurm.services.wiring", "create_slurm_image_service"),
+    "create_slurm_run_service": ("data_designer.slurm.services.wiring", "create_slurm_run_service"),
+}
 
 __all__ = [
     "SlurmBatchScriptRenderer",
     "SlurmBenchmarkBackend",
     "SlurmBenchmarkService",
+    "SlurmImageManager",
     "SlurmImageResolver",
     "SlurmImageService",
+    "SlurmPersistedAttemptStatus",
+    "SlurmPersistedRunStatus",
+    "SlurmPersistedShardStatus",
+    "SlurmRunArtifactPublisher",
+    "SlurmRunBackend",
+    "SlurmRunCancellation",
+    "SlurmRunExecution",
     "SlurmRunPlanner",
     "SlurmRunService",
     "SlurmServiceError",
     "SlurmServiceErrorCode",
     "SlurmServiceOperation",
+    "create_slurm_image_service",
+    "create_slurm_run_service",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily import production service wiring."""
+    if name in _LAZY_IMPORTS:
+        module_path, attribute_name = _LAZY_IMPORTS[name]
+        attribute = getattr(importlib.import_module(module_path), attribute_name)
+        globals()[name] = attribute
+        return attribute
+    raise AttributeError(f"module 'data_designer.slurm.services' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return public service exports."""
+    return __all__

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/errors.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/errors.py
@@ -29,7 +29,14 @@ class SlurmServiceOperation(str, Enum):
 
     PLAN_RUN = "plan_run"
     RENDER_ATTEMPT = "render_attempt"
+    EXECUTE_RUN = "execute_run"
+    STATUS_RUN = "status_run"
+    CANCEL_RUN = "cancel_run"
     RESOLVE_IMAGE = "resolve_image"
+    ADD_IMAGE = "add_image"
+    LIST_IMAGES = "list_images"
+    GET_IMAGE = "get_image"
+    REMOVE_IMAGE = "remove_image"
     RUN_BENCHMARK = "run_benchmark"
     ANALYZE_BENCHMARK = "analyze_benchmark"
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/images.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/images.py
@@ -7,13 +7,22 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from pydantic import TypeAdapter, ValidationError
+
 from data_designer.slurm.config import ImageKind, ImageRef
+from data_designer.slurm.config.images import ImageBuildRequest
+from data_designer.slurm.contracts import Identifier
+from data_designer.slurm.images.records import RegisteredImage
 from data_designer.slurm.planning import ResolvedImage
 from data_designer.slurm.services.errors import (
+    SlurmServiceError,
+    SlurmServiceErrorCode,
     SlurmServiceOperation,
     _invoke_service_backend,
     _make_invalid_request_error,
 )
+
+_IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 
 
 class SlurmImageResolver(Protocol):
@@ -26,18 +35,35 @@ class SlurmImageResolver(Protocol):
         """
 
 
+class SlurmImageManager(Protocol):
+    """Manage verified images through a supported service dependency."""
+
+    def add(self, request: ImageBuildRequest, *, replace: bool) -> RegisteredImage:
+        """Build or inspect and register one image."""
+
+    def list(self) -> tuple[RegisteredImage, ...]:
+        """Return all registered images in alias order."""
+
+    def get(self, name: Identifier) -> RegisteredImage:
+        """Return one registered image."""
+
+    def remove(self, name: Identifier) -> RegisteredImage:
+        """Unregister one alias without deleting its SQSH."""
+
+
 class SlurmImageService:
     """Expose stable image results through a package-owned boundary.
 
     The service borrows its injected dependency and does not manage its lifecycle.
 
     Args:
-        resolver: Image-resolution dependency implementing
-            ``SlurmImageResolver``.
+        resolver: Image-resolution dependency implementing ``SlurmImageResolver``.
+        manager: Optional image-operation dependency. Package-owned factories provide it.
     """
 
-    def __init__(self, resolver: SlurmImageResolver) -> None:
+    def __init__(self, resolver: SlurmImageResolver, manager: SlurmImageManager | None = None) -> None:
         self._resolver = resolver
+        self._manager = manager
 
     def resolve(self, reference: ImageRef, *, expected_kind: ImageKind) -> ResolvedImage:
         """Resolve one registered image for planning.
@@ -64,3 +90,80 @@ class SlurmImageService:
             return image
 
         return _invoke_service_backend(operation, resolve_image)
+
+    def add(self, request: ImageBuildRequest, *, replace: bool = False) -> RegisteredImage:
+        """Build or inspect and atomically register one image."""
+        operation = SlurmServiceOperation.ADD_IMAGE
+        if not isinstance(request, ImageBuildRequest):
+            raise _make_invalid_request_error(operation, "request must be an ImageBuildRequest")
+        if type(replace) is not bool:
+            raise _make_invalid_request_error(operation, "replace must be a boolean")
+        manager = self._require_manager(operation)
+
+        def add_image() -> RegisteredImage:
+            image = manager.add(request, replace=replace)
+            if not isinstance(image, RegisteredImage) or image.name != request.name or image.kind.value != request.kind:
+                raise TypeError("image manager returned an invalid registration result")
+            return image
+
+        return _invoke_service_backend(operation, add_image)
+
+    def list(self) -> tuple[RegisteredImage, ...]:
+        """Return all registered images in deterministic alias order."""
+        operation = SlurmServiceOperation.LIST_IMAGES
+        manager = self._require_manager(operation)
+
+        def list_images() -> tuple[RegisteredImage, ...]:
+            images = manager.list()
+            if not isinstance(images, tuple) or any(not isinstance(image, RegisteredImage) for image in images):
+                raise TypeError("image manager returned an invalid image list")
+            names = tuple(image.name for image in images)
+            if names != tuple(sorted(names)) or len(names) != len(set(names)):
+                raise ValueError("image manager returned an invalid image order")
+            return images
+
+        return _invoke_service_backend(operation, list_images)
+
+    def get(self, name: Identifier) -> RegisteredImage:
+        """Return one registered image by alias."""
+        operation = SlurmServiceOperation.GET_IMAGE
+        normalized_name = _validate_name(name, operation)
+        manager = self._require_manager(operation)
+
+        def get_image() -> RegisteredImage:
+            image = manager.get(normalized_name)
+            if not isinstance(image, RegisteredImage) or image.name != normalized_name:
+                raise TypeError("image manager returned an invalid image result")
+            return image
+
+        return _invoke_service_backend(operation, get_image)
+
+    def remove(self, name: Identifier) -> RegisteredImage:
+        """Unregister one alias without deleting its SQSH artifact."""
+        operation = SlurmServiceOperation.REMOVE_IMAGE
+        normalized_name = _validate_name(name, operation)
+        manager = self._require_manager(operation)
+
+        def remove_image() -> RegisteredImage:
+            image = manager.remove(normalized_name)
+            if not isinstance(image, RegisteredImage) or image.name != normalized_name:
+                raise TypeError("image manager returned an invalid removal result")
+            return image
+
+        return _invoke_service_backend(operation, remove_image)
+
+    def _require_manager(self, operation: SlurmServiceOperation) -> SlurmImageManager:
+        if self._manager is None:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE,
+                operation,
+                "image operations require package-owned service construction",
+            )
+        return self._manager
+
+
+def _validate_name(name: object, operation: SlurmServiceOperation) -> Identifier:
+    try:
+        return _IDENTIFIER_ADAPTER.validate_python(name, strict=True)
+    except ValidationError:
+        raise _make_invalid_request_error(operation, "name must be a valid identifier") from None

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/results.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/results.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable values returned by public Slurm operations."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import PositiveInt, model_validator
+
+from data_designer.slurm.contracts import ContractValue, Identifier, Sha256Digest
+from data_designer.slurm.state import (
+    AttemptManifest,
+    AttemptReadiness,
+    RunManifest,
+    ShardManifest,
+    ShardWinner,
+)
+
+
+class SlurmRunExecution(ContractValue):
+    """One rendered dry run or accepted Slurm submission."""
+
+    run_id: Identifier
+    state: Literal["dry_run", "submitted"]
+    plan_sha256: Sha256Digest
+    shard_count: PositiveInt
+    job_id: PositiveInt | None = None
+    batch_script: str | None = None
+
+    @model_validator(mode="after")
+    def validate_state(self) -> SlurmRunExecution:
+        if self.state == "dry_run":
+            if self.job_id is not None or not self.batch_script:
+                raise ValueError("dry-run execution requires only a rendered batch script")
+        elif self.job_id is None or self.batch_script is not None:
+            raise ValueError("submitted execution requires only a Slurm job ID")
+        return self
+
+
+class SlurmPersistedAttemptStatus(ContractValue):
+    """Persisted attempt state available without scheduler reconciliation."""
+
+    attempt: AttemptManifest
+    readiness: AttemptReadiness | None = None
+
+    @model_validator(mode="after")
+    def validate_readiness(self) -> SlurmPersistedAttemptStatus:
+        if self.readiness is not None and (
+            self.readiness.run_id,
+            self.readiness.shard_id,
+            self.readiness.attempt_id,
+        ) != (self.attempt.run_id, self.attempt.shard_id, self.attempt.attempt_id):
+            raise ValueError("readiness identity does not match its attempt")
+        return self
+
+
+class SlurmPersistedShardStatus(ContractValue):
+    """Persisted attempt and winner state for one shard."""
+
+    shard: ShardManifest
+    attempts: tuple[SlurmPersistedAttemptStatus, ...]
+    winner: ShardWinner | None = None
+
+    @model_validator(mode="after")
+    def validate_shard(self) -> SlurmPersistedShardStatus:
+        if any(status.attempt.shard_id != self.shard.shard_id for status in self.attempts):
+            raise ValueError("persisted status contains an attempt for another shard")
+        if self.winner is not None and (
+            self.winner.run_id != self.shard.run_id or self.winner.shard_id != self.shard.shard_id
+        ):
+            raise ValueError("persisted winner does not match its shard")
+        return self
+
+
+class SlurmPersistedRunStatus(ContractValue):
+    """M2 status assembled only from durable run records."""
+
+    run: RunManifest
+    shards: tuple[SlurmPersistedShardStatus, ...]
+
+    @model_validator(mode="after")
+    def validate_run(self) -> SlurmPersistedRunStatus:
+        if len(self.shards) != self.run.shard_count:
+            raise ValueError("persisted status must contain every run shard")
+        if tuple(status.shard.shard_index for status in self.shards) != tuple(range(self.run.shard_count)):
+            raise ValueError("persisted status shards must remain in planned order")
+        if any(status.shard.run_id != self.run.run_id for status in self.shards):
+            raise ValueError("persisted status contains a shard for another run")
+        return self
+
+
+class SlurmRunCancellation(ContractValue):
+    """Managed Slurm array jobs selected for cancellation."""
+
+    run_id: Identifier
+    job_ids: tuple[PositiveInt, ...]
+
+    @model_validator(mode="after")
+    def validate_jobs(self) -> SlurmRunCancellation:
+        if self.job_ids != tuple(sorted(set(self.job_ids))):
+            raise ValueError("cancelled job IDs must be sorted and unique")
+        return self
+
+
+__all__ = [
+    "SlurmPersistedAttemptStatus",
+    "SlurmPersistedRunStatus",
+    "SlurmPersistedShardStatus",
+    "SlurmRunCancellation",
+    "SlurmRunExecution",
+]

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/run.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/run.py
@@ -5,21 +5,34 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Protocol
 
+from pydantic import TypeAdapter, ValidationError
+
 from data_designer.slurm.config import DataDesignerSlurmConfig
+from data_designer.slurm.contracts import Identifier
 from data_designer.slurm.planning import ResolvedSlurmRunPlan
 from data_designer.slurm.services.errors import (
+    SlurmServiceError,
+    SlurmServiceErrorCode,
     SlurmServiceOperation,
     _invoke_service_backend,
     _make_invalid_request_error,
 )
+from data_designer.slurm.services.results import (
+    SlurmPersistedRunStatus,
+    SlurmRunCancellation,
+    SlurmRunExecution,
+)
+
+_IDENTIFIER_ADAPTER = TypeAdapter(Identifier)
 
 
 class SlurmRunPlanner(Protocol):
     """Resolve authored run configs through a supported service dependency."""
 
-    def plan(self, config: DataDesignerSlurmConfig) -> ResolvedSlurmRunPlan:
+    def plan(self, config: DataDesignerSlurmConfig, *, source_root: Path) -> ResolvedSlurmRunPlan:
         """Return the immutable plan for one authored run.
 
         Any non-``INTERNAL`` service error must contain a caller-safe message.
@@ -36,6 +49,26 @@ class SlurmBatchScriptRenderer(Protocol):
         """
 
 
+class SlurmRunBackend(Protocol):
+    """Execute and inspect runs through a supported service dependency."""
+
+    def execute(
+        self,
+        config: DataDesignerSlurmConfig,
+        *,
+        source_root: Path,
+        dry_run: bool,
+        force: bool,
+    ) -> SlurmRunExecution:
+        """Render or submit one run."""
+
+    def status(self, run_id: Identifier) -> SlurmPersistedRunStatus:
+        """Return the durable M2 status for one run."""
+
+    def cancel(self, run_id: Identifier) -> SlurmRunCancellation:
+        """Cancel active managed jobs recorded for one run."""
+
+
 class SlurmRunService:
     """Coordinate public run operations through package-owned boundaries.
 
@@ -44,15 +77,26 @@ class SlurmRunService:
 
     Args:
         planner: Run-planning dependency implementing ``SlurmRunPlanner``.
-        renderer: Batch-rendering dependency implementing
-            ``SlurmBatchScriptRenderer``.
+        renderer: Batch-rendering dependency implementing ``SlurmBatchScriptRenderer``.
+        backend: Optional run-operation dependency. Package-owned factories provide it.
     """
 
-    def __init__(self, planner: SlurmRunPlanner, renderer: SlurmBatchScriptRenderer) -> None:
+    def __init__(
+        self,
+        planner: SlurmRunPlanner,
+        renderer: SlurmBatchScriptRenderer,
+        backend: SlurmRunBackend | None = None,
+    ) -> None:
         self._planner = planner
         self._renderer = renderer
+        self._backend = backend
 
-    def plan(self, config: DataDesignerSlurmConfig) -> ResolvedSlurmRunPlan:
+    def plan(
+        self,
+        config: DataDesignerSlurmConfig,
+        *,
+        source_root: str | Path = ".",
+    ) -> ResolvedSlurmRunPlan:
         """Resolve and compile one run without rendering or submission.
 
         The returned plan must reference the exact serialized authored config.
@@ -63,9 +107,11 @@ class SlurmRunService:
         operation = SlurmServiceOperation.PLAN_RUN
         if not isinstance(config, DataDesignerSlurmConfig):
             raise _make_invalid_request_error(operation, "config must be a DataDesignerSlurmConfig")
+        if not isinstance(source_root, str | Path):
+            raise _make_invalid_request_error(operation, "source_root must be a path")
 
         def build_plan() -> ResolvedSlurmRunPlan:
-            plan = self._planner.plan(config)
+            plan = self._planner.plan(config, source_root=Path(source_root).expanduser().resolve())
             if not isinstance(plan, ResolvedSlurmRunPlan):
                 raise TypeError("run planner returned an invalid result")
             if plan.authored_config.sha256 != config.compute_sha256():
@@ -100,3 +146,78 @@ class SlurmRunService:
             return script
 
         return _invoke_service_backend(operation, render)
+
+    def execute(
+        self,
+        config: DataDesignerSlurmConfig,
+        *,
+        source_root: str | Path = ".",
+        dry_run: bool = False,
+        force: bool = False,
+    ) -> SlurmRunExecution:
+        """Render or submit one run through package-owned production wiring."""
+        operation = SlurmServiceOperation.EXECUTE_RUN
+        if not isinstance(config, DataDesignerSlurmConfig):
+            raise _make_invalid_request_error(operation, "config must be a DataDesignerSlurmConfig")
+        if not isinstance(source_root, str | Path):
+            raise _make_invalid_request_error(operation, "source_root must be a path")
+        if type(dry_run) is not bool or type(force) is not bool:
+            raise _make_invalid_request_error(operation, "dry_run and force must be booleans")
+        backend = self._require_backend(operation)
+
+        def execute_run() -> SlurmRunExecution:
+            result = backend.execute(
+                config,
+                source_root=Path(source_root).expanduser().resolve(),
+                dry_run=dry_run,
+                force=force,
+            )
+            if not isinstance(result, SlurmRunExecution):
+                raise TypeError("run backend returned an invalid execution result")
+            return result
+
+        return _invoke_service_backend(operation, execute_run)
+
+    def status(self, run_id: Identifier) -> SlurmPersistedRunStatus:
+        """Return persisted M2 records without scheduler reconciliation."""
+        operation = SlurmServiceOperation.STATUS_RUN
+        normalized_run_id = _validate_run_id(run_id, operation)
+        backend = self._require_backend(operation)
+
+        def load_status() -> SlurmPersistedRunStatus:
+            result = backend.status(normalized_run_id)
+            if not isinstance(result, SlurmPersistedRunStatus) or result.run.run_id != normalized_run_id:
+                raise TypeError("run backend returned an invalid status result")
+            return result
+
+        return _invoke_service_backend(operation, load_status)
+
+    def cancel(self, run_id: Identifier) -> SlurmRunCancellation:
+        """Cancel active managed jobs identified by persisted M2 records."""
+        operation = SlurmServiceOperation.CANCEL_RUN
+        normalized_run_id = _validate_run_id(run_id, operation)
+        backend = self._require_backend(operation)
+
+        def cancel_run() -> SlurmRunCancellation:
+            result = backend.cancel(normalized_run_id)
+            if not isinstance(result, SlurmRunCancellation) or result.run_id != normalized_run_id:
+                raise TypeError("run backend returned an invalid cancellation result")
+            return result
+
+        return _invoke_service_backend(operation, cancel_run)
+
+    def _require_backend(self, operation: SlurmServiceOperation) -> SlurmRunBackend:
+        if self._backend is None:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE,
+                operation,
+                "run operations require package-owned service construction",
+            )
+        return self._backend
+
+
+def _validate_run_id(run_id: object, operation: SlurmServiceOperation) -> Identifier:
+    try:
+        return _IDENTIFIER_ADAPTER.validate_python(run_id, strict=True)
+    except ValidationError:
+        raise _make_invalid_request_error(operation, "run_id must be a valid identifier") from None

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/run.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/run.py
@@ -66,7 +66,7 @@ class SlurmRunBackend(Protocol):
         """Return the durable M2 status for one run."""
 
     def cancel(self, run_id: Identifier) -> SlurmRunCancellation:
-        """Cancel active managed jobs recorded for one run."""
+        """Request cancellation of active jobs without changing persisted state."""
 
 
 class SlurmRunService:
@@ -193,7 +193,7 @@ class SlurmRunService:
         return _invoke_service_backend(operation, load_status)
 
     def cancel(self, run_id: Identifier) -> SlurmRunCancellation:
-        """Cancel active managed jobs identified by persisted M2 records."""
+        """Request cancellation of active jobs; reconciliation updates persisted state."""
         operation = SlurmServiceOperation.CANCEL_RUN
         normalized_run_id = _validate_run_id(run_id, operation)
         backend = self._require_backend(operation)

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
@@ -68,6 +68,7 @@ from data_designer.slurm.state import (
 RunIdFactory = Callable[[], str]
 Clock = Callable[[], datetime]
 _ResultT = TypeVar("_ResultT")
+_MAX_VISIBLE_JOB_IDS = 16
 
 
 class SlurmRunArtifactPublisher(Protocol):
@@ -196,11 +197,7 @@ class _RunPreparer:
             ) from None
         except SlurmLauncherError:
             raise SlurmServiceError(SlurmServiceErrorCode.UNAVAILABLE, operation, "Slurm is unavailable") from None
-        except SlurmRuntimeError:
-            raise SlurmServiceError(
-                SlurmServiceErrorCode.UNAVAILABLE, operation, "run artifacts cannot be staged"
-            ) from None
-        except OSError:
+        except (SlurmRuntimeError, OSError):
             raise SlurmServiceError(
                 SlurmServiceErrorCode.UNAVAILABLE, operation, "run artifacts cannot be staged"
             ) from None
@@ -390,7 +387,11 @@ class _SystemRunBackend:
                 attempts = tuple(
                     SlurmPersistedAttemptStatus(
                         attempt=attempt,
-                        readiness=_load_optional(lambda: writer.load_readiness(shard.shard_id, attempt.attempt_id)),
+                        readiness=_load_optional(
+                            lambda shard_id=shard.shard_id, attempt_id=attempt.attempt_id: writer.load_readiness(
+                                shard_id, attempt_id
+                            )
+                        ),
                     )
                     for attempt in writer.load_attempts(shard.shard_id)
                 )
@@ -398,7 +399,7 @@ class _SystemRunBackend:
                     SlurmPersistedShardStatus(
                         shard=shard,
                         attempts=attempts,
-                        winner=_load_optional(lambda: writer.load_winner(shard.shard_id)),
+                        winner=_load_optional(lambda shard_id=shard.shard_id: writer.load_winner(shard_id)),
                     )
                 )
             return SlurmPersistedRunStatus(run=run, shards=tuple(shards))
@@ -561,8 +562,8 @@ def _utc_now() -> datetime:
 
 
 def _format_job_ids(job_ids: list[int]) -> str:
-    visible = ", ".join(str(job_id) for job_id in job_ids[:16])
-    remaining = len(job_ids) - 16
+    visible = ", ".join(str(job_id) for job_id in job_ids[:_MAX_VISIBLE_JOB_IDS])
+    remaining = len(job_ids) - _MAX_VISIBLE_JOB_IDS
     return visible if remaining <= 0 else f"{visible}, and {remaining} more"
 
 

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
@@ -275,7 +275,7 @@ class _SystemRunBackend:
                 raise SlurmServiceError(
                     SlurmServiceErrorCode.UNAVAILABLE,
                     SlurmServiceOperation.EXECUTE_RUN,
-                    "STATE run-artifact persistence is not available",
+                    "run submission is not available; use --dry-run",
                 )
             publisher = self._publisher
             self._initialize_run(
@@ -463,7 +463,7 @@ class _RegistryImageBackend:
         raise SlurmServiceError(
             SlurmServiceErrorCode.UNAVAILABLE,
             SlurmServiceOperation.ADD_IMAGE,
-            "IMG lifecycle completion cannot be reopened safely",
+            "image registration is not available; use a pre-registered image",
         )
 
     def list(self) -> tuple[RegisteredImage, ...]:

--- a/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
+++ b/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py
@@ -1,0 +1,573 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package-owned production wiring for public Slurm services."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, TypeVar
+from uuid import uuid4
+
+from pydantic import JsonValue
+
+from data_designer.slurm.client.dependencies import (
+    ClientDependencyResolutionError,
+    ClientDependencyResolver,
+    ResolvedClientDependencies,
+)
+from data_designer.slurm.config import (
+    DataDesignerSlurmConfig,
+    ImageBuildRequest,
+    ImageKind,
+    ImageRef,
+    SelectedSlurmProfile,
+    SlurmConfigLoadError,
+    SlurmProfile,
+    SlurmProfileCatalog,
+    load_builder_payload,
+    resolve_profile,
+)
+from data_designer.slurm.contracts import Identifier
+from data_designer.slurm.images.errors import ImageConflictError, ImageNotFoundError, SlurmImageError
+from data_designer.slurm.images.records import RegisteredImage
+from data_designer.slurm.images.registry import ImageRegistryStore
+from data_designer.slurm.images.service import VerifiedImageRegistry
+from data_designer.slurm.launcher.client import SlurmCommandClient
+from data_designer.slurm.launcher.errors import SlurmLauncherError
+from data_designer.slurm.launcher.renderer import render_generation_attempt_script
+from data_designer.slurm.planning import ResolvedImage, ResolvedSlurmRunPlan
+from data_designer.slurm.planning.compiler import SlurmRunCompiler
+from data_designer.slurm.planning.resolution import resolve_slurm_config
+from data_designer.slurm.runtime.bundle import stage_runtime_bundle
+from data_designer.slurm.runtime.errors import SlurmRuntimeError
+from data_designer.slurm.services.errors import SlurmServiceError, SlurmServiceErrorCode, SlurmServiceOperation
+from data_designer.slurm.services.images import SlurmImageService
+from data_designer.slurm.services.results import (
+    SlurmPersistedAttemptStatus,
+    SlurmPersistedRunStatus,
+    SlurmPersistedShardStatus,
+    SlurmRunCancellation,
+    SlurmRunExecution,
+)
+from data_designer.slurm.services.run import SlurmRunService
+from data_designer.slurm.serving.resolver import resolve_vllm_server
+from data_designer.slurm.state import (
+    AttemptLifecycleState,
+    SlurmStateError,
+    SlurmStateWriter,
+    StateConflictError,
+    StateNotFoundError,
+)
+
+RunIdFactory = Callable[[], str]
+Clock = Callable[[], datetime]
+_ResultT = TypeVar("_ResultT")
+
+
+class SlurmRunArtifactPublisher(Protocol):
+    """Persist submission-critical run artifacts through the STATE boundary."""
+
+    def initialize(
+        self,
+        authored: DataDesignerSlurmConfig,
+        plan: ResolvedSlurmRunPlan,
+        dependencies: ResolvedClientDependencies,
+        builder_payload: dict[str, JsonValue] | None,
+        *,
+        force: bool,
+    ) -> None:
+        """Atomically publish all immutable run inputs before submission."""
+
+    def record_submission(self, plan: ResolvedSlurmRunPlan, job_id: int, *, submitted_at: datetime) -> None:
+        """Persist the submitted scheduler identity for every initial attempt."""
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedRun:
+    plan: ResolvedSlurmRunPlan
+    dependencies: ResolvedClientDependencies
+    builder_payload: dict[str, JsonValue] | None
+    batch_script: str
+
+
+class _RunPreparer:
+    def __init__(
+        self,
+        selected_profile: SelectedSlurmProfile,
+        image_registry: VerifiedImageRegistry,
+        dependency_resolver: ClientDependencyResolver,
+        launcher: SlurmCommandClient,
+        run_id_factory: RunIdFactory,
+        package_version: str,
+    ) -> None:
+        self._profile = selected_profile
+        self._images = image_registry
+        self._dependencies = dependency_resolver
+        self._launcher = launcher
+        self._run_id_factory = run_id_factory
+        self._package_version = package_version
+
+    @contextmanager
+    def prepare(
+        self,
+        authored: DataDesignerSlurmConfig,
+        *,
+        source_root: Path,
+        operation: SlurmServiceOperation,
+    ) -> Iterator[_PreparedRun]:
+        stack = ExitStack()
+        try:
+            prepared = self._prepare(authored, source_root=source_root, operation=operation, stack=stack)
+        except BaseException:
+            stack.close()
+            raise
+        try:
+            yield prepared
+        finally:
+            stack.close()
+
+    def _prepare(
+        self,
+        authored: DataDesignerSlurmConfig,
+        *,
+        source_root: Path,
+        operation: SlurmServiceOperation,
+        stack: ExitStack,
+    ) -> _PreparedRun:
+        try:
+            run_id = self._run_id_factory()
+            workspace_root = self._profile.profile.workspace_root
+            run_root = Path(workspace_root) / "runs" / run_id
+            client_image = self._images.resolve_for_planning(authored.client.image, expected_kind=ImageKind.CLIENT)
+            deployment_images = tuple(
+                self._images.resolve_for_planning(deployment.server.image, expected_kind=ImageKind.SERVING)
+                for deployment in authored.deployments
+            )
+            builder_payload = _resolve_builder_payload(authored, source_root)
+            dependencies = stack.enter_context(
+                self._dependencies.resolve(
+                    authored.client.dependencies,
+                    client_image,
+                    run_root=run_root,
+                    source_root=source_root,
+                )
+            )
+            runtime_bundle = stage_runtime_bundle(workspace_root)
+            effective = resolve_slurm_config(
+                authored,
+                selected_profile=self._profile,
+                client_image=client_image,
+                deployment_images=deployment_images,
+                dependency_lock=dependencies.lock,
+                runtime_bundle=runtime_bundle,
+                run_id=run_id,
+                package_version=self._package_version,
+                resolved_gpus_per_node=self._resolve_gpu_count(authored, operation),
+                builder_payload=builder_payload,
+            )
+            plan = SlurmRunCompiler.compile(effective)
+            for deployment in plan.deployments:
+                resolve_vllm_server(plan, deployment.deployment_id)
+            return _PreparedRun(
+                plan=plan,
+                dependencies=dependencies,
+                builder_payload=builder_payload,
+                batch_script=render_generation_attempt_script(plan, attempt_ordinal=1),
+            )
+        except SlurmServiceError:
+            raise
+        except ImageNotFoundError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.NOT_FOUND, operation, "required image is not registered"
+            ) from None
+        except SlurmImageError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.CONFLICT, operation, "required image cannot be verified"
+            ) from None
+        except (ClientDependencyResolutionError, SlurmConfigLoadError, ValueError):
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.INVALID_REQUEST, operation, "run configuration cannot be prepared"
+            ) from None
+        except SlurmLauncherError:
+            raise SlurmServiceError(SlurmServiceErrorCode.UNAVAILABLE, operation, "Slurm is unavailable") from None
+        except SlurmRuntimeError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE, operation, "run artifacts cannot be staged"
+            ) from None
+        except OSError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE, operation, "run artifacts cannot be staged"
+            ) from None
+
+    def _resolve_gpu_count(
+        self,
+        authored: DataDesignerSlurmConfig,
+        operation: SlurmServiceOperation,
+    ) -> int | None:
+        if self._profile.profile.gpus_per_node != "auto":
+            return None
+        partition = authored.submission.partition or self._profile.profile.scheduler.partition
+        counts = tuple(sorted(set(self._launcher.query_gpu_counts(partition=partition))))
+        if len(counts) != 1:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE,
+                operation,
+                "eligible Slurm nodes do not report one GPU count",
+            )
+        return counts[0]
+
+
+class _SystemRunPlanner:
+    def __init__(self, preparer: _RunPreparer) -> None:
+        self._preparer = preparer
+
+    def plan(self, config: DataDesignerSlurmConfig, *, source_root: Path) -> ResolvedSlurmRunPlan:
+        with self._preparer.prepare(
+            config, source_root=source_root, operation=SlurmServiceOperation.PLAN_RUN
+        ) as prepared:
+            return prepared.plan
+
+
+class _SystemRunBackend:
+    def __init__(
+        self,
+        preparer: _RunPreparer,
+        selected_profile: SelectedSlurmProfile,
+        launcher: SlurmCommandClient,
+        publisher: SlurmRunArtifactPublisher | None,
+        clock: Clock,
+    ) -> None:
+        self._preparer = preparer
+        self._profile = selected_profile
+        self._launcher = launcher
+        self._publisher = publisher
+        self._clock = clock
+
+    def execute(
+        self,
+        config: DataDesignerSlurmConfig,
+        *,
+        source_root: Path,
+        dry_run: bool,
+        force: bool,
+    ) -> SlurmRunExecution:
+        with self._preparer.prepare(
+            config,
+            source_root=source_root,
+            operation=SlurmServiceOperation.EXECUTE_RUN,
+        ) as prepared:
+            plan = prepared.plan
+            if dry_run:
+                return SlurmRunExecution(
+                    run_id=plan.run_id,
+                    state="dry_run",
+                    plan_sha256=plan.compute_sha256(),
+                    shard_count=len(plan.shards),
+                    batch_script=prepared.batch_script,
+                )
+            if self._publisher is None:
+                raise SlurmServiceError(
+                    SlurmServiceErrorCode.UNAVAILABLE,
+                    SlurmServiceOperation.EXECUTE_RUN,
+                    "STATE run-artifact persistence is not available",
+                )
+            publisher = self._publisher
+            self._initialize_run(
+                publisher,
+                config,
+                prepared,
+                force=force,
+            )
+            try:
+                receipt = self._launcher.submit_script(prepared.batch_script)
+            except SlurmLauncherError:
+                raise SlurmServiceError(
+                    SlurmServiceErrorCode.UNAVAILABLE,
+                    SlurmServiceOperation.EXECUTE_RUN,
+                    "Slurm submission is unavailable",
+                ) from None
+            try:
+                self._record_submission(publisher, plan, receipt.job_id)
+            except Exception as error:
+                try:
+                    self._launcher.cancel(receipt.job_id)
+                except Exception:
+                    raise SlurmServiceError(
+                        SlurmServiceErrorCode.UNAVAILABLE,
+                        SlurmServiceOperation.EXECUTE_RUN,
+                        f"Slurm job {receipt.job_id} was submitted but could not be recorded or cancelled",
+                    ) from error
+                raise
+            except BaseException:
+                try:
+                    self._launcher.cancel(receipt.job_id)
+                except Exception:
+                    pass
+                raise
+            return SlurmRunExecution(
+                run_id=plan.run_id,
+                state="submitted",
+                plan_sha256=plan.compute_sha256(),
+                shard_count=len(plan.shards),
+                job_id=receipt.job_id,
+            )
+
+    def _initialize_run(
+        self,
+        publisher: SlurmRunArtifactPublisher,
+        config: DataDesignerSlurmConfig,
+        prepared: _PreparedRun,
+        *,
+        force: bool,
+    ) -> None:
+        try:
+            publisher.initialize(
+                config,
+                prepared.plan,
+                prepared.dependencies,
+                prepared.builder_payload,
+                force=force,
+            )
+        except StateNotFoundError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.NOT_FOUND,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "required run state was not found",
+            ) from None
+        except StateConflictError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.CONFLICT,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "run state already contains different inputs",
+            ) from None
+        except SlurmStateError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.INTERNAL,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "run state cannot be initialized",
+            ) from None
+
+    def _record_submission(
+        self,
+        publisher: SlurmRunArtifactPublisher,
+        plan: ResolvedSlurmRunPlan,
+        job_id: int,
+    ) -> None:
+        try:
+            publisher.record_submission(plan, job_id, submitted_at=self._clock())
+        except StateNotFoundError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.NOT_FOUND,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "submitted run state was not found",
+            ) from None
+        except StateConflictError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.CONFLICT,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "submitted run state conflicts with persisted state",
+            ) from None
+        except SlurmStateError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.INTERNAL,
+                SlurmServiceOperation.EXECUTE_RUN,
+                "submission state cannot be recorded",
+            ) from None
+
+    def status(self, run_id: Identifier) -> SlurmPersistedRunStatus:
+        operation = SlurmServiceOperation.STATUS_RUN
+        try:
+            writer = SlurmStateWriter(self._profile.profile.workspace_root, run_id)
+            run = writer.load_run()
+            shards = []
+            for shard in writer.load_shards():
+                attempts = tuple(
+                    SlurmPersistedAttemptStatus(
+                        attempt=attempt,
+                        readiness=_load_optional(lambda: writer.load_readiness(shard.shard_id, attempt.attempt_id)),
+                    )
+                    for attempt in writer.load_attempts(shard.shard_id)
+                )
+                shards.append(
+                    SlurmPersistedShardStatus(
+                        shard=shard,
+                        attempts=attempts,
+                        winner=_load_optional(lambda: writer.load_winner(shard.shard_id)),
+                    )
+                )
+            return SlurmPersistedRunStatus(run=run, shards=tuple(shards))
+        except StateNotFoundError:
+            raise SlurmServiceError(SlurmServiceErrorCode.NOT_FOUND, operation, "run state was not found") from None
+        except StateConflictError:
+            raise SlurmServiceError(SlurmServiceErrorCode.CONFLICT, operation, "run state is inconsistent") from None
+        except SlurmStateError:
+            raise SlurmServiceError(SlurmServiceErrorCode.INTERNAL, operation, "run state cannot be read") from None
+
+    def cancel(self, run_id: Identifier) -> SlurmRunCancellation:
+        status = self.status(run_id)
+        active = {AttemptLifecycleState.SUBMITTED, AttemptLifecycleState.PENDING, AttemptLifecycleState.RUNNING}
+        job_ids = tuple(
+            sorted(
+                {
+                    attempt.attempt.scheduler.array_job_id
+                    for shard in status.shards
+                    for attempt in shard.attempts
+                    if attempt.attempt.state in active and attempt.attempt.scheduler is not None
+                }
+            )
+        )
+        failures = []
+        for job_id in job_ids:
+            try:
+                self._launcher.cancel(job_id)
+            except SlurmLauncherError:
+                failures.append(job_id)
+        if failures:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.UNAVAILABLE,
+                SlurmServiceOperation.CANCEL_RUN,
+                f"failed to cancel managed Slurm jobs: {_format_job_ids(failures)}",
+            )
+        return SlurmRunCancellation(run_id=run_id, job_ids=job_ids)
+
+
+class _RegistryImageBackend:
+    def __init__(self, workspace_root: str) -> None:
+        self._verified = VerifiedImageRegistry(workspace_root)
+        self._store = ImageRegistryStore(workspace_root)
+
+    def resolve(self, reference: ImageRef, *, expected_kind: ImageKind) -> ResolvedImage:
+        try:
+            return self._verified.resolve_for_planning(reference, expected_kind=expected_kind)
+        except ImageNotFoundError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.NOT_FOUND,
+                SlurmServiceOperation.RESOLVE_IMAGE,
+                "image is not registered",
+            ) from None
+        except SlurmImageError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.CONFLICT,
+                SlurmServiceOperation.RESOLVE_IMAGE,
+                "registered image cannot be verified",
+            ) from None
+
+    def add(self, request: ImageBuildRequest, *, replace: bool) -> RegisteredImage:
+        del request, replace
+        raise SlurmServiceError(
+            SlurmServiceErrorCode.UNAVAILABLE,
+            SlurmServiceOperation.ADD_IMAGE,
+            "IMG lifecycle completion cannot be reopened safely",
+        )
+
+    def list(self) -> tuple[RegisteredImage, ...]:
+        return self._invoke_registry(SlurmServiceOperation.LIST_IMAGES, self._store.list_images)
+
+    def get(self, name: Identifier) -> RegisteredImage:
+        return self._invoke_registry(SlurmServiceOperation.GET_IMAGE, lambda: self._store.get_by_name(name))
+
+    def remove(self, name: Identifier) -> RegisteredImage:
+        return self._invoke_registry(SlurmServiceOperation.REMOVE_IMAGE, lambda: self._verified.unregister(name))
+
+    @staticmethod
+    def _invoke_registry(operation: SlurmServiceOperation, call: Callable[[], _ResultT]) -> _ResultT:
+        try:
+            return call()
+        except ImageNotFoundError:
+            raise SlurmServiceError(SlurmServiceErrorCode.NOT_FOUND, operation, "image is not registered") from None
+        except ImageConflictError:
+            raise SlurmServiceError(SlurmServiceErrorCode.CONFLICT, operation, "image registry conflict") from None
+        except SlurmImageError:
+            raise SlurmServiceError(
+                SlurmServiceErrorCode.INTERNAL, operation, "image registry operation failed"
+            ) from None
+
+
+def create_slurm_run_service(
+    *,
+    profile: SlurmProfile | None = None,
+    catalog: SlurmProfileCatalog | None = None,
+    profile_file: str | Path | None = None,
+    cluster: str | None = None,
+    artifact_publisher: SlurmRunArtifactPublisher | None = None,
+    dependency_resolver: ClientDependencyResolver | None = None,
+    launcher: SlurmCommandClient | None = None,
+    run_id_factory: RunIdFactory | None = None,
+    clock: Clock | None = None,
+    package_version: str | None = None,
+) -> SlurmRunService:
+    """Create the production run service for one selected cluster profile."""
+    selected = resolve_profile(profile=profile, catalog=catalog, profile_file=profile_file, cluster=cluster)
+    command_client = launcher or SlurmCommandClient()
+    preparer = _RunPreparer(
+        selected,
+        VerifiedImageRegistry(selected.profile.workspace_root),
+        dependency_resolver or ClientDependencyResolver(),
+        command_client,
+        run_id_factory or _new_run_id,
+        package_version or importlib.metadata.version("data-designer-slurm"),
+    )
+    backend = _SystemRunBackend(
+        preparer,
+        selected,
+        command_client,
+        artifact_publisher,
+        clock or _utc_now,
+    )
+    return SlurmRunService(_SystemRunPlanner(preparer), render_generation_attempt_script, backend)
+
+
+def create_slurm_image_service(
+    *,
+    profile: SlurmProfile | None = None,
+    catalog: SlurmProfileCatalog | None = None,
+    profile_file: str | Path | None = None,
+    cluster: str | None = None,
+) -> SlurmImageService:
+    """Create the production image service for one selected cluster profile."""
+    selected = resolve_profile(profile=profile, catalog=catalog, profile_file=profile_file, cluster=cluster)
+    backend = _RegistryImageBackend(selected.profile.workspace_root)
+    return SlurmImageService(backend, backend)
+
+
+def _resolve_builder_payload(
+    authored: DataDesignerSlurmConfig,
+    source_root: Path,
+) -> dict[str, JsonValue] | None:
+    if authored.builder.source is None:
+        return None
+    return load_builder_payload(source_root / authored.builder.source)
+
+
+def _load_optional(call: Callable[[], _ResultT]) -> _ResultT | None:
+    try:
+        return call()
+    except StateNotFoundError:
+        return None
+
+
+def _new_run_id() -> str:
+    return f"run-{uuid4().hex}"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _format_job_ids(job_ids: list[int]) -> str:
+    visible = ", ".join(str(job_id) for job_id in job_ids[:16])
+    remaining = len(job_ids) - 16
+    return visible if remaining <= 0 else f"{visible}, and {remaining} more"
+
+
+__all__ = [
+    "SlurmRunArtifactPublisher",
+    "create_slurm_image_service",
+    "create_slurm_run_service",
+]

--- a/packages/data-designer-slurm/tests/client/test_dependency_resolution.py
+++ b/packages/data-designer-slurm/tests/client/test_dependency_resolution.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from data_designer.slurm.client.dependencies import (
+    ClientDependencyResolutionError,
+    ClientDependencyResolver,
+)
+from data_designer.slurm.config import ClientDependencies
+from data_designer.slurm.contracts import ArtifactReference
+from data_designer.slurm.planning import LockedPackage, ResolvedDependencyLock, ResolvedSlurmRunPlan
+
+
+def test_empty_requirements_resolve_without_invoking_pip(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    def unexpected_runner(*_args: object) -> None:
+        raise AssertionError("pip must not run")
+
+    resolver = ClientDependencyResolver(command_runner=unexpected_runner)
+    dependencies = ClientDependencies(requirements=[])
+
+    with resolver.resolve(
+        dependencies,
+        single_node_plan.client.image,
+        run_root=tmp_path / "workspace/runs/run-001",
+        source_root=tmp_path,
+    ) as resolved:
+        assert resolved.lock.authored_requirements == ()
+        assert resolved.lock.overlay_packages == ()
+        assert resolved.lock.client_image_sha256 == single_node_plan.client.image.sha256
+        assert resolved.wheel_sources == ()
+        assert resolved.lock_source is None
+
+
+def test_inline_requirements_resolve_pure_wheels_and_omit_image_packages(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    token = "DUMMY_INDEX_TOKEN"
+    calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
+
+    def download(command: tuple[str, ...], _cwd: Path, environment: dict[str, str]) -> None:
+        calls.append((command, environment))
+        destination = Path(next(item.removeprefix("--dest=") for item in command if item.startswith("--dest=")))
+        (destination / "example_plugin-1.2.0-py3-none-any.whl").write_bytes(b"plugin")
+        (destination / "pip-26.1-py3-none-any.whl").write_bytes(b"image package")
+
+    dependencies = ClientDependencies(
+        requirements=["example-plugin==1.2.0"],
+        index_credentials={
+            "private-index": {"type": "secret", "environment": "PACKAGE_INDEX_TOKEN"},
+        },
+    )
+    resolver = ClientDependencyResolver(
+        command_runner=download,
+        environ={"PACKAGE_INDEX_TOKEN": token},
+        python_executable="/python",
+    )
+    run_root = tmp_path / "workspace/runs/run-001"
+
+    with resolver.resolve(
+        dependencies,
+        single_node_plan.client.image,
+        run_root=run_root,
+        source_root=tmp_path,
+    ) as resolved:
+        assert calls[0][0][0:4] == ("/python", "-m", "pip", "download")
+        assert token not in calls[0][0]
+        assert calls[0][1]["PACKAGE_INDEX_TOKEN"] == token
+        assert tuple(package.name for package in resolved.lock.overlay_packages) == ("example-plugin",)
+        package = resolved.lock.overlay_packages[0]
+        assert package.artifact.path == (run_root / "dependencies/example_plugin-1.2.0-py3-none-any.whl").as_posix()
+        assert package.artifact.sha256 == hashlib.sha256(b"plugin").hexdigest()
+        assert len(resolved.wheel_sources) == 1
+        assert resolved.wheel_sources[0].is_file()
+
+
+def test_inline_resolution_rejects_platform_specific_wheels(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    def download(command: tuple[str, ...], _cwd: Path, _environment: dict[str, str]) -> None:
+        destination = Path(next(item.removeprefix("--dest=") for item in command if item.startswith("--dest=")))
+        (destination / "example_plugin-1.2.0-cp312-cp312-manylinux_2_28_x86_64.whl").write_bytes(b"plugin")
+
+    resolver = ClientDependencyResolver(command_runner=download)
+
+    with (
+        pytest.raises(ClientDependencyResolutionError, match="platform-independent"),
+        resolver.resolve(
+            ClientDependencies(requirements=["example-plugin==1.2.0"]),
+            single_node_plan.client.image,
+            run_root=tmp_path / "workspace/runs/run-001",
+            source_root=tmp_path,
+        ),
+    ):
+        pass
+
+
+def test_supplied_lock_is_verified_and_rebound_to_run_inputs(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    wheel = tmp_path / "example_plugin-1.2.0-py3-none-any.whl"
+    wheel.write_bytes(b"plugin")
+    image = single_node_plan.client.image.inspection_facts
+    supplied = ResolvedDependencyLock(
+        schema_version=1,
+        resolver_version="external-1",
+        python_abi=image.python_abi,
+        client_image_sha256=single_node_plan.client.image.sha256,
+        authored_requirements=("example-plugin==1.2.0",),
+        image_distributions=tuple(sorted(image.distributions, key=lambda item: item.name)),
+        overlay_packages=(
+            LockedPackage(
+                name="example-plugin",
+                version="1.2.0",
+                artifact=ArtifactReference(
+                    path=wheel.as_posix(),
+                    sha256=hashlib.sha256(b"plugin").hexdigest(),
+                ),
+            ),
+        ),
+    )
+    lock_file = tmp_path / "lock.json"
+    lock_file.write_text(supplied.serialize_json(), encoding="utf-8")
+    run_root = tmp_path / "workspace/runs/run-001"
+
+    with ClientDependencyResolver().resolve(
+        ClientDependencies(requirements=None, lock_file="lock.json"),
+        single_node_plan.client.image,
+        run_root=run_root,
+        source_root=tmp_path,
+    ) as resolved:
+        assert resolved.lock.authored_source == "lock.json"
+        assert resolved.lock.source == ArtifactReference(
+            path=(run_root / "inputs/lock.json").as_posix(),
+            sha256=hashlib.sha256(supplied.serialize_json().encode()).hexdigest(),
+        )
+        assert (
+            resolved.lock.overlay_packages[0].artifact.path
+            == (run_root / "dependencies/example_plugin-1.2.0-py3-none-any.whl").as_posix()
+        )
+        assert resolved.wheel_sources == (wheel,)
+        assert resolved.lock_source == lock_file
+
+
+def test_supplied_lock_rejects_platform_specific_wheels(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    wheel = tmp_path / "example_plugin-1.2.0-cp312-cp312-manylinux_2_28_x86_64.whl"
+    wheel.write_bytes(b"plugin")
+    image = single_node_plan.client.image.inspection_facts
+    supplied = ResolvedDependencyLock(
+        schema_version=1,
+        resolver_version="external-1",
+        python_abi=image.python_abi,
+        client_image_sha256=single_node_plan.client.image.sha256,
+        authored_requirements=("example-plugin==1.2.0",),
+        image_distributions=tuple(sorted(image.distributions, key=lambda item: item.name)),
+        overlay_packages=(
+            LockedPackage(
+                name="example-plugin",
+                version="1.2.0",
+                artifact=ArtifactReference(
+                    path=wheel.as_posix(),
+                    sha256=hashlib.sha256(b"plugin").hexdigest(),
+                ),
+            ),
+        ),
+    )
+    lock_file = tmp_path / "lock.json"
+    lock_file.write_text(supplied.serialize_json(), encoding="utf-8")
+
+    with (
+        pytest.raises(ClientDependencyResolutionError, match="artifact differs"),
+        ClientDependencyResolver().resolve(
+            ClientDependencies(requirements=None, lock_file="lock.json"),
+            single_node_plan.client.image,
+            run_root=tmp_path / "workspace/runs/run-001",
+            source_root=tmp_path,
+        ),
+    ):
+        pass
+
+
+def test_resolution_redacts_runner_failure_and_missing_credentials(
+    tmp_path: Path,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    def fail(*_args: object) -> None:
+        raise RuntimeError("DUMMY_SECRET_VALUE")
+
+    resolver = ClientDependencyResolver(command_runner=fail)
+    dependencies = ClientDependencies(requirements=["example-plugin==1.2.0"])
+    with pytest.raises(ClientDependencyResolutionError, match="resolution failed") as captured:
+        with resolver.resolve(
+            dependencies,
+            single_node_plan.client.image,
+            run_root=tmp_path / "workspace/runs/run-001",
+            source_root=tmp_path,
+        ):
+            pass
+    assert "DUMMY_SECRET_VALUE" not in str(captured.value)
+
+    credentialed = ClientDependencies(
+        requirements=["example-plugin==1.2.0"],
+        index_credentials={"private": {"type": "secret", "environment": "MISSING_TOKEN"}},
+    )
+    with pytest.raises(ClientDependencyResolutionError, match="credential is unavailable"):
+        with resolver.resolve(
+            credentialed,
+            single_node_plan.client.image,
+            run_root=tmp_path / "workspace/runs/run-002",
+            source_root=tmp_path,
+        ):
+            pass

--- a/packages/data-designer-slurm/tests/client/test_dependency_resolution.py
+++ b/packages/data-designer-slurm/tests/client/test_dependency_resolution.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 
 import pytest
@@ -61,7 +62,13 @@ def test_inline_requirements_resolve_pure_wheels_and_omit_image_packages(
     )
     resolver = ClientDependencyResolver(
         command_runner=download,
-        environ={"PACKAGE_INDEX_TOKEN": token},
+        environ={
+            "PACKAGE_INDEX_TOKEN": token,
+            "PIP_CONFIG_FILE": "/ambient/pip.conf",
+            "PIP_EXTRA_INDEX_URL": "https://ambient.example/simple",
+            "PIP_INDEX_URL": "https://ambient.example/simple",
+            "SAFE_VALUE": "preserved",
+        },
         python_executable="/python",
     )
     run_root = tmp_path / "workspace/runs/run-001"
@@ -74,7 +81,8 @@ def test_inline_requirements_resolve_pure_wheels_and_omit_image_packages(
     ) as resolved:
         assert calls[0][0][0:4] == ("/python", "-m", "pip", "download")
         assert token not in calls[0][0]
-        assert calls[0][1]["PACKAGE_INDEX_TOKEN"] == token
+        assert "--index-url=https://pypi.org/simple" in calls[0][0]
+        assert calls[0][1] == {"PIP_CONFIG_FILE": os.devnull, "SAFE_VALUE": "preserved"}
         assert tuple(package.name for package in resolved.lock.overlay_packages) == ("example-plugin",)
         package = resolved.lock.overlay_packages[0]
         assert package.artifact.path == (run_root / "dependencies/example_plugin-1.2.0-py3-none-any.whl").as_posix()

--- a/packages/data-designer-slurm/tests/config/test_loading_builder.py
+++ b/packages/data-designer-slurm/tests/config/test_loading_builder.py
@@ -19,6 +19,7 @@ from data_designer.slurm.config import (
     SlurmConfigBuilderError,
     SlurmConfigLoadError,
     SlurmProfileCatalog,
+    load_builder_payload,
     load_profile_catalog,
     load_run_config,
     resolve_profile,
@@ -261,6 +262,23 @@ def test_loader_preserves_literal_interpolation_inside_builder_payload(tmp_path:
     builder.write_config(path)
 
     assert load_run_config(path) == builder.build()
+
+
+def test_builder_payload_loader_validates_complete_config(tmp_path: Path) -> None:
+    payload = _config_builder(prompt="Use the literal ${HOME} value").build().builder.inline
+    assert payload is not None
+    path = tmp_path / "builder.json"
+    path.write_text(json.dumps(payload))
+
+    assert load_builder_payload(path) == payload
+
+
+def test_builder_payload_loader_rejects_partial_config(tmp_path: Path) -> None:
+    path = tmp_path / "builder.json"
+    path.write_text('{"library_version":"1.0"}')
+
+    with pytest.raises(SlurmConfigLoadError, match="failed validation"):
+        load_builder_payload(path)
 
 
 def test_profile_source_and_selection_precedence(

--- a/packages/data-designer-slurm/tests/services/test_services.py
+++ b/packages/data-designer-slurm/tests/services/test_services.py
@@ -29,8 +29,12 @@ from data_designer.slurm.services import (
     SlurmBatchScriptRenderer,
     SlurmBenchmarkBackend,
     SlurmBenchmarkService,
+    SlurmImageManager,
     SlurmImageResolver,
     SlurmImageService,
+    SlurmRunArtifactPublisher,
+    SlurmRunBackend,
+    SlurmRunExecution,
     SlurmRunPlanner,
     SlurmRunService,
     SlurmServiceError,
@@ -178,6 +182,46 @@ def test_run_service_rejects_untyped_config() -> None:
 
     assert caught.value.code is SlurmServiceErrorCode.INVALID_REQUEST
     assert caught.value.operation is SlurmServiceOperation.PLAN_RUN
+
+
+def test_run_service_delegates_execute_actions(
+    tmp_path: Path,
+    authored_run_single: DataDesignerSlurmConfig,
+) -> None:
+    class RunBackend:
+        def __init__(self) -> None:
+            self.calls: list[tuple[DataDesignerSlurmConfig, Path, bool, bool]] = []
+
+        def execute(
+            self,
+            config: DataDesignerSlurmConfig,
+            *,
+            source_root: Path,
+            dry_run: bool,
+            force: bool,
+        ) -> SlurmRunExecution:
+            self.calls.append((config, source_root, dry_run, force))
+            return SlurmRunExecution(
+                run_id="run-0001",
+                state="dry_run",
+                plan_sha256="1" * 64,
+                shard_count=1,
+                batch_script="script",
+            )
+
+        def status(self, run_id):
+            raise AssertionError(run_id)
+
+        def cancel(self, run_id):
+            raise AssertionError(run_id)
+
+    backend = RunBackend()
+    service = SlurmRunService(FakeRunPlanningBackend(()), FakeBatchScriptRenderer(()), backend)
+
+    result = service.execute(authored_run_single, source_root=tmp_path, dry_run=True, force=True)
+
+    assert result.run_id == "run-0001"
+    assert backend.calls == [(authored_run_single, tmp_path.resolve(), True, True)]
 
 
 def test_run_service_normalizes_and_redacts_unexpected_backend_errors(
@@ -359,6 +403,16 @@ def test_image_service_rejects_untyped_reference() -> None:
     assert caught.value.operation is SlurmServiceOperation.RESOLVE_IMAGE
 
 
+def test_image_service_requires_package_owned_manager() -> None:
+    service = SlurmImageService(FakeImageResolver(()))
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.list()
+
+    assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+    assert caught.value.operation is SlurmServiceOperation.LIST_IMAGES
+
+
 @pytest.mark.parametrize("mismatch", ["reference", "kind"])
 def test_image_service_rejects_uncorrelated_results(
     single_node_plan: ResolvedSlurmRunPlan,
@@ -511,7 +565,10 @@ def test_service_errors_use_the_data_designer_error_hierarchy() -> None:
     [
         ("SlurmBatchScriptRenderer", SlurmBatchScriptRenderer),
         ("SlurmBenchmarkBackend", SlurmBenchmarkBackend),
+        ("SlurmImageManager", SlurmImageManager),
         ("SlurmImageResolver", SlurmImageResolver),
+        ("SlurmRunArtifactPublisher", SlurmRunArtifactPublisher),
+        ("SlurmRunBackend", SlurmRunBackend),
         ("SlurmRunPlanner", SlurmRunPlanner),
     ],
 )

--- a/packages/data-designer-slurm/tests/services/test_wiring.py
+++ b/packages/data-designer-slurm/tests/services/test_wiring.py
@@ -1,0 +1,453 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from data_designer.slurm.client.dependencies import ResolvedClientDependencies
+from data_designer.slurm.config import (
+    BuilderInput,
+    DataDesignerSlurmConfig,
+    ImageBuildRequest,
+    SlurmProfile,
+    SlurmProfileCatalog,
+)
+from data_designer.slurm.contracts import ArtifactReference, canonical_json
+from data_designer.slurm.images.records import RegisteredImage
+from data_designer.slurm.images.registry import ImageRegistryStore
+from data_designer.slurm.launcher.models import SlurmJobSubmissionReceipt
+from data_designer.slurm.planning import ResolvedSlurmRunPlan
+from data_designer.slurm.services import (
+    SlurmServiceError,
+    SlurmServiceErrorCode,
+    create_slurm_image_service,
+    create_slurm_run_service,
+)
+from data_designer.slurm.state import (
+    AttemptLifecycleState,
+    AttemptManifest,
+    RunManifest,
+    SchedulerIdentity,
+    ShardManifest,
+    SlurmStateWriter,
+    StateConflictError,
+)
+
+
+class _Launcher:
+    def __init__(self, gpu_counts: tuple[int, ...] = (), *, cancel_error: Exception | None = None) -> None:
+        self.submissions: list[str] = []
+        self.cancellations: list[int] = []
+        self.gpu_counts = gpu_counts
+        self.cancel_error = cancel_error
+
+    def submit_script(self, script: str) -> SlurmJobSubmissionReceipt:
+        self.submissions.append(script)
+        return SlurmJobSubmissionReceipt(job_id=42)
+
+    def cancel(self, job_id: int) -> None:
+        self.cancellations.append(job_id)
+        if self.cancel_error is not None:
+            raise self.cancel_error
+
+    def query_gpu_counts(self, *, partition: str | None = None) -> tuple[int, ...]:
+        assert partition is not None
+        return self.gpu_counts
+
+
+class _Publisher:
+    def __init__(
+        self,
+        *,
+        initialization_error: BaseException | None = None,
+        submission_error: BaseException | None = None,
+    ) -> None:
+        self.initializations: list[tuple[str, bool]] = []
+        self.submissions: list[tuple[str, int, datetime]] = []
+        self.initialization_error = initialization_error
+        self.submission_error = submission_error
+
+    def initialize(
+        self,
+        authored: DataDesignerSlurmConfig,
+        plan: ResolvedSlurmRunPlan,
+        dependencies: ResolvedClientDependencies,
+        builder_payload: dict[str, object] | None,
+        *,
+        force: bool,
+    ) -> None:
+        if self.initialization_error is not None:
+            raise self.initialization_error
+        assert plan.authored_config.sha256 == authored.compute_sha256()
+        assert builder_payload is None
+        assert all(path.is_file() for path in dependencies.wheel_sources)
+        self.initializations.append((plan.run_id, force))
+
+    def record_submission(self, plan: ResolvedSlurmRunPlan, job_id: int, *, submitted_at: datetime) -> None:
+        if self.submission_error is not None:
+            raise self.submission_error
+        self.submissions.append((plan.run_id, job_id, submitted_at))
+
+
+def _profile(tmp_path: Path, profile_catalog: SlurmProfileCatalog) -> SlurmProfile:
+    return profile_catalog.clusters["primary"].model_copy(update={"workspace_root": tmp_path.as_posix()})
+
+
+def _register_images(
+    tmp_path: Path,
+    authored: DataDesignerSlurmConfig,
+    plan: ResolvedSlurmRunPlan,
+) -> None:
+    store = ImageRegistryStore(tmp_path)
+    pairs = ((authored.client.image, plan.client.image),) + tuple(
+        (deployment.server.image, resolved.image)
+        for deployment, resolved in zip(authored.deployments, plan.deployments, strict=True)
+    )
+    for index, (reference, resolved) in enumerate(pairs):
+        path = tmp_path / f"image-{index}.sqsh"
+        path.write_bytes(f"image-{index}".encode())
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        inspection = resolved.inspection.model_copy(update={"sqsh_sha256": digest})
+        assert reference.name is not None
+        image = RegisteredImage(
+            schema_version=1,
+            name=reference.name,
+            path=path.as_posix(),
+            sqsh_sha256=digest,
+            inspection=inspection,
+        )
+        store.register(image, verify_before_publish=lambda _: None)
+
+
+def test_production_wiring_dry_run_resolves_and_renders_without_submission(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    result = service.execute(authored_run_single, source_root=tmp_path, dry_run=True)
+
+    assert result.run_id == "run-wired"
+    assert result.state == "dry_run"
+    assert result.batch_script is not None
+    assert "#SBATCH --array=0" in result.batch_script
+    assert launcher.submissions == []
+
+
+def test_public_plan_resolves_builder_relative_to_explicit_source_root(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    payload = authored_run_single.builder.inline
+    assert payload is not None
+    (tmp_path / "builder.json").write_bytes(canonical_json(payload))
+    authored = authored_run_single.model_copy(update={"builder": BuilderInput(source="builder.json")})
+    _register_images(tmp_path, authored, single_node_plan)
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        launcher=_Launcher(),  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    plan = service.plan(authored, source_root=tmp_path)
+
+    assert plan.builder.authored_source == "builder.json"
+    assert plan.builder.source is not None
+    assert plan.builder.source.path == (tmp_path / "runs/run-wired/builder-config.json").as_posix()
+
+
+def test_production_wiring_submits_after_publisher_initialization(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    publisher = _Publisher()
+    submitted_at = datetime(2026, 9, 8, tzinfo=UTC)
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        artifact_publisher=publisher,  # type: ignore[arg-type]
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        clock=lambda: submitted_at,
+        package_version="0.9.2",
+    )
+
+    result = service.execute(authored_run_single, source_root=tmp_path, force=True)
+
+    assert result.state == "submitted"
+    assert result.job_id == 42
+    assert publisher.initializations == [("run-wired", True)]
+    assert publisher.submissions == [("run-wired", 42, submitted_at)]
+    assert len(launcher.submissions) == 1
+
+
+def test_production_wiring_stops_before_submission_without_state_publisher(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.execute(authored_run_single, source_root=tmp_path)
+
+    assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+    assert launcher.submissions == []
+
+
+def test_auto_gpu_resolution_rejects_mixed_node_shapes(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    profile = profile_catalog.clusters["lab"].model_copy(update={"workspace_root": tmp_path.as_posix()})
+    service = create_slurm_run_service(
+        profile=profile,
+        launcher=_Launcher((4, 8)),  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.execute(authored_run_single, source_root=tmp_path, dry_run=True)
+
+    assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+
+
+def test_publisher_value_error_is_not_misattributed_to_run_preparation(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        artifact_publisher=_Publisher(initialization_error=ValueError("backend bug")),  # type: ignore[arg-type]
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.execute(authored_run_single, source_root=tmp_path)
+
+    assert caught.value.code is SlurmServiceErrorCode.INTERNAL
+    assert str(caught.value) == "execute run failed"
+    assert launcher.submissions == []
+
+
+def test_recording_conflict_cancels_the_accepted_job(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    publisher = _Publisher(submission_error=StateConflictError("conflict"))
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        artifact_publisher=publisher,  # type: ignore[arg-type]
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.execute(authored_run_single, source_root=tmp_path)
+
+    assert caught.value.code is SlurmServiceErrorCode.CONFLICT
+    assert launcher.cancellations == [42]
+
+
+def test_failed_compensating_cancel_reports_accepted_job_id(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher(cancel_error=RuntimeError("cancel failed"))
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        artifact_publisher=_Publisher(submission_error=StateConflictError("conflict")),  # type: ignore[arg-type]
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError, match="Slurm job 42") as caught:
+        service.execute(authored_run_single, source_root=tmp_path)
+
+    assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+
+
+def test_recording_interrupt_is_preserved_when_compensating_cancel_fails(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher(cancel_error=RuntimeError("cancel failed"))
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        artifact_publisher=_Publisher(submission_error=KeyboardInterrupt()),  # type: ignore[arg-type]
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        service.execute(authored_run_single, source_root=tmp_path)
+
+    assert launcher.cancellations == [42]
+
+
+def test_production_status_and_cancel_use_only_persisted_m2_records(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    launcher = _Launcher()
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        launcher=launcher,  # type: ignore[arg-type]
+        run_id_factory=lambda: "run-wired",
+        package_version="0.9.2",
+    )
+    plan = service.plan(authored_run_single)
+    now = datetime(2026, 9, 8, tzinfo=UTC)
+    plan_reference = ArtifactReference(
+        path=(tmp_path / "runs/run-wired/resolved-plan.json").as_posix(),
+        sha256=plan.compute_sha256(),
+    )
+    run = RunManifest(
+        schema_version=1,
+        run_id=plan.run_id,
+        created_at=now,
+        authored_config=plan.authored_config,
+        resolved_plan=plan_reference,
+        shard_count=len(plan.shards),
+    )
+    shards = tuple(
+        ShardManifest(
+            schema_version=1,
+            run_id=plan.run_id,
+            shard_id=shard.shard_id,
+            shard_index=shard.shard_index,
+            record_range=shard.record_range,
+            input_partition=shard.input_partition,
+            resume_workspace=shard.resume_workspace,
+            created_at=now,
+        )
+        for shard in plan.shards
+    )
+    writer = SlurmStateWriter(tmp_path, plan.run_id)
+    writer.initialize_run(authored_run_single, plan, run, shards)
+    created = AttemptManifest(
+        schema_version=1,
+        run_id=plan.run_id,
+        shard_id=shards[0].shard_id,
+        attempt_id="attempt-0001",
+        attempt_ordinal=1,
+        resolved_plan=plan_reference,
+        state=AttemptLifecycleState.CREATED,
+        created_at=now,
+        updated_at=now,
+    )
+    writer.create_attempt(created)
+    assert service.cancel(plan.run_id).job_ids == ()
+    assert launcher.cancellations == []
+    writer.update_attempt(
+        created.model_copy(
+            update={
+                "state": AttemptLifecycleState.SUBMITTED,
+                "scheduler": SchedulerIdentity(array_job_id=42, array_task_id=0),
+            }
+        )
+    )
+
+    status = service.status(plan.run_id)
+    cancellation = service.cancel(plan.run_id)
+
+    assert status.run == run
+    assert status.shards[0].attempts[0].attempt.state is AttemptLifecycleState.SUBMITTED
+    assert cancellation.job_ids == (42,)
+    assert launcher.cancellations == [42]
+
+
+def test_production_status_maps_unknown_run_to_not_found(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+) -> None:
+    service = create_slurm_run_service(
+        profile=_profile(tmp_path, profile_catalog),
+        launcher=_Launcher(),  # type: ignore[arg-type]
+        package_version="0.9.2",
+    )
+
+    with pytest.raises(SlurmServiceError) as caught:
+        service.status("run-missing")
+
+    assert caught.value.code is SlurmServiceErrorCode.NOT_FOUND
+
+
+def test_production_image_registry_operations_and_lifecycle_gap(
+    tmp_path: Path,
+    profile_catalog: SlurmProfileCatalog,
+    authored_run_single: DataDesignerSlurmConfig,
+    single_node_plan: ResolvedSlurmRunPlan,
+) -> None:
+    _register_images(tmp_path, authored_run_single, single_node_plan)
+    service = create_slurm_image_service(profile=_profile(tmp_path, profile_catalog))
+
+    images = service.list()
+    selected = service.get(images[0].name)
+    removed = service.remove(images[0].name)
+
+    assert selected == removed == images[0]
+    assert len(service.list()) == 1
+    with pytest.raises(SlurmServiceError) as caught:
+        service.add(
+            ImageBuildRequest(
+                name="new-image",
+                kind="client",
+                source=f"registry.example/client@sha256:{'1' * 64}",
+            )
+        )
+    assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE

--- a/packages/data-designer-slurm/tests/services/test_wiring.py
+++ b/packages/data-designer-slurm/tests/services/test_wiring.py
@@ -220,6 +220,7 @@ def test_production_wiring_stops_before_submission_without_state_publisher(
         service.execute(authored_run_single, source_root=tmp_path)
 
     assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+    assert str(caught.value) == "run submission is not available; use --dry-run"
     assert launcher.submissions == []
 
 
@@ -451,3 +452,4 @@ def test_production_image_registry_operations_and_lifecycle_gap(
             )
         )
     assert caught.value.code is SlurmServiceErrorCode.UNAVAILABLE
+    assert str(caught.value) == "image registration is not available; use a pre-registered image"

--- a/packages/data-designer-slurm/tests/services/test_wiring.py
+++ b/packages/data-designer-slurm/tests/services/test_wiring.py
@@ -405,10 +405,12 @@ def test_production_status_and_cancel_use_only_persisted_m2_records(
 
     status = service.status(plan.run_id)
     cancellation = service.cancel(plan.run_id)
+    persisted_after_cancel = service.status(plan.run_id)
 
     assert status.run == run
     assert status.shards[0].attempts[0].attempt.state is AttemptLifecycleState.SUBMITTED
     assert cancellation.job_ids == (42,)
+    assert persisted_after_cancel.shards[0].attempts[0].attempt.state is AttemptLifecycleState.SUBMITTED
     assert launcher.cancellations == [42]
 
 

--- a/packages/data-designer-slurm/tests/slurm_test_fakes/services.py
+++ b/packages/data-designer-slurm/tests/slurm_test_fakes/services.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Generic, TypeVar
 
 from data_designer.slurm.benchmark import BenchmarkManifest, BenchmarkReport
@@ -64,8 +65,9 @@ class FakeRunPlanningBackend(SlurmRunPlanner):
         self._script = _ScriptedResponses(responses)
         self.calls = self._script.calls
 
-    def plan(self, config: DataDesignerSlurmConfig) -> ResolvedSlurmRunPlan:
+    def plan(self, config: DataDesignerSlurmConfig, *, source_root: Path) -> ResolvedSlurmRunPlan:
         """Return the plan scripted for one exact authored config."""
+        del source_root
         return self._script.next(config, operation="run plan")
 
     def assert_complete(self) -> None:

--- a/packages/data-designer-slurm/tests/test_cli.py
+++ b/packages/data-designer-slurm/tests/test_cli.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import data_designer.slurm.cli as cli_module
+from data_designer.slurm.config import DataDesignerSlurmConfig
+from data_designer.slurm.services import (
+    SlurmRunExecution,
+    SlurmServiceError,
+    SlurmServiceErrorCode,
+    SlurmServiceOperation,
+)
+
+
+class _RunService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[DataDesignerSlurmConfig, Path, bool, bool]] = []
+
+    def execute(
+        self,
+        config: DataDesignerSlurmConfig,
+        *,
+        source_root: Path,
+        dry_run: bool,
+        force: bool,
+    ) -> SlurmRunExecution:
+        self.calls.append((config, source_root, dry_run, force))
+        return SlurmRunExecution(
+            run_id="run-0001",
+            state="dry_run",
+            plan_sha256="1" * 64,
+            shard_count=1,
+            batch_script="#!/bin/bash\n",
+        )
+
+
+def test_execute_emits_deterministic_json_and_forwards_actions(
+    tmp_path: Path,
+    authored_run_single: DataDesignerSlurmConfig,
+    monkeypatch,
+) -> None:
+    run_file = tmp_path / "run.json"
+    run_file.write_text(authored_run_single.serialize_json())
+    service = _RunService()
+    monkeypatch.setattr(cli_module, "create_slurm_run_service", lambda **_: service)
+
+    result = CliRunner().invoke(cli_module.create_cli(), ["execute", str(run_file), "--dry-run", "--force"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "batch_script": "#!/bin/bash\n",
+        "job_id": None,
+        "plan_sha256": "1" * 64,
+        "run_id": "run-0001",
+        "shard_count": 1,
+        "state": "dry_run",
+    }
+    assert service.calls == [(authored_run_single, tmp_path, True, True)]
+
+
+@pytest.mark.parametrize(
+    ("code", "exit_code"),
+    [
+        (SlurmServiceErrorCode.INVALID_REQUEST, 2),
+        (SlurmServiceErrorCode.NOT_FOUND, 3),
+        (SlurmServiceErrorCode.CONFLICT, 4),
+        (SlurmServiceErrorCode.UNAVAILABLE, 5),
+    ],
+)
+def test_cli_emits_stable_service_error(monkeypatch, code: SlurmServiceErrorCode, exit_code: int) -> None:
+    error = SlurmServiceError(
+        code,
+        SlurmServiceOperation.STATUS_RUN,
+        "stable failure",
+    )
+
+    def fail(**_):
+        raise error
+
+    monkeypatch.setattr(cli_module, "create_slurm_run_service", fail)
+
+    result = CliRunner().invoke(cli_module.create_cli(), ["status", "run-0001"])
+
+    assert result.exit_code == exit_code
+    assert json.loads(result.stderr) == {
+        "error": {
+            "code": code.value,
+            "message": "stable failure",
+            "operation": "status_run",
+        }
+    }
+
+
+def test_execute_preserves_sanitized_config_diagnostic(tmp_path: Path) -> None:
+    run_file = tmp_path / "run.json"
+    run_file.write_text('{"schema_version":1}')
+
+    result = CliRunner().invoke(cli_module.create_cli(), ["execute", str(run_file)])
+
+    assert result.exit_code == 2
+    error = json.loads(result.stderr)["error"]
+    assert error["code"] == "invalid_request"
+    assert "failed validation" in error["message"]
+
+
+def test_execute_bounds_large_config_diagnostic(tmp_path: Path) -> None:
+    run_file = tmp_path / f"{'x' * 240}.json"
+    run_file.write_text(json.dumps({f"unknown_field_{index}": index for index in range(100)}))
+
+    result = CliRunner().invoke(cli_module.create_cli(), ["execute", str(run_file)])
+
+    assert result.exit_code == 2
+    message = json.loads(result.stderr)["error"]["message"]
+    assert len(message) == 512
+    assert message.endswith("...")
+
+
+def test_cli_exposes_only_m2_run_commands() -> None:
+    result = CliRunner().invoke(cli_module.create_cli(), ["--help"])
+
+    assert result.exit_code == 0
+    assert all(command in result.stdout for command in ("execute", "status", "cancel", "image"))
+    assert all(command not in result.stdout for command in ("retry", "merge", "benchmark"))

--- a/packages/data-designer-slurm/tests/test_cli.py
+++ b/packages/data-designer-slurm/tests/test_cli.py
@@ -122,6 +122,23 @@ def test_execute_bounds_large_config_diagnostic(tmp_path: Path) -> None:
     assert message.endswith("...")
 
 
+@pytest.mark.parametrize(
+    "source",
+    ["nvcr.io/nvidia/pytorch:24.01-py3", "docker://ubuntu:22.04"],
+)
+def test_image_add_rejects_mutable_oci_source(source: str) -> None:
+    result = CliRunner().invoke(cli_module.create_cli(), ["image", "add", source, "--kind", "client"])
+
+    assert result.exit_code == 2
+    assert json.loads(result.stderr) == {
+        "error": {
+            "code": "invalid_request",
+            "message": "OCI image source must be digest-qualified as name@sha256:<digest>",
+            "operation": "add_image",
+        }
+    }
+
+
 def test_cli_exposes_only_m2_run_commands() -> None:
     result = CliRunner().invoke(cli_module.create_cli(), ["--help"])
 

--- a/scripts/test_slurm_package_install.py
+++ b/scripts/test_slurm_package_install.py
@@ -191,11 +191,13 @@ def main() -> None:
         base_leaf_requirement = requirement(base_metadata, "data-designer-slurm")
         leaf_base_requirement = requirement(leaf_metadata, "data-designer")
         leaf_packaging_requirement = requirement(leaf_metadata, "packaging")
+        leaf_pip_requirement = requirement(leaf_metadata, "pip")
         leaf_pydantic_requirement = requirement(leaf_metadata, "pydantic")
         leaf_pyyaml_requirement = requirement(leaf_metadata, "pyyaml")
         assert str(base_leaf_requirement.specifier) == f"=={version}"
         assert str(leaf_base_requirement.specifier) == f"=={version}"
         assert leaf_packaging_requirement.specifier == Requirement("packaging>=25,<27").specifier
+        assert leaf_pip_requirement.specifier == Requirement("pip>=25,<27").specifier
         assert leaf_pydantic_requirement.specifier == Requirement("pydantic>=2.9.2,<3").specifier
         assert leaf_pyyaml_requirement.specifier == Requirement("pyyaml>=6.0.1,<7").specifier
         assert base_leaf_requirement.marker is not None

--- a/uv.lock
+++ b/uv.lock
@@ -957,6 +957,7 @@ source = { editable = "packages/data-designer-slurm" }
 dependencies = [
     { name = "data-designer" },
     { name = "packaging" },
+    { name = "pip" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -965,6 +966,7 @@ dependencies = [
 requires-dist = [
     { name = "data-designer", editable = "packages/data-designer" },
     { name = "packaging", specifier = ">=25,<27" },
+    { name = "pip", specifier = ">=25,<27" },
     { name = "pydantic", specifier = ">=2.9.2,<3" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
 ]
@@ -3139,6 +3141,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
     { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📋 Summary

Adds package-owned M2 execution, status, cancellation, and image service wiring on top of the Slurm staging branch. Thin `data-designer slurm` commands expose the reviewed operations while incomplete STATE and IMG dependencies remain fail-closed.

## 🔗 Related Issue

Part of #874

## 🔄 Changes

### ✨ Added

- Added pure-wheel client dependency resolution with strict supplied-lock verification and canonical artifact staging.
- Added stable result contracts and production factories for execute, status, cancel, and image operations.
- Added `execute`, `status`, `cancel`, and `image add/ls/info/rm` CLI commands with deterministic JSON and error rendering.
- Added focused dependency, service wiring, and CLI coverage.

### 🔧 Changed

- Propagated authored source roots through configuration loading and run planning.
- Declared the leaf package's pip runtime dependency and verified it in built-wheel installation tests.

### 🐛 Fixed

- Rejected swapped non-regular SQSH descriptors before hashing so filesystem-race failures remain deterministic on Linux.
- Added actionable fail-closed messages and rejected mutable OCI image tags with digest-qualified guidance.
- Pinned submit-side dependency resolution to PyPI, ignored ambient pip configuration, and kept allocation-only credentials out of the pip process.
- Bound persisted-status reads to their current shard and attempt, and documented that cancellation state changes only through scheduler reconciliation.
- Consolidated staging error handling and replaced production-path assertions with explicit dependency errors.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`services/wiring.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/feat/slurm-service-cli-wiring/packages/data-designer-slurm/src/data_designer/slurm/services/wiring.py) - package composition, submission compensation, and fail-closed STATE/IMG seams.
- [`client/dependencies.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/feat/slurm-service-cli-wiring/packages/data-designer-slurm/src/data_designer/slurm/client/dependencies.py) - isolated pip resolution, lock verification, and source staging.
- [`cli.py`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/andreatnvidia/feat/slurm-service-cli-wiring/packages/data-designer-slurm/src/data_designer/slurm/cli.py) - thin command handlers and stable diagnostic rendering.

## 🧪 Testing

- [x] `make test-slurm` passes - 1,289 tests
- [x] `make test-slurm-wheel-install` passes for base-only, extra, and leaf-package installations
- [x] `.venv/bin/ruff check --fix .` and `.venv/bin/ruff format .` pass
- [x] Unit tests added and updated
- [ ] Cluster submission E2E - not run because no Slurm environment was available

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable to this slice)

---
*Description updated with AI*
