### PR TITLE
chore: enforce future annotations in src

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/analysis/__init__.py
+++ b/packages/data-designer-config/src/data_designer/config/analysis/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/column_generators/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/column_generators/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/column_generators/generators/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/utils/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/utils/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/models/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/models/parsers/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/parsers/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/processing/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/processing/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/processing/ginja/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/processing/ginja/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/processing/gsonschema/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/processing/gsonschema/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/processing/processors/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/processing/processors/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/resources/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/sampling_gen/entities/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/sampling_gen/entities/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer-engine/src/data_designer/engine/storage/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/storage/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from data_designer.engine.storage.media_storage import MediaStorage, StorageMode
 
 __all__ = ["MediaStorage", "StorageMode"]

--- a/packages/data-designer/src/data_designer/cli/commands/__init__.py
+++ b/packages/data-designer/src/data_designer/cli/commands/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/packages/data-designer/src/data_designer/integrations/huggingface/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/huggingface/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from data_designer.integrations.huggingface.client import HuggingFaceHubClient, HuggingFaceHubClientUploadError
 from data_designer.integrations.huggingface.dataset_card import DataDesignerDatasetCard
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["data_designer", "data_designer_e2e_tests"]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.per-file-ignores]
+"!packages/*/src/**" = ["I002"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"


### PR DESCRIPTION
## 📋 Summary

AGENTS.md and STYLEGUIDE.md require `from __future__ import annotations` in every source file, but nothing enforces it, and 16 `__init__.py` files under `packages/*/src` don't have it. This adds ruff's `required-imports` (`I002`) for `packages/*/src` and adds the import to those files.

## 🔗 Related Issue

Closes #760

## 🔄 Changes

- Uses `I002` instead of the `FA102` the issue suggests. `FA102` only fires for targets below py310, so with `target-version = "py310"` it passes on `main` even with these files missing the import.
- `"!packages/*/src/**" = ["I002"]` in per-file-ignores keeps tests, `tests_e2e` and scripts out of scope.
- `I002` skips files with no statements, so 14 of the 16 files (header-only stubs) get the import but aren't guarded until they have code.

## 🧪 Testing

- [ ] `make test` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] `make lint` passes. Deleting the import from `engine/storage/__init__.py` gives `I002 Missing required import`; an existing tests file without it (`config/analysis/conftest.py`) is not flagged.
- [x] The touched packages import cleanly, and `pytest packages/data-designer-engine/tests/engine/storage packages/data-designer/tests/integrations` passes (158 tests).

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
